### PR TITLE
chore: Simplify ChainSync agent logic

### DIFF
--- a/pallas-miniprotocols/examples/chainsync-blocks.rs
+++ b/pallas-miniprotocols/examples/chainsync-blocks.rs
@@ -1,7 +1,7 @@
-use pallas_primitives::alonzo::{crypto, Block, BlockWrapper};
+use pallas_primitives::alonzo::{Block, BlockWrapper};
 use pallas_primitives::Fragment;
 
-use pallas_miniprotocols::chainsync::{BlockLike, Consumer, NoopObserver};
+use pallas_miniprotocols::chainsync::{Consumer, NoopObserver};
 use pallas_miniprotocols::handshake::n2c::{Client, VersionTable};
 use pallas_miniprotocols::{run_agent, Point, MAINNET_MAGIC};
 use pallas_miniprotocols::{DecodePayload, EncodePayload, PayloadDecoder, PayloadEncoder};
@@ -25,14 +25,6 @@ impl DecodePayload for Content {
         Ok(Content(block))
     }
 }
-
-impl BlockLike for Content {
-    fn block_point(&self) -> Result<Point, Box<dyn std::error::Error>> {
-        let hash = crypto::hash_block_header(&self.0.header);
-        Ok(Point(self.0.header.header_body.slot, hash.to_vec()))
-    }
-}
-
 fn main() {
     env_logger::init();
 

--- a/pallas-miniprotocols/examples/chainsync-headers.rs
+++ b/pallas-miniprotocols/examples/chainsync-headers.rs
@@ -1,12 +1,12 @@
 use minicbor::data::Tag;
 use net2::TcpStreamExt;
-use pallas_primitives::alonzo::{crypto, Header};
+use pallas_primitives::alonzo::Header;
 use pallas_primitives::Fragment;
 
 use pallas_miniprotocols::Point;
 use std::net::TcpStream;
 
-use pallas_miniprotocols::chainsync::{BlockLike, Consumer, NoopObserver};
+use pallas_miniprotocols::chainsync::{Consumer, NoopObserver};
 use pallas_miniprotocols::handshake::n2n::{Client, VersionTable};
 use pallas_miniprotocols::{
     run_agent, DecodePayload, EncodePayload, PayloadDecoder, PayloadEncoder, MAINNET_MAGIC,
@@ -35,13 +35,6 @@ impl DecodePayload for Content {
         let bytes = d.bytes()?;
         let header = Header::decode_fragment(bytes)?;
         Ok(Content(unknown, header))
-    }
-}
-
-impl BlockLike for Content {
-    fn block_point(&self) -> Result<Point, Box<dyn std::error::Error>> {
-        let hash = crypto::hash_block_header(&self.1);
-        Ok(Point(self.1.header_body.slot, hash.to_vec()))
     }
 }
 

--- a/pallas-miniprotocols/src/chainsync/protocol.rs
+++ b/pallas-miniprotocols/src/chainsync/protocol.rs
@@ -1,7 +1,6 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, ops::Deref};
 
 use crate::common::Point;
-use crate::machines::{DecodePayload, EncodePayload};
 
 #[derive(Debug)]
 pub struct Tip(pub Point, pub u64);
@@ -17,10 +16,7 @@ pub enum State {
 
 /// A generic chain-sync message for either header or block content
 #[derive(Debug)]
-pub enum Message<C>
-where
-    C: EncodePayload + DecodePayload + Sized,
-{
+pub enum Message<C> {
     RequestNext,
     AwaitReply,
     RollForward(C, Tip),
@@ -30,3 +26,23 @@ where
     IntersectNotFound(Tip),
     Done,
 }
+
+#[derive(Debug)]
+pub enum HeaderContent {
+    Byron(u8, u64, Vec<u8>),
+    Shelley(Vec<u8>),
+}
+
+#[derive(Debug)]
+pub struct BlockContent(pub Vec<u8>);
+
+impl Deref for BlockContent {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug)]
+pub struct SkippedContent;


### PR DESCRIPTION
Instead of forcing the consumer agent to extract a cursor from the payload, we just pass the bytes to the observer. In this way, implementors can decide when / how to execute the decoding.

Bonus: we now pass the tip of the chain to the observer (needed for Oura).