### PR TITLE
feat: Make chainsync protocol era-agnostic

### DIFF
--- a/pallas-miniprotocols/src/chainsync/codec.rs
+++ b/pallas-miniprotocols/src/chainsync/codec.rs
@@ -119,7 +119,7 @@ where
 impl DecodePayload for HeaderContent {
     fn decode_payload(d: &mut crate::PayloadDecoder) -> Result<Self, Box<dyn std::error::Error>> {
         d.array()?;
-        let variant = d.u32()?; // WTF is this value?
+        let variant = d.u8()?; // era variant
 
         match variant {
             // byron
@@ -133,13 +133,22 @@ impl DecodePayload for HeaderContent {
                 d.tag()?;
                 let bytes = d.bytes()?;
 
-                Ok(HeaderContent::Byron(a, b, Vec::from(bytes)))
+                Ok(HeaderContent {
+                    variant,
+                    byron_prefix: Some((a, b)),
+                    cbor: Vec::from(bytes),
+                })
             }
-            // shelley
+            // shelley and beyond
             _ => {
                 d.tag()?;
                 let bytes = d.bytes()?;
-                Ok(HeaderContent::Shelley(Vec::from(bytes)))
+
+                Ok(HeaderContent {
+                    variant,
+                    byron_prefix: None,
+                    cbor: Vec::from(bytes),
+                })
             }
         }
     }

--- a/pallas-miniprotocols/src/chainsync/protocol.rs
+++ b/pallas-miniprotocols/src/chainsync/protocol.rs
@@ -28,9 +28,10 @@ pub enum Message<C> {
 }
 
 #[derive(Debug)]
-pub enum HeaderContent {
-    Byron(u8, u64, Vec<u8>),
-    Shelley(Vec<u8>),
+pub struct HeaderContent {
+    pub variant: u8,
+    pub byron_prefix: Option<(u8, u64)>,
+    pub cbor: Vec<u8>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
remove from the chainsync implementation any reference to "eras". Era-specific code should live downstream.