### PR TITLE
refactor(miniprotocols): Use pure functions for state machines

### DIFF
--- a/examples/block-download/src/main.rs
+++ b/examples/block-download/src/main.rs
@@ -2,7 +2,7 @@ use net2::TcpStreamExt;
 
 use pallas::network::{
     miniprotocols::{
-        handshake::n2n::{Client, VersionTable},
+        handshake::{n2n::VersionTable, Initiator},
         run_agent, Point, MAINNET_MAGIC,
     },
     multiplexer::Multiplexer,
@@ -34,7 +34,7 @@ fn main() {
 
     let mut hs_channel = muxer.use_channel(0);
     let versions = VersionTable::v4_and_above(MAINNET_MAGIC);
-    let _last = run_agent(Client::initial(versions), &mut hs_channel).unwrap();
+    let _last = run_agent(Initiator::initial(versions), &mut hs_channel).unwrap();
 
     let range = (
         Point::Specific(

--- a/pallas-miniprotocols/examples/blockfetch.rs
+++ b/pallas-miniprotocols/examples/blockfetch.rs
@@ -2,7 +2,7 @@ use net2::TcpStreamExt;
 use std::net::TcpStream;
 
 use pallas_miniprotocols::blockfetch::{BatchClient, NoopObserver};
-use pallas_miniprotocols::handshake::n2n::{Client, VersionTable};
+use pallas_miniprotocols::handshake::{n2n::VersionTable, Initiator};
 use pallas_miniprotocols::{run_agent, Point, MAINNET_MAGIC};
 use pallas_multiplexer::Multiplexer;
 
@@ -19,7 +19,7 @@ fn main() {
 
     let mut hs_channel = muxer.use_channel(0);
     let versions = VersionTable::v4_and_above(MAINNET_MAGIC);
-    let last = run_agent(Client::initial(versions), &mut hs_channel).unwrap();
+    let last = run_agent(Initiator::initial(versions), &mut hs_channel).unwrap();
     println!("{:?}", last);
 
     let range = (

--- a/pallas-miniprotocols/examples/chainsync-blocks.rs
+++ b/pallas-miniprotocols/examples/chainsync-blocks.rs
@@ -1,5 +1,5 @@
 use pallas_miniprotocols::chainsync::{BlockContent, Consumer, NoopObserver};
-use pallas_miniprotocols::handshake::n2c::{Client, VersionTable};
+use pallas_miniprotocols::handshake::{n2c::VersionTable, Initiator};
 use pallas_miniprotocols::{run_agent, Point, MAINNET_MAGIC};
 use pallas_multiplexer::Multiplexer;
 use std::os::unix::net::UnixStream;
@@ -15,7 +15,7 @@ fn main() {
 
     let mut hs_channel = muxer.use_channel(0);
     let versions = VersionTable::v1_and_above(MAINNET_MAGIC);
-    let last = run_agent(Client::initial(versions), &mut hs_channel).unwrap();
+    let last = run_agent(Initiator::initial(versions), &mut hs_channel).unwrap();
     println!("last hanshake state: {:?}", last);
 
     // some random known-point in the chain to use as starting point for the sync

--- a/pallas-miniprotocols/examples/chainsync-headers.rs
+++ b/pallas-miniprotocols/examples/chainsync-headers.rs
@@ -5,7 +5,7 @@ use pallas_miniprotocols::Point;
 use std::net::TcpStream;
 
 use pallas_miniprotocols::chainsync::{Consumer, HeaderContent, NoopObserver};
-use pallas_miniprotocols::handshake::n2n::{Client, VersionTable};
+use pallas_miniprotocols::handshake::{n2n::VersionTable, Initiator};
 use pallas_miniprotocols::{run_agent, MAINNET_MAGIC};
 use pallas_multiplexer::Multiplexer;
 
@@ -23,7 +23,7 @@ fn main() {
     let mut hs_channel = muxer.use_channel(0);
 
     let versions = VersionTable::v4_and_above(MAINNET_MAGIC);
-    let last = run_agent(Client::initial(versions), &mut hs_channel).unwrap();
+    let last = run_agent(Initiator::initial(versions), &mut hs_channel).unwrap();
     println!("{:?}", last);
 
     let known_points = vec![Point::Specific(

--- a/pallas-miniprotocols/examples/handshake-client.rs
+++ b/pallas-miniprotocols/examples/handshake-client.rs
@@ -1,7 +1,7 @@
 use net2::TcpStreamExt;
 use std::net::TcpStream;
 
-use pallas_miniprotocols::handshake::n2c::{Client, VersionTable};
+use pallas_miniprotocols::handshake::{n2c::VersionTable, Initiator};
 use pallas_miniprotocols::{run_agent, MAINNET_MAGIC};
 use pallas_multiplexer::Multiplexer;
 
@@ -18,7 +18,7 @@ fn main() {
 
     let mut hs_channel = muxer.use_channel(0);
     let versions = VersionTable::v1_and_above(MAINNET_MAGIC);
-    let last = run_agent(Client::initial(versions), &mut hs_channel).unwrap();
+    let last = run_agent(Initiator::initial(versions), &mut hs_channel).unwrap();
 
     println!("{:?}", last);
 }

--- a/pallas-miniprotocols/examples/handshake-node.rs
+++ b/pallas-miniprotocols/examples/handshake-node.rs
@@ -1,7 +1,7 @@
 use net2::TcpStreamExt;
 use std::net::TcpStream;
 
-use pallas_miniprotocols::handshake::n2n::{Client, VersionTable};
+use pallas_miniprotocols::handshake::{n2n::VersionTable, Initiator};
 use pallas_miniprotocols::{run_agent, MAINNET_MAGIC};
 use pallas_multiplexer::Multiplexer;
 
@@ -18,7 +18,7 @@ fn main() {
     let mut channel = muxer.use_channel(0);
 
     let versions = VersionTable::v4_and_above(MAINNET_MAGIC);
-    let last = run_agent(Client::initial(versions), &mut channel).unwrap();
+    let last = run_agent(Initiator::initial(versions), &mut channel).unwrap();
 
     println!("{:?}", last);
 }

--- a/pallas-miniprotocols/examples/localstate-chainpoint.rs
+++ b/pallas-miniprotocols/examples/localstate-chainpoint.rs
@@ -1,4 +1,4 @@
-use pallas_miniprotocols::handshake::n2c::{Client, VersionTable};
+use pallas_miniprotocols::handshake::{n2c::VersionTable, Initiator};
 use pallas_miniprotocols::localstate::{
     queries::{QueryV10, RequestV10},
     OneShotClient,
@@ -19,7 +19,7 @@ fn main() {
 
     let mut hs_channel = muxer.use_channel(0);
     let versions = VersionTable::only_v10(MAINNET_MAGIC);
-    let last = run_agent(Client::initial(versions), &mut hs_channel).unwrap();
+    let last = run_agent(Initiator::initial(versions), &mut hs_channel).unwrap();
     println!("last hanshake state: {:?}", last);
 
     let mut ls_channel = muxer.use_channel(7);

--- a/pallas-miniprotocols/examples/txsubmission-naive.rs
+++ b/pallas-miniprotocols/examples/txsubmission-naive.rs
@@ -1,7 +1,7 @@
 use net2::TcpStreamExt;
 use std::net::TcpStream;
 
-use pallas_miniprotocols::handshake::n2c::{Client, VersionTable};
+use pallas_miniprotocols::handshake::{n2c::VersionTable, Initiator};
 use pallas_miniprotocols::txsubmission::NaiveProvider;
 use pallas_miniprotocols::{run_agent, MAINNET_MAGIC};
 use pallas_multiplexer::Multiplexer;
@@ -19,7 +19,7 @@ fn main() {
 
     let mut hs_channel = muxer.use_channel(0);
     let versions = VersionTable::v1_and_above(MAINNET_MAGIC);
-    let last = run_agent(Client::initial(versions), &mut hs_channel).unwrap();
+    let last = run_agent(Initiator::initial(versions), &mut hs_channel).unwrap();
     println!("{:?}", last);
 
     let mut ts_channel = muxer.use_channel(4);

--- a/pallas-miniprotocols/src/chainsync/mod.rs
+++ b/pallas-miniprotocols/src/chainsync/mod.rs
@@ -1,9 +1,9 @@
+mod agents;
 mod buffer;
-mod clients;
 mod codec;
 mod protocol;
 
+pub use agents::*;
 pub use buffer::*;
-pub use clients::*;
 pub use codec::*;
 pub use protocol::*;

--- a/pallas-miniprotocols/src/handshake/agents.rs
+++ b/pallas-miniprotocols/src/handshake/agents.rs
@@ -1,0 +1,91 @@
+use std::fmt::Debug;
+
+use crate::{Agent, Transition};
+
+use super::protocol::{Message, RefuseReason, State, VersionNumber, VersionTable};
+
+#[derive(Debug)]
+pub enum Output<D> {
+    Pending,
+    Accepted(VersionNumber, D),
+    Refused(RefuseReason),
+}
+
+#[derive(Debug)]
+pub struct Initiator<D>
+where
+    D: Debug + Clone,
+{
+    pub state: State,
+    pub output: Output<D>,
+    pub version_table: VersionTable<D>,
+}
+
+impl<D> Initiator<D>
+where
+    D: Debug + Clone,
+{
+    pub fn initial(version_table: VersionTable<D>) -> Self {
+        Initiator {
+            state: State::Propose,
+            output: Output::Pending,
+            version_table,
+        }
+    }
+}
+
+impl<D> Agent for Initiator<D>
+where
+    D: Debug + Clone,
+{
+    type Message = Message<D>;
+
+    fn is_done(&self) -> bool {
+        self.state == State::Done
+    }
+
+    fn has_agency(&self) -> bool {
+        match self.state {
+            State::Propose => true,
+            State::Confirm => false,
+            State::Done => false,
+        }
+    }
+
+    fn build_next(&self) -> Self::Message {
+        match self.state {
+            State::Propose => Message::Propose(self.version_table.clone()),
+            _ => panic!("I don't have agency, nothing to send"),
+        }
+    }
+
+    fn apply_start(self) -> Transition<Self> {
+        Ok(self)
+    }
+
+    fn apply_outbound(self, msg: Self::Message) -> Transition<Self> {
+        match (self.state, msg) {
+            (State::Propose, Message::Propose(_)) => Ok(Self {
+                state: State::Confirm,
+                ..self
+            }),
+            _ => panic!(""),
+        }
+    }
+
+    fn apply_inbound(self, msg: Self::Message) -> Transition<Self> {
+        match (self.state, msg) {
+            (State::Confirm, Message::Accept(version, data)) => Ok(Self {
+                state: State::Done,
+                output: Output::Accepted(version, data),
+                ..self
+            }),
+            (State::Confirm, Message::Refuse(reason)) => Ok(Self {
+                state: State::Done,
+                output: Output::Refused(reason),
+                ..self
+            }),
+            _ => panic!("Current state does't expect to receive a message"),
+        }
+    }
+}

--- a/pallas-miniprotocols/src/handshake/mod.rs
+++ b/pallas-miniprotocols/src/handshake/mod.rs
@@ -1,4 +1,8 @@
-mod common;
+mod agents;
+mod protocol;
 
 pub mod n2c;
 pub mod n2n;
+
+pub use agents::*;
+pub use protocol::*;

--- a/pallas-miniprotocols/src/handshake/n2c.rs
+++ b/pallas-miniprotocols/src/handshake/n2c.rs
@@ -1,13 +1,10 @@
-use core::panic;
 use std::collections::HashMap;
 
 use pallas_codec::minicbor::{decode, encode, Decode, Decoder, Encode, Encoder};
 
-use crate::machines::{Agent, MachineOutput};
+use super::protocol::NetworkMagic;
 
-use super::common::{NetworkMagic, RefuseReason, VersionNumber};
-
-pub type VersionTable = super::common::VersionTable<VersionData>;
+pub type VersionTable = super::protocol::VersionTable<VersionData>;
 
 const PROTOCOL_V1: u64 = 1;
 const PROTOCOL_V2: u64 = 32770;
@@ -65,133 +62,5 @@ impl<'b> Decode<'b> for VersionData {
         let network_magic = d.u64()?;
 
         Ok(Self(network_magic))
-    }
-}
-
-#[derive(Debug)]
-pub enum Message {
-    Propose(VersionTable),
-    Accept(VersionNumber, VersionData),
-    Refuse(RefuseReason),
-}
-
-impl Encode for Message {
-    fn encode<W: encode::Write>(&self, e: &mut Encoder<W>) -> Result<(), encode::Error<W::Error>> {
-        match self {
-            Message::Propose(version_table) => {
-                e.array(2)?.u16(0)?;
-                version_table.encode(e)?;
-            }
-            Message::Accept(version_number, version_data) => {
-                e.array(3)?.u16(1)?;
-                e.u64(*version_number)?;
-                version_data.encode(e)?;
-            }
-            Message::Refuse(reason) => {
-                e.array(2)?.u16(2)?;
-                reason.encode(e)?;
-            }
-        };
-
-        Ok(())
-    }
-}
-
-impl<'b> Decode<'b> for Message {
-    fn decode(d: &mut Decoder<'b>) -> Result<Self, decode::Error> {
-        d.array()?;
-
-        match d.u16()? {
-            0 => todo!(),
-            1 => {
-                let version_number = d.u64()?;
-                let version_data = VersionData::decode(d)?;
-                Ok(Message::Accept(version_number, version_data))
-            }
-            2 => {
-                let reason = RefuseReason::decode(d)?;
-                Ok(Message::Refuse(reason))
-            }
-            _ => Err(decode::Error::message(
-                "unkown variant for handshake message",
-            )),
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum State {
-    Propose,
-    Confirm,
-    Done,
-}
-
-#[derive(Debug)]
-pub enum Output {
-    Pending,
-    Accepted(VersionNumber, VersionData),
-    Refused(RefuseReason),
-}
-
-#[derive(Debug)]
-pub struct Client {
-    pub state: State,
-    pub output: Output,
-    pub version_table: VersionTable,
-}
-
-impl Client {
-    pub fn initial(version_table: VersionTable) -> Self {
-        Client {
-            state: State::Propose,
-            output: Output::Pending,
-            version_table,
-        }
-    }
-}
-
-impl Agent for Client {
-    type Message = Message;
-
-    fn is_done(&self) -> bool {
-        self.state == State::Done
-    }
-
-    fn has_agency(&self) -> bool {
-        match self.state {
-            State::Propose => true,
-            State::Confirm => false,
-            State::Done => false,
-        }
-    }
-
-    fn send_next(self, tx: &impl MachineOutput) -> Result<Self, Box<dyn std::error::Error>> {
-        match self.state {
-            State::Propose => {
-                tx.send_msg(&Message::Propose(self.version_table.clone()))?;
-
-                Ok(Self {
-                    state: State::Confirm,
-                    ..self
-                })
-            }
-            _ => panic!("I don't have agency, nothing to send"),
-        }
-    }
-
-    fn receive_next(self, msg: Self::Message) -> Result<Self, Box<dyn std::error::Error>> {
-        match (self.state, msg) {
-            (State::Confirm, Message::Accept(version, data)) => Ok(Self {
-                state: State::Done,
-                output: Output::Accepted(version, data),
-                ..self
-            }),
-            (State::Confirm, Message::Refuse(reason)) => Ok(Self {
-                state: State::Done,
-                output: Output::Refused(reason),
-                ..self
-            }),
-            _ => panic!("Current state does't expect to receive a message"),
-        }
     }
 }

--- a/pallas-miniprotocols/src/handshake/n2n.rs
+++ b/pallas-miniprotocols/src/handshake/n2n.rs
@@ -1,13 +1,8 @@
-use core::panic;
 use std::collections::HashMap;
 
-use pallas_codec::minicbor::{decode, encode, Decode, Encode, Encoder};
+use pallas_codec::minicbor::{decode, encode, Decode, Decoder, Encode, Encoder};
 
-use crate::machines::{Agent, MachineOutput};
-
-use super::common::{RefuseReason, VersionNumber};
-
-pub type VersionTable = super::common::VersionTable<VersionData>;
+pub type VersionTable = super::protocol::VersionTable<VersionData>;
 
 const PROTOCOL_V4: u64 = 4;
 const PROTOCOL_V5: u64 = 5;
@@ -66,9 +61,7 @@ impl Encode for VersionData {
 }
 
 impl<'b> Decode<'b> for VersionData {
-    fn decode(
-        d: &mut pallas_codec::minicbor::Decoder<'b>,
-    ) -> Result<Self, pallas_codec::minicbor::decode::Error> {
+    fn decode(d: &mut Decoder<'b>) -> Result<Self, decode::Error> {
         d.array()?;
         let network_magic = d.u64()?;
         let initiator_and_responder_diffusion_mode = d.bool()?;
@@ -77,135 +70,5 @@ impl<'b> Decode<'b> for VersionData {
             network_magic,
             initiator_and_responder_diffusion_mode,
         })
-    }
-}
-
-#[derive(Debug)]
-pub enum Message {
-    Propose(VersionTable),
-    Accept(VersionNumber, VersionData),
-    Refuse(RefuseReason),
-}
-
-impl Encode for Message {
-    fn encode<W: encode::Write>(&self, e: &mut Encoder<W>) -> Result<(), encode::Error<W::Error>> {
-        match self {
-            Message::Propose(version_table) => {
-                e.array(2)?.u16(0)?;
-                version_table.encode(e)?;
-            }
-            Message::Accept(version_number, version_data) => {
-                e.array(3)?.u16(1)?;
-                e.u64(*version_number)?;
-                version_data.encode(e)?;
-            }
-            Message::Refuse(reason) => {
-                e.array(2)?.u16(2)?;
-                reason.encode(e)?;
-            }
-        };
-
-        Ok(())
-    }
-}
-
-impl<'b> Decode<'b> for Message {
-    fn decode(
-        d: &mut pallas_codec::minicbor::Decoder<'b>,
-    ) -> Result<Self, pallas_codec::minicbor::decode::Error> {
-        d.array()?;
-
-        match d.u16()? {
-            0 => todo!(),
-            1 => {
-                let version_number = d.u64()?;
-                let version_data = VersionData::decode(d)?;
-                Ok(Message::Accept(version_number, version_data))
-            }
-            2 => {
-                let reason = RefuseReason::decode(d)?;
-                Ok(Message::Refuse(reason))
-            }
-            _ => Err(decode::Error::message(
-                "unknown variant for handshake message",
-            )),
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum State {
-    Propose,
-    Confirm,
-    Done,
-}
-
-#[derive(Debug)]
-pub enum Output {
-    Pending,
-    Accepted(VersionNumber, VersionData),
-    Refused(RefuseReason),
-}
-
-#[derive(Debug)]
-pub struct Client {
-    pub state: State,
-    pub output: Output,
-    pub version_table: VersionTable,
-}
-
-impl Client {
-    pub fn initial(version_table: VersionTable) -> Self {
-        Client {
-            state: State::Propose,
-            output: Output::Pending,
-            version_table,
-        }
-    }
-}
-
-impl Agent for Client {
-    type Message = Message;
-
-    fn is_done(&self) -> bool {
-        self.state == State::Done
-    }
-
-    fn has_agency(&self) -> bool {
-        match self.state {
-            State::Propose => true,
-            State::Confirm => false,
-            State::Done => false,
-        }
-    }
-
-    fn send_next(self, tx: &impl MachineOutput) -> Result<Self, Box<dyn std::error::Error>> {
-        match self.state {
-            State::Propose => {
-                tx.send_msg(&Message::Propose(self.version_table.clone()))?;
-
-                Ok(Self {
-                    state: State::Confirm,
-                    ..self
-                })
-            }
-            _ => panic!("I don't have agency, nothing to send"),
-        }
-    }
-
-    fn receive_next(self, msg: Self::Message) -> Result<Self, Box<dyn std::error::Error>> {
-        match (self.state, msg) {
-            (State::Confirm, Message::Accept(version, data)) => Ok(Self {
-                state: State::Done,
-                output: Output::Accepted(version, data),
-                ..self
-            }),
-            (State::Confirm, Message::Refuse(reason)) => Ok(Self {
-                state: State::Done,
-                output: Output::Refused(reason),
-                ..self
-            }),
-            _ => panic!("Current state does't expect to receive a message"),
-        }
     }
 }

--- a/pallas-miniprotocols/src/handshake/protocol.rs
+++ b/pallas-miniprotocols/src/handshake/protocol.rs
@@ -10,9 +10,9 @@ where
     pub values: HashMap<u64, T>,
 }
 
-impl<'b, T> Encode for VersionTable<T>
+impl<T> Encode for VersionTable<T>
 where
-    T: Debug + Clone + Encode + Decode<'b>,
+    T: Debug + Clone + Encode,
 {
     fn encode<W: encode::Write>(&self, e: &mut Encoder<W>) -> Result<(), encode::Error<W::Error>> {
         e.map(self.values.len() as u64)?;
@@ -26,9 +26,88 @@ where
     }
 }
 
+impl<'b, T> Decode<'b> for VersionTable<T>
+where
+    T: Debug + Clone + Decode<'b>,
+{
+    fn decode(_d: &mut Decoder<'b>) -> Result<Self, decode::Error> {
+        todo!()
+    }
+}
+
 pub type NetworkMagic = u64;
 
 pub type VersionNumber = u64;
+
+#[derive(Debug)]
+pub enum Message<D>
+where
+    D: Debug + Clone,
+{
+    Propose(VersionTable<D>),
+    Accept(VersionNumber, D),
+    Refuse(RefuseReason),
+}
+
+impl<D> Encode for Message<D>
+where
+    D: Debug + Clone,
+    D: Encode,
+    VersionTable<D>: Encode,
+{
+    fn encode<W: encode::Write>(&self, e: &mut Encoder<W>) -> Result<(), encode::Error<W::Error>> {
+        match self {
+            Message::Propose(version_table) => {
+                e.array(2)?.u16(0)?;
+                e.encode(version_table)?;
+            }
+            Message::Accept(version_number, version_data) => {
+                e.array(3)?.u16(1)?;
+                e.u64(*version_number)?;
+                e.encode(version_data)?;
+            }
+            Message::Refuse(reason) => {
+                e.array(2)?.u16(2)?;
+                reason.encode(e)?;
+            }
+        };
+
+        Ok(())
+    }
+}
+
+impl<'b, D> Decode<'b> for Message<D>
+where
+    D: Decode<'b> + Debug + Clone,
+    VersionTable<D>: Decode<'b>,
+{
+    fn decode(d: &mut Decoder<'b>) -> Result<Self, decode::Error> {
+        d.array()?;
+
+        match d.u16()? {
+            0 => todo!(),
+            1 => {
+                let version_number = d.u64()?;
+                let version_data = d.decode()?;
+                Ok(Message::Accept(version_number, version_data))
+            }
+            2 => {
+                let reason = RefuseReason::decode(d)?;
+                Ok(Message::Refuse(reason))
+            }
+            _ => Err(decode::Error::message(
+                "unknown variant for handshake message",
+            )),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum State {
+    Propose,
+    Confirm,
+    Done,
+}
 
 #[derive(Debug)]
 pub enum RefuseReason {

--- a/pallas-multiplexer/src/bearers.rs
+++ b/pallas-multiplexer/src/bearers.rs
@@ -20,8 +20,9 @@ fn write_segment(
 
     if log_enabled!(log::Level::Trace) {
         trace!(
-            "sending segment, header {:?}, payload length: {}",
+            "sending segment, header {:?}, protocol id: {}, payload length: {}",
             hex::encode(&msg),
+            protocol_id,
             payload.len()
         );
     }


### PR DESCRIPTION
Very heavy refactoring of the whole state-machine implementation framework. The goal is to decouple the state-machine execution from any side-event by turning inbound / outbound message processing into pure functions.

This makes the implementation easier to follow, but more important, it allows us to create easy tests of the formal business logic of each state-machine without any networking concerns.