### PR TITLE
fix(primitives): Fix native scripts before/after type serialization

### DIFF
--- a/pallas-primitives/src/alonzo/json.rs
+++ b/pallas-primitives/src/alonzo/json.rs
@@ -62,8 +62,8 @@ impl ToCanonicalJson for super::NativeScript {
                 let scripts: Vec<_> = k.iter().map(|i| i.to_json()).collect();
                 json!({ "type": "atLeast", "required": n, "scripts" : scripts })
             }
-            super::NativeScript::InvalidBefore(slot) => json!({ "type": "before", "slot": slot }),
-            super::NativeScript::InvalidHereafter(slot) => json!({"type": "after", "slot": slot }),
+            super::NativeScript::InvalidBefore(slot) => json!({ "type": "after", "slot": slot }),
+            super::NativeScript::InvalidHereafter(slot) => json!({"type": "before", "slot": slot }),
         }
     }
 }


### PR DESCRIPTION
`InvalidBefore` should actually be serialized to (valid) "after", and `InvalidHereafter` to "before".