### PR TITLE
fix(primitives): Fix native scripts policy id (add missing tag)

### DIFF
--- a/pallas-crypto/src/hash/hasher.rs
+++ b/pallas-crypto/src/hash/hasher.rs
@@ -78,6 +78,14 @@ macro_rules! common_hasher {
                 hasher.finalize()
             }
 
+            #[inline]
+            pub fn hash_tagged_cbor(data: &impl minicbor::Encode, tag: u8) -> Hash<{ $size / 8 }> {
+                let mut hasher = Self::new();
+                hasher.input(&[tag]);
+                let () = minicbor::encode(data, &mut hasher).expect("Infallible");
+                hasher.finalize()
+            }
+
             /// consume the [`Hasher`] and returns the computed digest
             pub fn finalize(mut self) -> Hash<{ $size / 8 }> {
                 use cryptoxide::digest::Digest as _;

--- a/pallas-primitives/src/alonzo/crypto.rs
+++ b/pallas-primitives/src/alonzo/crypto.rs
@@ -21,7 +21,7 @@ pub fn hash_plutus_data(data: &PlutusData) -> Hash<32> {
 
 impl NativeScript {
     pub fn to_hash(&self) -> Hash<28> {
-        Hasher::<224>::hash_cbor(self)
+        Hasher::<224>::hash_tagged_cbor(self, 0)
     }
 }
 


### PR DESCRIPTION
Native scripts hashes need the tag 0 to compute the correct policy id, see:

https://github.com/input-output-hk/cardano-ledger/blob/736c9295f5896de28fbcedc6a8fc4d509fb78d10/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Scripts.hs#L61-L65

https://github.com/input-output-hk/cardano-ledger/blob/736c9295f5896de28fbcedc6a8fc4d509fb78d10/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Scripts.hs#L163-L171

We can add a comment in the code if you want.