### PR TITLE
feat: Implement Plutus Data hashing / JSON

### DIFF
--- a/pallas-codec/src/utils.rs
+++ b/pallas-codec/src/utils.rs
@@ -268,6 +268,12 @@ impl<T> Deref for CborWrap<T> {
 #[derive(Debug)]
 pub struct TagWrap<I, const T: u64>(I);
 
+impl<I, const T: u64> TagWrap<I, T> {
+    pub fn new(inner: I) -> Self {
+        TagWrap(inner)
+    }
+}
+
 impl<'b, I, const T: u64> minicbor::Decode<'b> for TagWrap<I, T>
 where
     I: minicbor::Decode<'b>,

--- a/pallas-primitives/src/alonzo/json.rs
+++ b/pallas-primitives/src/alonzo/json.rs
@@ -7,7 +7,7 @@ impl<A> super::Constr<A> {
         match self.tag {
             121..=127 => Some(self.tag - 121),
             1280..=1400 => Some(self.tag - 1280 + 7),
-            102 => self.any_constructor.clone(),
+            102 => self.any_constructor,
             _ => None,
         }
     }

--- a/pallas-primitives/src/alonzo/model.rs
+++ b/pallas-primitives/src/alonzo/model.rs
@@ -908,7 +908,9 @@ impl minicbor::encode::Encode for NativeScript {
     }
 }
 
-pub type PlutusScript = ByteVec;
+#[derive(Encode, Decode, Debug, PartialEq)]
+#[cbor(transparent)]
+pub struct PlutusScript(#[n(0)] ByteVec);
 
 /*
 big_int = int / big_uint / big_nint ; New
@@ -1058,13 +1060,13 @@ impl minicbor::encode::Encode for PlutusData {
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Constr<A> {
     pub tag: u64,
-    pub prefix: Option<u32>,
-    pub values: MaybeIndefArray<A>,
+    pub any_constructor: Option<u64>,
+    pub fields: MaybeIndefArray<A>,
 }
 
 impl<'b, A> minicbor::decode::Decode<'b> for Constr<A>
 where
-    A: minicbor::decode::Decode<'b>,
+    A: minicbor::decode::Decode<'b> + std::fmt::Debug,
 {
     fn decode(d: &mut minicbor::Decoder<'b>) -> Result<Self, minicbor::decode::Error> {
         let tag = d.tag()?;
@@ -1073,17 +1075,16 @@ where
             Tag::Unassigned(x) => match x {
                 121..=127 | 1280..=1400 => Ok(Constr {
                     tag: x,
-                    values: d.decode()?,
-                    prefix: None,
+                    fields: d.decode()?,
+                    any_constructor: None,
                 }),
                 102 => {
                     d.array()?;
-                    let prefix = Some(d.decode()?);
-                    let values = d.decode()?;
+
                     Ok(Constr {
-                        tag: 102,
-                        prefix,
-                        values,
+                        tag: x,
+                        any_constructor: Some(d.decode()?),
+                        fields: d.decode()?,
                     })
                 }
                 _ => Err(minicbor::decode::Error::message(
@@ -1110,13 +1111,13 @@ where
         match self.tag {
             102 => {
                 e.array(2)?;
-                e.encode(self.prefix)?;
-                e.encode(&self.values)?;
+                e.encode(self.any_constructor.unwrap_or_default())?;
+                e.encode(&self.fields)?;
 
                 Ok(())
             }
             _ => {
-                e.encode(&self.values)?;
+                e.encode(&self.fields)?;
 
                 Ok(())
             }

--- a/pallas-primitives/src/alonzo/model.rs
+++ b/pallas-primitives/src/alonzo/model.rs
@@ -1066,7 +1066,7 @@ pub struct Constr<A> {
 
 impl<'b, A> minicbor::decode::Decode<'b> for Constr<A>
 where
-    A: minicbor::decode::Decode<'b> + std::fmt::Debug,
+    A: minicbor::decode::Decode<'b>,
 {
     fn decode(d: &mut minicbor::Decoder<'b>) -> Result<Self, minicbor::decode::Error> {
         let tag = d.tag()?;


### PR DESCRIPTION
After some source code spelunking, this PR adds:

- a mechanism to hash Plutus Data from wire-cbor in an equivalent fashion as the cardano-cli.
- export a Plutus Data struct into JSON format that can be read by the cardano-cli
