### PR TITLE
feat: Add mechanism to check era's features

### DIFF
--- a/pallas-traverse/src/era.rs
+++ b/pallas-traverse/src/era.rs
@@ -1,0 +1,16 @@
+use crate::{Era, Feature};
+
+impl Era {
+    pub fn has_feature(&self, feature: Feature) -> bool {
+        match (self, feature) {
+            (Era::Byron, _) => false,
+            (Era::Shelley, Feature::SmartContracts) => false,
+            (Era::Shelley, Feature::TimeLocks) => false,
+            (Era::Shelley, Feature::MultiAssets) => false,
+            (Era::Allegra, Feature::MultiAssets) => false,
+            (Era::Allegra, Feature::SmartContracts) => false,
+            (Era::Mary, Feature::SmartContracts) => false,
+            _ => true,
+        }
+    }
+}

--- a/pallas-traverse/src/lib.rs
+++ b/pallas-traverse/src/lib.rs
@@ -8,6 +8,7 @@ use thiserror::Error;
 
 pub mod block;
 pub mod cert;
+pub mod era;
 pub mod output;
 pub mod probe;
 mod support;
@@ -21,6 +22,15 @@ pub enum Era {
     Allegra, // time-locks
     Mary,    // multi-assets
     Alonzo,  // smart-contracts
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum Feature {
+    TimeLocks,
+    MultiAssets,
+    Staking,
+    SmartContracts,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
sometimes it is useful to branch block-traversing processes by specific features available for each era. For example, don't bother searching smart contract datums in eras before Alonzo.

This PR introduces a way to query features per era using hard-coded references.