### PR TITLE
Parse Babbage headers

### DIFF
--- a/pallas-traverse/src/header.rs
+++ b/pallas-traverse/src/header.rs
@@ -17,6 +17,10 @@ impl<'b> MultiEraHeader<'b> {
                     Ok(MultiEraHeader::Byron(header))
                 }
             },
+            5 => {
+                let header = minicbor::decode(cbor).map_err(Error::invalid_cbor)?;
+                Ok(MultiEraHeader::Babbage(header))
+            }
             _ => {
                 let header = minicbor::decode(cbor).map_err(Error::invalid_cbor)?;
                 Ok(MultiEraHeader::AlonzoCompatible(header))


### PR DESCRIPTION
Make sure we parse babbage headers based on the era tag of 5 for babbage.