### PR TITLE
Expose collateral return in pallas-traverse

### DIFF
--- a/pallas-traverse/src/tx.rs
+++ b/pallas-traverse/src/tx.rs
@@ -192,6 +192,17 @@ impl<'b> MultiEraTx<'b> {
         }
     }
 
+    pub fn collateral_return(&self) -> Option<MultiEraOutput> {
+        match self {
+            MultiEraTx::Babbage(x) => x
+                .transaction_body
+                .collateral_return
+                .as_ref()
+                .map(MultiEraOutput::from_babbage),
+            _ => None
+        }
+    }
+
     pub fn withdrawals(&self) -> MultiEraWithdrawals {
         match self {
             MultiEraTx::AlonzoCompatible(x, _) => match &x.transaction_body.withdrawals {


### PR DESCRIPTION
Seems this field wasn't exposed in the pallas-traverse but we need to access it in Carp

There are some other fields also not exposed (reference_inputs, total_collateral), but I'm keeping this PR small since I need this to unblock myself on Carp 🙏