### PR TITLE
Getters for witness fields

### DIFF
--- a/pallas-traverse/src/witnesses.rs
+++ b/pallas-traverse/src/witnesses.rs
@@ -1,4 +1,3 @@
-use pallas_codec::utils::MaybeIndefArray;
 use pallas_primitives::{alonzo::{self, VKeyWitness, Redeemer, PlutusData, BootstrapWitness, NativeScript}, babbage::{self, PlutusV2Script}};
 
 use crate::MultiEraWitnesses;
@@ -18,57 +17,57 @@ impl<'b> MultiEraWitnesses<'b> {
         }
     }
 
-    pub fn vkeywitness(&self) -> Option<&MaybeIndefArray<VKeyWitness>> {
+    pub fn vkeywitness(&self) -> Option<&[VKeyWitness]> {
         match self {
-            Self::AlonzoCompatible(x) => x.vkeywitness.as_ref(),
-            Self::Babbage(x) => x.vkeywitness.as_ref(),
+            Self::AlonzoCompatible(x) => x.vkeywitness.as_ref().map(|x| x.as_ref()),
+            Self::Babbage(x) => x.vkeywitness.as_ref().map(|x| x.as_ref()),
             _ => None,
         }
     }
 
-    pub fn native_script(&self) -> Option<&MaybeIndefArray<NativeScript>> {
+    pub fn native_script(&self) -> Option<&[NativeScript]> {
         match self {
-            Self::AlonzoCompatible(x) => x.native_script.as_ref(),
-            Self::Babbage(x) => x.native_script.as_ref(),
+            Self::AlonzoCompatible(x) => x.native_script.as_ref().map(|x| x.as_ref()),
+            Self::Babbage(x) => x.native_script.as_ref().map(|x| x.as_ref()),
             _ => None,
         }
     }
 
-    pub fn bootstrap_witness(&self) -> Option<&MaybeIndefArray<BootstrapWitness>> {
+    pub fn bootstrap_witness(&self) -> Option<&[BootstrapWitness]> {
         match self {
-            Self::AlonzoCompatible(x) => x.bootstrap_witness.as_ref(),
-            Self::Babbage(x) => x.bootstrap_witness.as_ref(),
+            Self::AlonzoCompatible(x) => x.bootstrap_witness.as_ref().map(|x| x.as_ref()),
+            Self::Babbage(x) => x.bootstrap_witness.as_ref().map(|x| x.as_ref()),
             _ => None,
         }
     }
 
-    pub fn plutus_v1_script(&self) -> Option<&MaybeIndefArray<alonzo::PlutusScript>> {
+    pub fn plutus_v1_script(&self) -> Option<&[alonzo::PlutusScript]> {
         match self {
-            Self::AlonzoCompatible(x) => x.plutus_script.as_ref(),
-            Self::Babbage(x) => x.plutus_v1_script.as_ref(),
+            Self::AlonzoCompatible(x) => x.plutus_script.as_ref().map(|x| x.as_ref()),
+            Self::Babbage(x) => x.plutus_v1_script.as_ref().map(|x| x.as_ref()),
             _ => None,
         }
     }
 
-    pub fn plutus_data(&self) -> Option<&MaybeIndefArray<PlutusData>> {
+    pub fn plutus_data(&self) -> Option<&[PlutusData]> {
         match self {
-            Self::AlonzoCompatible(x) => x.plutus_data.as_ref(),
-            Self::Babbage(x) => x.plutus_data.as_ref(),
+            Self::AlonzoCompatible(x) => x.plutus_data.as_ref().map(|x| x.as_ref()),
+            Self::Babbage(x) => x.plutus_data.as_ref().map(|x| x.as_ref()),
             _ => None,
         }
     }
 
-    pub fn redeemer(&self) -> Option<&MaybeIndefArray<Redeemer>> {
+    pub fn redeemer(&self) -> Option<&[Redeemer]> {
         match self {
-            Self::AlonzoCompatible(x) => x.redeemer.as_ref(),
-            Self::Babbage(x) => x.redeemer.as_ref(),
+            Self::AlonzoCompatible(x) => x.redeemer.as_ref().map(|x| x.as_ref()),
+            Self::Babbage(x) => x.redeemer.as_ref().map(|x| x.as_ref()),
             _ => None,
         }
     }
 
-    pub fn plutus_v2_script(&self) -> Option<&MaybeIndefArray<PlutusV2Script>> {
+    pub fn plutus_v2_script(&self) -> Option<&[PlutusV2Script]> {
         match self {
-            Self::Babbage(x) => x.plutus_v2_script.as_ref(),
+            Self::Babbage(x) => x.plutus_v2_script.as_ref().map(|x| x.as_ref()),
             _ => None,
         }
     }

--- a/pallas-traverse/src/witnesses.rs
+++ b/pallas-traverse/src/witnesses.rs
@@ -1,4 +1,5 @@
-use pallas_primitives::{alonzo, babbage};
+use pallas_codec::utils::MaybeIndefArray;
+use pallas_primitives::{alonzo::{self, VKeyWitness, Redeemer, PlutusData, BootstrapWitness, NativeScript}, babbage::{self, PlutusV2Script}};
 
 use crate::MultiEraWitnesses;
 
@@ -13,6 +14,61 @@ impl<'b> MultiEraWitnesses<'b> {
     pub fn as_babbage(&self) -> Option<&babbage::TransactionWitnessSet> {
         match self {
             Self::Babbage(x) => Some(x),
+            _ => None,
+        }
+    }
+
+    pub fn vkeywitness(&self) -> Option<&MaybeIndefArray<VKeyWitness>> {
+        match self {
+            Self::AlonzoCompatible(x) => x.vkeywitness.as_ref(),
+            Self::Babbage(x) => x.vkeywitness.as_ref(),
+            _ => None,
+        }
+    }
+
+    pub fn native_script(&self) -> Option<&MaybeIndefArray<NativeScript>> {
+        match self {
+            Self::AlonzoCompatible(x) => x.native_script.as_ref(),
+            Self::Babbage(x) => x.native_script.as_ref(),
+            _ => None,
+        }
+    }
+
+    pub fn bootstrap_witness(&self) -> Option<&MaybeIndefArray<BootstrapWitness>> {
+        match self {
+            Self::AlonzoCompatible(x) => x.bootstrap_witness.as_ref(),
+            Self::Babbage(x) => x.bootstrap_witness.as_ref(),
+            _ => None,
+        }
+    }
+
+    pub fn plutus_v1_script(&self) -> Option<&MaybeIndefArray<alonzo::PlutusScript>> {
+        match self {
+            Self::AlonzoCompatible(x) => x.plutus_script.as_ref(),
+            Self::Babbage(x) => x.plutus_v1_script.as_ref(),
+            _ => None,
+        }
+    }
+
+    pub fn plutus_data(&self) -> Option<&MaybeIndefArray<PlutusData>> {
+        match self {
+            Self::AlonzoCompatible(x) => x.plutus_data.as_ref(),
+            Self::Babbage(x) => x.plutus_data.as_ref(),
+            _ => None,
+        }
+    }
+
+    pub fn redeemer(&self) -> Option<&MaybeIndefArray<Redeemer>> {
+        match self {
+            Self::AlonzoCompatible(x) => x.redeemer.as_ref(),
+            Self::Babbage(x) => x.redeemer.as_ref(),
+            _ => None,
+        }
+    }
+
+    pub fn plutus_v2_script(&self) -> Option<&MaybeIndefArray<PlutusV2Script>> {
+        match self {
+            Self::Babbage(x) => x.plutus_v2_script.as_ref(),
             _ => None,
         }
     }


### PR DESCRIPTION
I'm not sure what is the policy for flattening fields for Pallas. Presumably based on the way blocks and txs are handled, the policy is to flatten stuff when it's shared between eras? Based on this I added some getters for the witness types