### PR TITLE
feat: return all assets at a tx out

### DIFF
--- a/pallas-codec/src/utils.rs
+++ b/pallas-codec/src/utils.rs
@@ -1,6 +1,6 @@
 use minicbor::{data::Tag, Decode, Encode};
 use serde::{Deserialize, Serialize};
-use std::ops::Deref;
+use std::{fmt, ops::Deref};
 
 /// Utility for skipping parts of the CBOR payload, use only for debugging
 #[derive(Debug, PartialEq, PartialOrd, Eq, Ord)]
@@ -775,6 +775,14 @@ impl TryFrom<String> for Bytes {
 impl From<Bytes> for String {
     fn from(b: Bytes) -> Self {
         hex::encode(b.deref())
+    }
+}
+
+impl fmt::Display for Bytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let bytes: Vec<u8> = self.clone().into();
+
+        f.write_str(&hex::encode(bytes))
     }
 }
 

--- a/pallas-traverse/src/lib.rs
+++ b/pallas-traverse/src/lib.rs
@@ -7,7 +7,11 @@ use thiserror::Error;
 
 use pallas_codec::utils::KeepRaw;
 use pallas_crypto::hash::Hash;
-use pallas_primitives::{alonzo, babbage, byron};
+use pallas_primitives::{
+    alonzo,
+    babbage::{self, AssetName, PolicyId},
+    byron,
+};
 
 pub mod block;
 pub mod cert;
@@ -134,8 +138,23 @@ pub struct OutputRef(Hash<32>, u64);
 
 #[derive(Debug, Clone)]
 pub struct Asset {
-    pub unit: String,
+    pub subject: Subject,
     pub quantity: u64,
+}
+
+#[derive(Debug, Clone)]
+pub enum Subject {
+    Lovelace,
+    NativeAsset(PolicyId, AssetName),
+}
+
+impl ToString for Subject {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Lovelace => String::from("lovelace"),
+            Self::NativeAsset(p, n) => format!("{p}.{n}"),
+        }
+    }
 }
 
 #[derive(Debug, Error)]

--- a/pallas-traverse/src/lib.rs
+++ b/pallas-traverse/src/lib.rs
@@ -132,6 +132,12 @@ pub enum MultiEraSigners<'b> {
 #[derive(Debug, Clone)]
 pub struct OutputRef(Hash<32>, u64);
 
+#[derive(Debug, Clone)]
+pub struct Asset {
+    pub unit: String,
+    pub quantity: u64,
+}
+
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Invalid CBOR structure: {0}")]


### PR DESCRIPTION
* loop through multiasset and concat policy + asset name
* ada unit is lovelace

I can probably create a helper that takes a `&mut assets` to reduce some code. The same double for loop is written 3 times