### PR TITLE
Match CBOR encoding of plutus data with the haskell implementation.

### DIFF
--- a/pallas-codec/src/utils.rs
+++ b/pallas-codec/src/utils.rs
@@ -853,20 +853,18 @@ impl<C> Encode<C> for PlutusBytes {
             }
             e.end()?;
         }
-        return Ok(());
+        Ok(())
     }
 }
 
-impl<'b, C> minicbor::decode::Decode<'b, C> for PlutusBytes
-where
-{
+impl<'b, C> minicbor::decode::Decode<'b, C> for PlutusBytes {
     fn decode(d: &mut minicbor::Decoder<'b>, _: &mut C) -> Result<Self, minicbor::decode::Error> {
         let mut res = Vec::new();
         for chunk in d.bytes_iter()? {
             let bs = chunk?;
             res.extend_from_slice(bs);
-        };
-        return Ok(PlutusBytes::from(res));
+        }
+        Ok(PlutusBytes::from(res))
     }
 }
 

--- a/pallas-primitives/src/alonzo/model.rs
+++ b/pallas-primitives/src/alonzo/model.rs
@@ -7,7 +7,9 @@ use serde::{Deserialize, Serialize};
 use pallas_codec::minicbor::{data::Tag, Decode, Encode};
 use pallas_crypto::hash::Hash;
 
-use pallas_codec::utils::{Bytes, Int, KeepRaw, KeyValuePairs, MaybeIndefArray, Nullable, PlutusBytes};
+use pallas_codec::utils::{
+    Bytes, Int, KeepRaw, KeyValuePairs, MaybeIndefArray, Nullable, PlutusBytes,
+};
 
 // required for derive attrs to work
 use pallas_codec::minicbor;
@@ -974,22 +976,22 @@ impl<'b, C> minicbor::decode::Decode<'b, C> for PlutusData {
 }
 
 fn encode_list<C, W: minicbor::encode::Write, A: minicbor::encode::Encode<C>>(
-    a : &Vec<A>,
+    a: &Vec<A>,
     e: &mut minicbor::Encoder<W>,
     ctx: &mut C,
-    ) -> Result<(), minicbor::encode::Error<W::Error>> {
-        // Mimics default haskell list encoding from cborg:
-        // We use indef array for non-empty arrays but definite 0-length array for empty 
-        if a.is_empty() {
-            e.array(0)?;
-        } else {
-            e.begin_array()?;
-            for v in a {
-                e.encode_with(v, ctx)?;
-            }
-            e.end()?;
+) -> Result<(), minicbor::encode::Error<W::Error>> {
+    // Mimics default haskell list encoding from cborg:
+    // We use indef array for non-empty arrays but definite 0-length array for empty
+    if a.is_empty() {
+        e.array(0)?;
+    } else {
+        e.begin_array()?;
+        for v in a {
+            e.encode_with(v, ctx)?;
         }
-        return Ok(());
+        e.end()?;
+    }
+    Ok(())
 }
 
 impl<C> minicbor::encode::Encode<C> for PlutusData {


### PR DESCRIPTION
Fixes #211. 

I've seen you already decided to fix the problem of ambiguous CBOR encodings with `KeepRaw` and keeping the initial bytes to be used for hashing etc.

But it is only a plus to make encodings here follow the ones in the [haskell implementation](https://github.com/input-output-hk/plutus/blob/9538fc9829426b2ecb0628d352e2d7af96ec8204/plutus-core/plutus-core/src/PlutusCore/Data.hs#L140), so I made the change.

I've looked on `PlutusData` encoding only. The differences to haskell implementation were:
 - empty lists and lists of arguments to a constructor are encoded as a special case as 0-length definite length arrays
 - maps are encoded as definite arrays (!)
 - bytestrings over 64 bytes are encoded as indefinite bytestrings
 
 I modified those 3 to match haskell. There is a new type `PlutusBytes`, same as `Bytes` but the encoding/decoding different. There is a test case `plutus_data_isomorphic_decoding_encoding`. 