### PR TITLE
derive Debug for Bearer

### DIFF
--- a/pallas-multiplexer/src/bearers.rs
+++ b/pallas-multiplexer/src/bearers.rs
@@ -98,6 +98,7 @@ fn read_segment_with_timeout(reader: &mut impl Read) -> Result<Option<Segment>, 
 }
  */
 
+#[derive(Debug)]
 pub enum Bearer {
     Tcp(TcpStream),
 


### PR DESCRIPTION
I have a few structs that contain `Bearer`s that I want to `#[derive(Debug)]` on,, but `Bearer` doesn't implement `Debug`. This adds a `#[derive(Debug)]` for `Bearer`