### PR TITLE
Fix a few small typos in the txsubmission readme

### DIFF
--- a/pallas-miniprotocols/README.md
+++ b/pallas-miniprotocols/README.md
@@ -12,15 +12,15 @@ The following architectural decisions were made for this particular Rust impleme
 
 ## Development Status
 
-| mini-protocol       | initiator | responder |
-| ------------------- | --------- | --------- |
-| block-fetch         | done      | planned   |
-| chain-sync          | done      | planned   |
-| handshake           | done      | planned   |
-| local-state         | done      | planned   |
-| tx-submission       | planned   | minimal   |
-| local tx monitor    | done      | planned   |
-| local-tx-submission | ongoing   | planned   |
+| mini-protocol                                     | initiator | responder |
+| ------------------------------------------------- | --------- | --------- |
+| block-fetch                                       | done      | planned   |
+| chain-sync                                        | done      | planned   |
+| handshake                                         | done      | planned   |
+| local-state                                       | done      | planned   |
+| [tx-submission](src/txsubmission/README.md)       | done      | done      |
+| local tx monitor                                  | done      | planned   |
+| local-tx-submission                               | ongoing   | planned   |
 
 ## Implementation Details
 

--- a/pallas-miniprotocols/src/txsubmission/README.md
+++ b/pallas-miniprotocols/src/txsubmission/README.md
@@ -161,7 +161,7 @@ And wait for a response
 
 You can download those transactions with
 ```rust
-server.request_txs(ids.iter().map(|tx_and_size| tx_and_size.0).collect());
+server.request_txs(ids.iter().map(|tx_and_size| tx_and_size.0.clone()).collect());
 ```
 
 After you receive some transaction Ids, if you request more you should acknowledge the ones you received
@@ -179,11 +179,11 @@ All-together, this event loop could look something like this:
     loop {
         match server.receive_next_reply()? {
             Reply::TxIds(ids_and_sizes) => {
-                server.request_txs(ids_and_sizes.iter().map(|tx| tx.0).collect())?;
+                server.request_txs(ids_and_sizes.iter().map(|tx| tx.0.clone()).collect())?;
             },
             Reply::Txs(txs) => {
                 tx_channel.send(txs);
-                server.acknowledge_and_request_ids(true, txs.len(), 16)?;
+                server.acknowledge_and_request_ids(true, txs.len() as usize, 16)?;
             },
             Reply::Done => {
                 break;

--- a/pallas-miniprotocols/src/txsubmission/README.md
+++ b/pallas-miniprotocols/src/txsubmission/README.md
@@ -175,8 +175,7 @@ All-together, this event loop could look something like this:
 ```rust
     let mut server = txsubmission::Server::new(channel4);
     server.wait_for_init()?;
-    let mut previous_count = 0;
-    server.acknowledge_and_request_ids(true, previous_count, 16);
+    server.acknowledge_and_request_ids(true, 0, 16)?;
     loop {
         match server.receive_next_reply()? {
             Reply::TxIds(ids_and_sizes) => {


### PR DESCRIPTION
This was bugging me :sweat_smile: 

Also added a link to the miniprotocol-specific readme from the crate readme; as I write a similar document for each miniprotocol, I intend to add them all here