### PR TITLE
Make TxBody in TxSubmission generic, removing hard-coded encoding/decoding.

### DIFF
--- a/examples/n2c-miniprotocols/src/main.rs
+++ b/examples/n2c-miniprotocols/src/main.rs
@@ -1,14 +1,12 @@
 use pallas::network::{
-    miniprotocols::{
-        chainsync, handshake, localstate, Point, MAINNET_MAGIC, PROTOCOL_N2C_CHAIN_SYNC,
-        PROTOCOL_N2C_HANDSHAKE, PROTOCOL_N2C_STATE_QUERY,
-    },
+    miniprotocols::{chainsync, handshake, localstate, Point, MAINNET_MAGIC},
     multiplexer,
 };
 
 #[derive(Debug)]
 struct LoggingObserver;
 
+#[allow(dead_code)]
 fn do_handshake(channel: multiplexer::StdChannel) {
     let mut client = handshake::N2CClient::new(channel);
 
@@ -26,6 +24,7 @@ fn do_handshake(channel: multiplexer::StdChannel) {
     }
 }
 
+#[allow(dead_code)]
 fn do_localstate_query(channel: multiplexer::StdChannel) {
     let mut client = localstate::ClientV10::new(channel);
     client.acquire(None).unwrap();
@@ -37,6 +36,7 @@ fn do_localstate_query(channel: multiplexer::StdChannel) {
     log::info!("system start result: {:?}", result);
 }
 
+#[allow(dead_code)]
 fn do_chainsync(channel: multiplexer::StdChannel) {
     let known_points = vec![Point::Specific(
         43847831u64,
@@ -75,6 +75,12 @@ fn main() {
     // path for your environment
     #[cfg(target_family = "unix")]
     {
+        use pallas::network::{
+            miniprotocols::{
+                PROTOCOL_N2C_CHAIN_SYNC, PROTOCOL_N2C_HANDSHAKE, PROTOCOL_N2C_STATE_QUERY,
+            },
+            multiplexer::bearers::Bearer,
+        };
         let bearer = Bearer::connect_unix("/tmp/node.socket").unwrap();
 
         // setup the multiplexer by specifying the bearer and the IDs of the

--- a/pallas-miniprotocols/src/txsubmission/client.rs
+++ b/pallas-miniprotocols/src/txsubmission/client.rs
@@ -8,14 +8,14 @@ use super::{
     EraTxBody, EraTxId,
 };
 
-pub enum Request<TxId = EraTxId> {
+pub enum Request<TxId> {
     TxIds(u16, u16),
     TxIdsNonBlocking(u16, u16),
     Txs(Vec<TxId>),
 }
 
 /// A generic Ouroboros client for submitting a generic notion of "transactions" to another server
-pub struct GenericClient<H, TxId = EraTxId, TxBody = EraTxBody>(
+pub struct GenericClient<H, TxId, TxBody>(
     State,
     ChannelBuffer<H>,
     PhantomData<TxId>,

--- a/pallas-miniprotocols/src/txsubmission/client.rs
+++ b/pallas-miniprotocols/src/txsubmission/client.rs
@@ -3,7 +3,10 @@ use std::marker::PhantomData;
 use pallas_codec::Fragment;
 use pallas_multiplexer::agents::{Channel, ChannelBuffer};
 
-use super::{protocol::{Error, Message, State, TxIdAndSize}, EraTxId, EraTxBody};
+use super::{
+    protocol::{Error, Message, State, TxIdAndSize},
+    EraTxBody, EraTxId,
+};
 
 pub enum Request<TxId = EraTxId> {
     TxIds(u16, u16),
@@ -11,18 +14,32 @@ pub enum Request<TxId = EraTxId> {
     Txs(Vec<TxId>),
 }
 
-pub struct Client<H, TxId = EraTxId, TxBody = EraTxBody>(State, ChannelBuffer<H>, PhantomData<TxId>, PhantomData<TxBody>)
+/// A generic Ouroboros client for submitting a generic notion of "transactions" to another server
+pub struct GenericClient<H, TxId = EraTxId, TxBody = EraTxBody>(
+    State,
+    ChannelBuffer<H>,
+    PhantomData<TxId>,
+    PhantomData<TxBody>,
+)
 where
     H: Channel,
     Message<TxId, TxBody>: Fragment;
 
-impl<H, TxId, TxBody> Client<H, TxId, TxBody>
+/// A cardano specific instantiation of the ouroboros protocol
+pub type Client<H> = GenericClient<H, EraTxId, EraTxBody>;
+
+impl<H, TxId, TxBody> GenericClient<H, TxId, TxBody>
 where
     H: Channel,
     Message<TxId, TxBody>: Fragment,
 {
     pub fn new(channel: H) -> Self {
-        Self(State::Init, ChannelBuffer::new(channel), PhantomData {}, PhantomData {})
+        Self(
+            State::Init,
+            ChannelBuffer::new(channel),
+            PhantomData {},
+            PhantomData {},
+        )
     }
 
     pub fn state(&self) -> &State {

--- a/pallas-miniprotocols/src/txsubmission/codec.rs
+++ b/pallas-miniprotocols/src/txsubmission/codec.rs
@@ -71,7 +71,7 @@ impl<TxId: Encode<()>, TxBody: Encode<()>> Encode<()> for Message<TxId, TxBody> 
                 e.array(2)?.u16(3)?;
                 e.begin_array()?;
                 for tx in txs {
-                    e.encode(tx);
+                    e.encode(tx)?;
                 }
                 e.end()?;
                 Ok(())

--- a/pallas-miniprotocols/src/txsubmission/codec.rs
+++ b/pallas-miniprotocols/src/txsubmission/codec.rs
@@ -1,4 +1,4 @@
-use pallas_codec::minicbor::{decode, encode, Decode, Decoder, Encode, Encoder, data::Tag};
+use pallas_codec::minicbor::{data::Tag, decode, encode, Decode, Decoder, Encode, Encoder};
 
 use super::{
     protocol::{Message, TxIdAndSize},
@@ -90,7 +90,7 @@ impl<'b> Decode<'b, ()> for EraTxBody {
         let era = d.u16()?;
         let tag = d.tag()?;
         if tag != Tag::Cbor {
-            return Err(decode::Error::message("Expected encoded CBOR data item"))
+            return Err(decode::Error::message("Expected encoded CBOR data item"));
         }
         Ok(EraTxBody(era, d.bytes()?.to_vec()))
     }

--- a/pallas-miniprotocols/src/txsubmission/codec.rs
+++ b/pallas-miniprotocols/src/txsubmission/codec.rs
@@ -2,7 +2,7 @@ use pallas_codec::minicbor::{decode, encode, Decode, Decoder, Encode, Encoder};
 
 use super::{
     protocol::{Message, TxIdAndSize},
-    EraTxId, EraTxBody,
+    EraTxBody, EraTxId,
 };
 
 impl<TxId: Encode<()>> Encode<()> for TxIdAndSize<TxId> {
@@ -94,7 +94,11 @@ impl<'b> Decode<'b, ()> for EraTxBody {
 }
 
 impl Encode<()> for EraTxBody {
-    fn encode<W: encode::Write>(&self, e: &mut Encoder<W>, _ctx: &mut ()) -> Result<(), encode::Error<W::Error>> {
+    fn encode<W: encode::Write>(
+        &self,
+        e: &mut Encoder<W>,
+        _ctx: &mut (),
+    ) -> Result<(), encode::Error<W::Error>> {
         e.array(2)?;
         e.u16(self.0)?;
         e.tag(self.1)?;

--- a/pallas-miniprotocols/src/txsubmission/protocol.rs
+++ b/pallas-miniprotocols/src/txsubmission/protocol.rs
@@ -22,9 +22,9 @@ pub type TxSizeInBytes = u32;
 #[derive(Debug, Clone)]
 pub struct EraTxId(pub u16, pub Vec<u8>);
 
-// The bytes of a transaction, with an era number and some kind of cbor tag; TODO(pi): identify the significance of this tag
+// The bytes of a transaction, with an era number and some raw CBOR
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct EraTxBody(pub u16, pub Tag, pub Vec<u8>);
+pub struct EraTxBody(pub u16, pub Vec<u8>);
 
 #[derive(Debug)]
 pub struct TxIdAndSize<TxID>(pub TxID, pub TxSizeInBytes);

--- a/pallas-miniprotocols/src/txsubmission/protocol.rs
+++ b/pallas-miniprotocols/src/txsubmission/protocol.rs
@@ -51,7 +51,7 @@ pub enum Error {
 }
 
 #[derive(Debug)]
-pub enum Message<TxId = EraTxId, TxBody = EraTxBody> {
+pub enum Message<TxId, TxBody> {
     Init,
     RequestTxIds(Blocking, TxCount, TxCount),
     ReplyTxIds(Vec<TxIdAndSize<TxId>>),

--- a/pallas-miniprotocols/src/txsubmission/protocol.rs
+++ b/pallas-miniprotocols/src/txsubmission/protocol.rs
@@ -1,3 +1,4 @@
+use pallas_codec::minicbor::data::Tag;
 use pallas_multiplexer::agents::ChannelError;
 use thiserror::Error;
 
@@ -21,20 +22,12 @@ pub type TxSizeInBytes = u32;
 #[derive(Debug, Clone)]
 pub struct EraTxId(pub u16, pub Vec<u8>);
 
+// The bytes of a transaction, with an era number and some kind of cbor tag; TODO(pi): identify the significance of this tag
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct EraTxBody(pub u16, pub Tag, pub Vec<u8>);
+
 #[derive(Debug)]
 pub struct TxIdAndSize<TxID>(pub TxID, pub TxSizeInBytes);
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TxBody(pub Vec<u8>);
-
-#[derive(Debug, Clone)]
-pub struct Tx<TxId>(pub TxId, pub TxBody);
-
-impl<TxId> From<Tx<TxId>> for TxIdAndSize<TxId> {
-    fn from(other: Tx<TxId>) -> Self {
-        TxIdAndSize(other.0, other.1 .0.len() as u32)
-    }
-}
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -58,7 +51,7 @@ pub enum Error {
 }
 
 #[derive(Debug)]
-pub enum Message<TxId> {
+pub enum Message<TxId = EraTxId, TxBody = EraTxBody> {
     Init,
     RequestTxIds(Blocking, TxCount, TxCount),
     ReplyTxIds(Vec<TxIdAndSize<TxId>>),

--- a/pallas-miniprotocols/src/txsubmission/protocol.rs
+++ b/pallas-miniprotocols/src/txsubmission/protocol.rs
@@ -1,4 +1,3 @@
-use pallas_codec::minicbor::data::Tag;
 use pallas_multiplexer::agents::ChannelError;
 use thiserror::Error;
 

--- a/pallas-miniprotocols/src/txsubmission/server.rs
+++ b/pallas-miniprotocols/src/txsubmission/server.rs
@@ -8,14 +8,14 @@ use super::{
     EraTxBody, EraTxId,
 };
 
-pub enum Reply<TxId = EraTxId, TxBody = EraTxBody> {
+pub enum Reply<TxId, TxBody> {
     TxIds(Vec<TxIdAndSize<TxId>>),
     Txs(Vec<TxBody>),
     Done,
 }
 
 /// A generic implementation of an ouroboros server protocol ready to request and receive transactions from a client
-pub struct GenericServer<H, TxId = EraTxId, TxBody = EraTxBody>(
+pub struct GenericServer<H, TxId, TxBody>(
     State,
     ChannelBuffer<H>,
     PhantomData<TxId>,

--- a/pallas-miniprotocols/tests/integration.rs
+++ b/pallas-miniprotocols/tests/integration.rs
@@ -2,7 +2,7 @@ use pallas_miniprotocols::{
     blockfetch,
     chainsync::{self, NextResponse},
     handshake::{self, Confirmation},
-    txsubmission::{self, EraTxId, Reply, TxIdAndSize, EraTxBody, Server},
+    txsubmission::{self, EraTxBody, EraTxId, Reply, Server, TxIdAndSize},
     Point, PROTOCOL_N2N_BLOCK_FETCH, PROTOCOL_N2N_CHAIN_SYNC, PROTOCOL_N2N_HANDSHAKE,
     PROTOCOL_N2N_TX_SUBMISSION,
 };
@@ -178,7 +178,7 @@ pub fn txsubmission_server_happy_path() {
 
     let N2NChannels { txsubmission, .. } = setup_n2n_client_connection();
 
-    let mut server: Server<_, EraTxId, EraTxBody> = txsubmission::Server::new(txsubmission);
+    let mut server = txsubmission::Server::new(txsubmission);
 
     assert!(matches!(server.wait_for_init(), Ok(_)));
 

--- a/pallas-miniprotocols/tests/integration.rs
+++ b/pallas-miniprotocols/tests/integration.rs
@@ -2,7 +2,7 @@ use pallas_miniprotocols::{
     blockfetch,
     chainsync::{self, NextResponse},
     handshake::{self, Confirmation},
-    txsubmission::{self, EraTxId, Reply, TxIdAndSize},
+    txsubmission::{self, EraTxId, Reply, TxIdAndSize, EraTxBody, Server},
     Point, PROTOCOL_N2N_BLOCK_FETCH, PROTOCOL_N2N_CHAIN_SYNC, PROTOCOL_N2N_HANDSHAKE,
     PROTOCOL_N2N_TX_SUBMISSION,
 };
@@ -178,7 +178,7 @@ pub fn txsubmission_server_happy_path() {
 
     let N2NChannels { txsubmission, .. } = setup_n2n_client_connection();
 
-    let mut server = txsubmission::Server::new(txsubmission);
+    let mut server: Server<_, EraTxId, EraTxBody> = txsubmission::Server::new(txsubmission);
 
     assert!(matches!(server.wait_for_init(), Ok(_)));
 
@@ -187,7 +187,7 @@ pub fn txsubmission_server_happy_path() {
         Ok(_)
     ));
 
-    let reply = server.receive_next_reply();
+    let reply: Result<_, _> = server.receive_next_reply();
     assert!(matches!(reply, Ok(Reply::TxIds(_))));
     let Ok(Reply::TxIds(tx_ids)) = reply else { unreachable!() };
 


### PR DESCRIPTION
We were still baking in some assumptions about encoding/decoding the TxBody, so this makes it generic in the same way as TxId.

We also provide a default implementation for Cardano specific use cases, since that will be 99% of the cases.