### PR TITLE
Add clone impls to some errors

### DIFF
--- a/pallas-miniprotocols/src/blockfetch/client.rs
+++ b/pallas-miniprotocols/src/blockfetch/client.rs
@@ -6,7 +6,7 @@ use crate::common::Point;
 
 use super::{Message, State};
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum Error {
     #[error("attempted to receive message while agency is ours")]
     AgencyIsOurs,

--- a/pallas-miniprotocols/src/chainsync/client.rs
+++ b/pallas-miniprotocols/src/chainsync/client.rs
@@ -8,7 +8,7 @@ use crate::common::Point;
 
 use super::{BlockContent, HeaderContent, Message, State, Tip};
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum Error {
     #[error("attempted to receive message while agency is ours")]
     AgencyIsOurs,

--- a/pallas-multiplexer/src/agents.rs
+++ b/pallas-multiplexer/src/agents.rs
@@ -4,7 +4,7 @@ use crate::Payload;
 use pallas_codec::{minicbor, Fragment};
 use thiserror::Error;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error)]
 pub enum ChannelError {
     #[error("channel is not connected, failed to send payload")]
     NotConnected(Option<Payload>),


### PR DESCRIPTION
Very small PR that adds `Clone` impls to a couple of error types. I have some error types in my own crate that have `Clone` bounds, and IMO it's better for the underlying error to implement `Clone`, rather than chucking it in an `Arc`.

Thanks :grin: 