### PR TITLE
feat: Windows Socket Connections

### DIFF
--- a/pallas-network/Cargo.toml
+++ b/pallas-network/Cargo.toml
@@ -23,6 +23,10 @@ thiserror = "1.0.31"
 tokio = { version = "1", features = ["net", "io-util", "time", "sync"] }
 tracing = "0.1.37"
 
+[target.'cfg(windows)'.dependencies]
+tokio-named-pipes = "0.1.0"
+windows-sys = "0.48.0"
+
 [dev-dependencies]
 tracing-subscriber = "0.3.16"
 tokio = { version = "1", features = ["full"] }

--- a/pallas-network/src/facades.rs
+++ b/pallas-network/src/facades.rs
@@ -130,7 +130,7 @@ impl NodeClient {
     pub async fn connect(pipe_name: impl AsRef<std::ffi::OsStr>, magic: u64) -> Result<Self, Error> {
         debug!("connecting");
 
-        let bearer = Bearer::connect_pipe(pipe_name)
+        let bearer = Bearer::connect_named_pipe(pipe_name)
             .await
             .map_err(Error::ConnectFailure)?;
 

--- a/pallas-network/src/multiplexer.rs
+++ b/pallas-network/src/multiplexer.rs
@@ -130,7 +130,7 @@ impl Bearer {
         }
     }
 
-    async fn try_read(&mut self, buf: &mut [u8]) -> tokio::io::Result<usize> {
+    fn try_read(&mut self, buf: &mut [u8]) -> tokio::io::Result<usize> {
         match self {
             Bearer::Tcp(x) => x.try_read(buf),
             #[cfg(not(target_os = "windows"))]
@@ -203,8 +203,8 @@ impl SegmentBuffer {
 
             let remaining = required - self.1.len();
             let mut buf = vec![0u8; remaining];
-
-            match self.0.try_read(&mut buf).await {
+            
+            match self.0.try_read(&mut buf) {
                 Ok(0) => {
                     error!("empty bearer");
                     break Err(Error::EmptyBearer);

--- a/pallas-network/src/multiplexer.rs
+++ b/pallas-network/src/multiplexer.rs
@@ -67,7 +67,7 @@ pub struct Segment {
 #[cfg(target_os = "windows")]
 pub enum Bearer {
     Tcp(TcpStream),
-    Socket(NamedPipeClient)
+    NamedPipe(NamedPipeClient)
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -90,7 +90,7 @@ impl Bearer {
     }
 
     #[cfg(windows)]
-    pub async fn connect_pipe(pipe_name: impl AsRef<std::ffi::OsStr>) -> Result<Self, tokio::io::Error>{
+    pub async fn connect_named_pipe(pipe_name: impl AsRef<std::ffi::OsStr>) -> Result<Self, tokio::io::Error>{
         let client = loop {
             match tokio::net::windows::named_pipe::ClientOptions::new().open(&pipe_name) {
                 Ok(client) => break client,
@@ -100,7 +100,7 @@ impl Bearer {
         
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         };
-        Ok(Self::Socket(client))
+        Ok(Self::NamedPipe(client))
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -116,7 +116,7 @@ impl Bearer {
             Bearer::Unix(x) => x.readable().await,
 
             #[cfg(target_os = "windows")]
-            Bearer::Socket(x) => x.readable().await
+            Bearer::NamedPipe(x) => x.readable().await
             
         }
     }
@@ -127,7 +127,7 @@ impl Bearer {
             #[cfg(not(target_os = "windows"))]
             Bearer::Unix(x) => x.try_read(buf),
             #[cfg(target_os = "windows")]
-            Bearer::Socket(x) => x.try_read(buf)
+            Bearer::NamedPipe(x) => x.try_read(buf)
         }
     }
 
@@ -137,7 +137,7 @@ impl Bearer {
             #[cfg(not(target_os = "windows"))]
             Bearer::Unix(x) => x.write_all(buf).await,
             #[cfg(target_os = "windows")]
-            Bearer::Socket(x) => x.write_all(buf).await,
+            Bearer::NamedPipe(x) => x.write_all(buf).await,
         }
     }
 
@@ -147,7 +147,7 @@ impl Bearer {
             #[cfg(not(target_os = "windows"))]
             Bearer::Unix(x) => x.flush().await,
             #[cfg(target_os = "windows")]
-            Bearer::Socket(x) => x.flush().await,
+            Bearer::NamedPipe(x) => x.flush().await,
         }
     }
 }

--- a/pallas-network/src/multiplexer.rs
+++ b/pallas-network/src/multiplexer.rs
@@ -104,7 +104,7 @@ impl Bearer {
     }
 
     #[cfg(not(target_os = "windows"))]
-    pub async fn connect_unix(path: impl AsRef<Path>) -> Result<Self, tokio::io::Error> {
+    pub async fn connect_unix(path: impl AsRef<std::path::Path>) -> Result<Self, tokio::io::Error> {
         let stream = UnixStream::connect(path).await?;
         Ok(Self::Unix(stream))
     }


### PR DESCRIPTION
This PR adds a platform specific connect method to the NodeClient so that it can connect to cardano nodes via named pipes on Windows.

Client setup as usual:
```rust
let mut client = 
  pallas_network::facades::NodeClient::connect(
      r#"\\.\pipe\cardano-node-preprod"#, 
      self.configuration.magic
  ).await
```
Run node with named pipe:
```powershell
cardano-node.exe run ....... --socket-path "\\.\pipe\cardano-node-preprod"
```