### PR TITLE
network: Fix return of empty value in the ResponseNextTx

### DIFF
--- a/pallas-network/src/miniprotocols/txmonitor/codec.rs
+++ b/pallas-network/src/miniprotocols/txmonitor/codec.rs
@@ -80,14 +80,19 @@ impl<'b> Decode<'b, ()> for Message {
             // find the specs
             4 => Ok(Message::AwaitAcquire),
             5 => Ok(Message::RequestNextTx),
-            6 => match d.datatype()? {
-                pallas_codec::minicbor::data::Type::Array
-                | pallas_codec::minicbor::data::Type::ArrayIndef => {
-                    let tx = d.decode()?;
-                    Ok(Message::ResponseNextTx(Some(tx)))
-                }
-                _ => Ok(Message::ResponseNextTx(None)),
-            },
+            6 => match d.datatype() {
+                Ok(datatype) => {
+                    match datatype {
+                        pallas_codec::minicbor::data::Type::Array
+                        | pallas_codec::minicbor::data::Type::ArrayIndef => {
+                            let tx = d.decode()?;
+                            Ok(Message::ResponseNextTx(Some(tx)))
+                        }
+                        _ => Ok(Message::ResponseNextTx(None))
+                    }
+                },
+                Err(_) => Ok(Message::ResponseNextTx(None))
+            }
             7 => {
                 let id = d.decode()?;
                 Ok(Message::RequestHasTx(id))

--- a/pallas-network/src/miniprotocols/txmonitor/codec.rs
+++ b/pallas-network/src/miniprotocols/txmonitor/codec.rs
@@ -135,4 +135,15 @@ pub mod tests {
             unreachable!();
         }
     }
+    #[test]
+    fn test_empty_next_tx_response() {
+        let bytes = vec![129, 6];
+        let msg: super::Message = pallas_codec::minicbor::decode(&bytes).unwrap();
+
+        if let super::Message::ResponseNextTx(None) = msg {
+            assert_eq!(0u64, 0u64);
+        } else {
+            unreachable!();
+        }
+    }
 }


### PR DESCRIPTION
Rationale:
the node answers with [129, 6] if it sent all tx's from the snapshot

More information:
https://ogmios.dev/mini-protocols/local-tx-monitor/#how-to-use
```
1. acquireMempool  → acquireMempoolResponse
2. nextTransaction → nextTransactionResponse t0
3. nextTransaction → nextTransactionResponse t1
4. nextTransaction → nextTransactionResponse t2
5. nextTransaction → nextTransactionResponse null
``` 