### PR TITLE
pallas-primitives: fix PostAlonzoAuxiliaryData

### DIFF
--- a/pallas-primitives/src/alonzo/model.rs
+++ b/pallas-primitives/src/alonzo/model.rs
@@ -1333,7 +1333,10 @@ pub struct PostAlonzoAuxiliaryData {
     pub native_scripts: Option<Vec<NativeScript>>,
 
     #[n(2)]
-    pub plutus_scripts: Option<Vec<PlutusScript>>,
+    pub plutus_v1_scripts: Option<Vec<PlutusScript>>,
+
+    #[n(3)]
+    pub plutus_v2_scripts: Option<Vec<PlutusScript>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]

--- a/pallas-traverse/src/auxiliary.rs
+++ b/pallas-traverse/src/auxiliary.rs
@@ -8,7 +8,7 @@ impl<'b> MultiEraTx<'b> {
     pub fn aux_plutus_v1_scripts(&self) -> &[alonzo::PlutusScript] {
         if let Some(aux_data) = self.aux_data() {
             if let alonzo::AuxiliaryData::PostAlonzo(x) = aux_data.deref() {
-                if let Some(plutus) = &x.plutus_scripts {
+                if let Some(plutus) = &x.plutus_v1_scripts {
                     return plutus.as_ref();
                 }
             }


### PR DESCRIPTION
I noticed a small difference between the cddl and the rust definition for `PostAlonzoAuziliaryData`.

I wasn't sure if it was intentional or a mistake but I made the adjustment and all tests still pass.

If this is intentional feel free to close this PR. It was a simple adjustment so no worries.