### PR TITLE
candidate to fix build errors

### DIFF
--- a/pallas-network/Cargo.toml
+++ b/pallas-network/Cargo.toml
@@ -20,7 +20,7 @@ itertools = "0.10.5"
 pallas-codec = { version = "=0.19.1", path = "../pallas-codec" }
 pallas-crypto = { version = "=0.19.1", path = "../pallas-crypto" }
 thiserror = "1.0.31"
-tokio = { version = "1", features = ["net", "io-util", "time", "sync"] }
+tokio = { version = "1", features = ["net", "io-util", "time", "sync", "macros"] }
 tracing = "0.1.37"
 
 [dev-dependencies]

--- a/pallas-network/src/facades.rs
+++ b/pallas-network/src/facades.rs
@@ -97,7 +97,7 @@ pub struct PeerServer {
 }
 
 impl PeerServer {
-    pub async fn accept(listener: &TcpListener, magic: u64) -> Result<Self, Error> {
+    pub async fn accept(listener: TcpListener, magic: u64) -> Result<Self, Error> {
         let (bearer, _) = Bearer::accept_tcp(listener)
             .await
             .map_err(Error::ConnectFailure)?;

--- a/pallas-network/src/multiplexer.rs
+++ b/pallas-network/src/multiplexer.rs
@@ -85,17 +85,17 @@ impl Bearer {
     }
 
     #[cfg(not(target_os = "windows"))]
-    pub async fn connect_unix(path: impl AsRef<Path>) -> Result<Self, tokio::io::Error> {
-        let stream = UnixStream::connect(path).await?;
-        Ok(Self::Unix(stream))
-    }
-
-    #[cfg(not(target_os = "windows"))]
     pub async fn accept_unix(
         listener: &UnixListener,
     ) -> tokio::io::Result<(Self, tokio::net::unix::SocketAddr)> {
         let (stream, addr) = listener.accept().await?;
         Ok((Self::Unix(stream), addr))
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    pub async fn connect_unix(path: impl AsRef<Path>) -> Result<Self, tokio::io::Error> {
+        let stream = UnixStream::connect(path).await?;
+        Ok(Self::Unix(stream))
     }
 
     pub async fn readable(&self) -> tokio::io::Result<()> {

--- a/pallas-network/src/multiplexer.rs
+++ b/pallas-network/src/multiplexer.rs
@@ -79,9 +79,15 @@ impl Bearer {
         Ok(Self::Tcp(stream))
     }
 
-    pub async fn accept_tcp(listener: &TcpListener) -> tokio::io::Result<(Self, SocketAddr)> {
+    pub async fn accept_tcp(listener: TcpListener) -> tokio::io::Result<(Self, SocketAddr)> {
         let (stream, addr) = listener.accept().await?;
         Ok((Self::Tcp(stream), addr))
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    pub async fn connect_unix(path: impl AsRef<Path>) -> Result<Self, tokio::io::Error> {
+        let stream = UnixStream::connect(path).await?;
+        Ok(Self::Unix(stream))
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -90,12 +96,6 @@ impl Bearer {
     ) -> tokio::io::Result<(Self, tokio::net::unix::SocketAddr)> {
         let (stream, addr) = listener.accept().await?;
         Ok((Self::Unix(stream), addr))
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    pub async fn connect_unix(path: impl AsRef<Path>) -> Result<Self, tokio::io::Error> {
-        let stream = UnixStream::connect(path).await?;
-        Ok(Self::Unix(stream))
     }
 
     pub async fn readable(&self) -> tokio::io::Result<()> {


### PR DESCRIPTION
we are currently going trough the following errors compiling using the `main` branch as a not dev dependency.

```rust
error[E0432]: unresolved import `tokio::select`
  --> /Users/runner/.cargo/git/checkouts/pallas-ea09e9ab4b7b6058/c772da6/pallas-network/src/multiplexer.rs:10:5
   |
10 | use tokio::select;
   |     ^^^^^^^^^^^^^ no `select` in the root

error: cannot determine resolution for the macro `select`
   --> /Users/runner/.cargo/git/checkouts/pallas-ea09e9ab4b7b6058/c772da6/pallas-network/src/multiplexer.rs:368:13
    |
368 |             select! {
    |             ^^^^^^
    |
    = note: import resolution is stuck, try simplifying macro imports

error: future cannot be sent between threads safely
   --> /Users/runner/.cargo/git/checkouts/pallas-ea09e9ab4b7b6058/c772da6/pallas-network/src/facades.rs:55:42
    |
55  |         let plexer_handle = tokio::spawn(async move { plexer.run().await });
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
note: opaque type is declared here
   --> /Users/runner/.cargo/git/checkouts/pallas-ea09e9ab4b7b6058/c772da6/pallas-network/src/multiplexer.rs:365:36
    |
365 |     pub async fn run(&mut self) -> Result<(), Error> {
    |                                    ^^^^^^^^^^^^^^^^^
note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
   --> /Users/runner/.cargo/git/checkouts/pallas-ea09e9ab4b7b6058/c772da6/pallas-network/src/facades.rs:43:18
    |
43  |     pub async fn connect(address: &str, magic: u64) -> Result<Self, Error> {
    |                  ^^^^^^^
note: future is not `Send` as it awaits another future which is not `Send`
   --> /Users/runner/.cargo/git/checkouts/pallas-ea09e9ab4b7b6058/c772da6/pallas-network/src/facades.rs:55:55
    |
55  |         let plexer_handle = tokio::spawn(async move { plexer.run().await });
    |                                                       ^^^^^^^^^^^^ await occurs here on type `impl Future<Output = Result<(), multiplexer::Error>>`, which is not `Send`
note: required by a bound in `tokio::spawn`
   --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.33.0/src/task/spawn.rs:166:21
    |
164 |     pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
    |            ----- required by a bound in this function
165 |     where
166 |         F: Future + Send + 'static,
    |                     ^^^^ required by this bound in `spawn`

error: future cannot be sent between threads safely
   --> /Users/runner/.cargo/git/checkouts/pallas-ea09e9ab4b7b6058/c772da6/pallas-network/src/facades.rs:115:42
    |
115 |         let plexer_handle = tokio::spawn(async move { server_plexer.run().await });
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
note: opaque type is declared here
   --> /Users/runner/.cargo/git/checkouts/pallas-ea09e9ab4b7b6058/c772da6/pallas-network/src/multiplexer.rs:365:36
    |
365 |     pub async fn run(&mut self) -> Result<(), Error> {
    |                                    ^^^^^^^^^^^^^^^^^
note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
   --> /Users/runner/.cargo/git/checkouts/pallas-ea09e9ab4b7b6058/c772da6/pallas-network/src/facades.rs:100:18
    |
100 |     pub async fn accept(listener: &TcpListener, magic: u64) -> Result<Self, Error> {
    |                  ^^^^^^
note: future is not `Send` as it awaits another future which is not `Send`
   --> /Users/runner/.cargo/git/checkouts/pallas-ea09e9ab4b7b6058/c772da6/pallas-network/src/facades.rs:115:55
    |
115 |         let plexer_handle = tokio::spawn(async move { server_plexer.run().await });
    |                                                       ^^^^^^^^^^^^^^^^^^^ await occurs here on type `impl Future<Output = Result<(), multiplexer::Error>>`, which is not `Send`
note: required by a bound in `tokio::spawn`
   --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.33.0/src/task/spawn.rs:166:21
    |
164 |     pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
    |            ----- required by a bound in this function
165 |     where
166 |         F: Future + Send + 'static,
    |                     ^^^^ required by this bound in `spawn`

error: future cannot be sent between threads safely
   --> /Users/runner/.cargo/git/checkouts/pallas-ea09e9ab4b7b6058/c772da6/pallas-network/src/facades.rs:171:42
    |
171 |         let plexer_handle = tokio::spawn(async move { plexer.run().await });
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
note: opaque type is declared here
   --> /Users/runner/.cargo/git/checkouts/pallas-ea09e9ab4b7b6058/c772da6/pallas-network/src/multiplexer.rs:365:36
    |
365 |     pub async fn run(&mut self) -> Result<(), Error> {
    |                                    ^^^^^^^^^^^^^^^^^
note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
   --> /Users/runner/.cargo/git/checkouts/pallas-ea09e9ab4b7b6058/c772da6/pallas-network/src/facades.rs:158:18
    |
158 |     pub async fn connect(path: impl AsRef<Path>, magic: u64) -> Result<Self, Error> {
    |                  ^^^^^^^
note: future is not `Send` as it awaits another future which is not `Send`
   --> /Users/runner/.cargo/git/checkouts/pallas-ea09e9ab4b7b6058/c772da6/pallas-network/src/facades.rs:171:55
    |
171 |         let plexer_handle = tokio::spawn(async move { plexer.run().await });
    |                                                       ^^^^^^^^^^^^ await occurs here on type `impl Future<Output = Result<(), multiplexer::Error>>`, which is not `Send`
note: required by a bound in `tokio::spawn`
   --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.33.0/src/task/spawn.rs:166:21
    |
164 |     pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
    |            ----- required by a bound in this function
165 |     where
166 |         F: Future + Send + 'static,
    |                     ^^^^ required by this bound in `spawn`

error: future cannot be sent between threads safely
   --> /Users/runner/.cargo/git/checkouts/pallas-ea09e9ab4b7b6058/c772da6/pallas-network/src/facades.rs:209:42
    |
209 |         let plexer_handle = tokio::spawn(async move { plexer.run().await });
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
note: opaque type is declared here
   --> /Users/runner/.cargo/git/checkouts/pallas-ea09e9ab4b7b6058/c772da6/pallas-network/src/multiplexer.rs:365:36
    |
365 |     pub async fn run(&mut self) -> Result<(), Error> {
    |                                    ^^^^^^^^^^^^^^^^^
note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
   --> /Users/runner/.cargo/git/checkouts/pallas-ea09e9ab4b7b6058/c772da6/pallas-network/src/facades.rs:195:18
    |
195 |     pub async fn handshake_query(
    |                  ^^^^^^^^^^^^^^^
note: future is not `Send` as it awaits another future which is not `Send`
   --> /Users/runner/.cargo/git/checkouts/pallas-ea09e9ab4b7b6058/c772da6/pallas-network/src/facades.rs:209:55
    |
209 |         let plexer_handle = tokio::spawn(async move { plexer.run().await });
    |                                                       ^^^^^^^^^^^^ await occurs here on type `impl Future<Output = Result<(), multiplexer::Error>>`, which is not `Send`
note: required by a bound in `tokio::spawn`
   --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.33.0/src/task/spawn.rs:166:21
    |
164 |     pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
    |            ----- required by a bound in this function
165 |     where
166 |         F: Future + Send + 'static,
    |                     ^^^^ required by this bound in `spawn`

error: future cannot be sent between threads safely
   --> /Users/runner/.cargo/git/checkouts/pallas-ea09e9ab4b7b6058/c772da6/pallas-network/src/facades.rs:273:42
    |
273 |         let plexer_handle = tokio::spawn(async move { server_plexer.run().await });
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
note: opaque type is declared here
   --> /Users/runner/.cargo/git/checkouts/pallas-ea09e9ab4b7b6058/c772da6/pallas-network/src/multiplexer.rs:365:36
    |
365 |     pub async fn run(&mut self) -> Result<(), Error> {
    |                                    ^^^^^^^^^^^^^^^^^
note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
   --> /Users/runner/.cargo/git/checkouts/pallas-ea09e9ab4b7b6058/c772da6/pallas-network/src/facades.rs:258:18
    |
258 |     pub async fn accept(listener: &UnixListener, magic: u64) -> Result<Self, Error> {
    |                  ^^^^^^
note: future is not `Send` as it awaits another future which is not `Send`
   --> /Users/runner/.cargo/git/checkouts/pallas-ea09e9ab4b7b6058/c772da6/pallas-network/src/facades.rs:273:55
    |
273 |         let plexer_handle = tokio::spawn(async move { server_plexer.run().await });
    |                                                       ^^^^^^^^^^^^^^^^^^^ await occurs here on type `impl Future<Output = Result<(), multiplexer::Error>>`, which is not `Send`
note: required by a bound in `tokio::spawn`
   --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.33.0/src/task/spawn.rs:166:21
    |
164 |     pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
    |            ----- required by a bound in this function
165 |     where
166 |         F: Future + Send + 'static,
    |                     ^^^^ required by this bound in `spawn`
```
