### PR TITLE
add epoch number struct and encode/decode implementations for `hardforkquery` and `ledgerquery`

### DIFF
--- a/pallas-network/src/miniprotocols/localstate/queries_v16/codec.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/codec.rs
@@ -172,8 +172,14 @@ impl Encode<()> for HardForkQuery {
 }
 
 impl<'b> Decode<'b, ()> for HardForkQuery {
-    fn decode(_d: &mut Decoder<'b>, _: &mut ()) -> Result<Self, decode::Error> {
-        todo!()
+    fn decode(d: &mut Decoder<'b>, _: &mut ()) -> Result<Self, decode::Error> {
+        d.array()?;
+        let tag = d.u16()?;
+        match tag {
+            0 => Ok(Self::GetInterpreter),
+            1 => Ok(Self::GetCurrentEra),
+            _ => unreachable!(),
+        }
     }
 }
 
@@ -197,8 +203,20 @@ impl Encode<()> for LedgerQuery {
 }
 
 impl<'b> Decode<'b, ()> for LedgerQuery {
-    fn decode(_d: &mut Decoder<'b>, _: &mut ()) -> Result<Self, decode::Error> {
-        todo!()
+    fn decode(d: &mut Decoder<'b>, _: &mut ()) -> Result<Self, decode::Error> {
+        d.array()?;
+        let tag = d.u16()?;
+        match tag {
+            0 => {
+                let (era, q) = d.decode()?;
+                Ok(Self::BlockQuery(era, q))
+            }
+            2 => {
+                let q = d.decode()?;
+                Ok(Self::HardForkQuery(q))
+            }
+            _ => Err(decode::Error::message("invalid tag")),
+        }
     }
 }
 

--- a/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
@@ -80,6 +80,9 @@ pub struct SystemStart {
     pub picoseconds_of_day: u64,
 }
 
+#[derive(Debug, Encode, Decode, PartialEq)]
+pub struct EpochNo(#[n(0)] pub u32);
+
 pub async fn get_chain_point(client: &mut Client) -> Result<Point, ClientError> {
     let query = Request::GetChainPoint;
     let result = client.query(query).await?;


### PR DESCRIPTION
those were missing to make the localstate query test fixtures.

for now supporting the block epoch number.

