### PR TITLE
`anycbor` struct: make the `inner` property publicly accessible

### DIFF
--- a/pallas-codec/src/utils.rs
+++ b/pallas-codec/src/utils.rs
@@ -665,7 +665,7 @@ impl<C, T> minicbor::Encode<C> for KeepRaw<'_, T> {
 /// ```
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub struct AnyCbor {
-    inner: Vec<u8>,
+    pub inner: Vec<u8>,
 }
 
 impl AnyCbor {


### PR DESCRIPTION
A minor nip to help https://github.com/input-output-hk/mithril/pull/1403 to be finished.