### PR TITLE
Set so_linger socket option the same as cardano-node

### DIFF
--- a/pallas-network/src/multiplexer.rs
+++ b/pallas-network/src/multiplexer.rs
@@ -83,6 +83,7 @@ impl Bearer {
         tcp_keepalive = tcp_keepalive.with_interval(tokio::time::Duration::from_secs(20));
         sock_ref.set_tcp_keepalive(&tcp_keepalive)?;
         sock_ref.set_nodelay(true)?;
+        sock_ref.set_linger(Some(std::time::Duration::from_secs(0)))?;
 
         Ok(())
     }


### PR DESCRIPTION
Enable SO_LINGER with a timeout of 0 seconds. This will immediately close the socket by sending a RST packet.

See: https://github.com/IntersectMBO/ouroboros-network/blob/c3d5669bf7c7c3df03c1d80b84adbd77cc7af103/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs#L173-L180