### PR TITLE
Implement NamedPipes entry point

### DIFF
--- a/pallas-network/src/facades.rs
+++ b/pallas-network/src/facades.rs
@@ -255,33 +255,37 @@ impl NodeClient {
         Ok(client)
     }
 
-    // #[cfg(windows)]
-    // pub async fn connect(
-    //     pipe_name: impl AsRef<std::ffi::OsStr>,
-    //     magic: u64,
-    // ) -> Result<Self, Error> {
-    //     let bearer = tokio::task::spawn_blocking(move ||
-    // Bearer::connect_named_pipe(pipe_name))         .await
-    //         .expect("can't join tokio thread")
-    //         .map_err(Error::ConnectFailure)?;
+    #[cfg(windows)]
+    pub async fn connect(
+        pipe_name: impl AsRef<std::ffi::OsStr>,
+        magic: u64,
+    ) -> Result<Self, Error> {
+        let pipe_name = pipe_name.as_ref().to_os_string();
 
-    //     let mut client = Self::new(bearer);
+        let bearer = tokio::task::spawn_blocking(move || {
+            Bearer::connect_named_pipe(pipe_name)
+        })
+        .await
+        .expect("can't join tokio thread")
+        .map_err(Error::ConnectFailure)?;
 
-    //     let versions = handshake::n2c::VersionTable::v10_and_above(magic);
+        let mut client = Self::new(bearer);
 
-    //     let handshake = client
-    //         .handshake()
-    //         .handshake(versions)
-    //         .await
-    //         .map_err(Error::HandshakeProtocol)?;
+        let versions = handshake::n2c::VersionTable::v10_and_above(magic);
 
-    //     if let handshake::Confirmation::Rejected(reason) = handshake {
-    //         error!(?reason, "handshake refused");
-    //         return Err(Error::IncompatibleVersion);
-    //     }
+        let handshake = client
+            .handshake()
+            .handshake(versions)
+            .await
+            .map_err(Error::HandshakeProtocol)?;
 
-    //     Ok(client)
-    // }
+        if let handshake::Confirmation::Rejected(reason) = handshake {
+            error!(?reason, "handshake refused");
+            return Err(Error::IncompatibleVersion);
+        }
+
+        Ok(client)
+    }
 
     #[cfg(unix)]
     pub async fn handshake_query(

--- a/pallas-network/src/multiplexer.rs
+++ b/pallas-network/src/multiplexer.rs
@@ -1,16 +1,13 @@
 //! A multiplexer of several mini-protocols through a single bearer
 
 use std::collections::HashMap;
-use std::sync::Arc;
-use std::time::Duration;
 
 use byteorder::{ByteOrder, NetworkEndian};
 use pallas_codec::{minicbor, Fragment};
 use thiserror::Error;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, ReadHalf, WriteHalf};
-use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
-use tokio::time::{Instant, sleep};
+use tokio::time::Instant;
 use tokio::{select, sync::mpsc::error::SendError};
 use tracing::{debug, error, trace, warn};
 


### PR DESCRIPTION
This PR implements the entry point code to support connection to `cardano-node` via `NamedPipes` for windows. 

`examples/n2c-miniprotocols` code has been updated to showcase `NamedPipes` connection functionality.

credits to @olofblomqvist for suggesting `tokio::io::split` to split the NamedPipe instance into ReadHalf and WriteHalf instances.