### PR TITLE
fix(codec) Fix flat encoding and decoding of arbitrarily size integers

### DIFF
--- a/pallas-codec/Cargo.toml
+++ b/pallas-codec/Cargo.toml
@@ -14,9 +14,13 @@ authors = [
   "Kasey White <kwhitemsg@gmail.com>",
 ]
 
+[features]
+default = []
+
 [dependencies]
 hex = "0.4.3"
 minicbor = { version = "0.20", features = ["std", "half", "derive"] }
+num-bigint = { version = "0.4.4", optional = true }
 serde = { version = "1.0.143", features = ["derive"] }
 thiserror = "1.0.39"
 

--- a/pallas-codec/src/flat/decode/mod.rs
+++ b/pallas-codec/src/flat/decode/mod.rs
@@ -3,6 +3,9 @@ mod error;
 
 use crate::flat::filler::Filler;
 
+#[cfg(feature = "num-bigint")]
+use num_bigint::BigInt;
+
 pub use decoder::Decoder;
 pub use error::Error;
 
@@ -36,9 +39,10 @@ impl Decode<'_> for isize {
     }
 }
 
-impl Decode<'_> for i128 {
+#[cfg(feature = "num-bigint")]
+impl Decode<'_> for BigInt {
     fn decode(d: &mut Decoder) -> Result<Self, Error> {
-        d.big_integer()
+        Ok(d.big_integer()?.into())
     }
 }
 

--- a/pallas-codec/src/flat/encode/mod.rs
+++ b/pallas-codec/src/flat/encode/mod.rs
@@ -3,6 +3,9 @@ mod error;
 
 use crate::flat::filler::Filler;
 
+#[cfg(feature = "num-bigint")]
+use num_bigint::BigInt;
+
 pub use encoder::Encoder;
 pub use error::Error;
 
@@ -26,9 +29,10 @@ impl Encode for u8 {
     }
 }
 
-impl Encode for i128 {
+#[cfg(feature = "num-bigint")]
+impl Encode for BigInt {
     fn encode(&self, e: &mut Encoder) -> Result<(), Error> {
-        e.big_integer(*self);
+        e.big_integer(self.clone());
 
         Ok(())
     }

--- a/pallas-codec/src/flat/zigzag.rs
+++ b/pallas-codec/src/flat/zigzag.rs
@@ -1,27 +1,51 @@
-pub fn to_usize(x: isize) -> usize {
-    let double_x = x << 1;
+#[cfg(feature = "num-bigint")]
+use num_bigint::{BigInt, BigUint, ToBigInt};
 
-    if x.is_positive() || x == 0 {
-        double_x as usize
-    } else {
-        (-double_x - 1) as usize
+pub trait ZigZag {
+    type Zag;
+    fn zigzag(self) -> Self::Zag;
+}
+
+#[cfg(feature = "num-bigint")]
+impl ZigZag for BigInt {
+    type Zag = BigUint;
+
+    fn zigzag(self) -> Self::Zag where {
+        if self >= 0.into() {
+            self << 1
+        } else {
+            let double: BigInt = self << 1;
+            -double - <u8 as Into<BigInt>>::into(1)
+        }
+        .to_biguint()
+        .expect("number is positive")
     }
 }
 
-pub fn to_isize(u: usize) -> isize {
-    ((u >> 1) as isize) ^ (-((u & 1) as isize))
-}
+impl ZigZag for isize {
+    type Zag = usize;
 
-pub fn to_u128(x: i128) -> u128 {
-    let double_x = x << 1;
-
-    if x.is_positive() || x == 0 {
-        double_x as u128
-    } else {
-        (-double_x - 1) as u128
+    fn zigzag(self) -> Self::Zag where {
+        let bits = isize::BITS as i128;
+        let i = self as i128;
+        ((i << 1) ^ (i >> (bits - 1))) as usize
     }
 }
 
-pub fn to_i128(u: u128) -> i128 {
-    ((u >> 1) as i128) ^ (-((u & 1) as i128))
+#[cfg(feature = "num-bigint")]
+impl ZigZag for BigUint {
+    type Zag = BigInt;
+
+    fn zigzag(self) -> Self::Zag where {
+        let i = self.to_bigint().expect("always possible");
+        (i.clone() >> 1) ^ -(i & <u8 as Into<BigInt>>::into(1))
+    }
+}
+
+impl ZigZag for usize {
+    type Zag = isize;
+
+    fn zigzag(self) -> Self::Zag where {
+        ((self >> 1) as isize) ^ -((self & 1) as isize)
+    }
 }

--- a/pallas-codec/tests/zigzag.rs
+++ b/pallas-codec/tests/zigzag.rs
@@ -1,18 +1,18 @@
-use pallas_codec::flat::zigzag::{to_isize, to_usize};
+use pallas_codec::flat::zigzag::ZigZag;
 use proptest::prelude::*;
 
 proptest! {
     #[test]
     fn zigzag(i: isize) {
-        let u = to_usize(i);
-        let converted_i = to_isize(u);
+        let u = i.zigzag();
+        let converted_i = u.zigzag();
         assert_eq!(converted_i, i);
     }
 
     #[test]
     fn zagzig(u: usize) {
-        let i = to_isize(u);
-        let converted_u = to_usize(i);
+        let i = u.zigzag();
+        let converted_u = i.zigzag();
         assert_eq!(converted_u, u);
     }
 }


### PR DESCRIPTION
  This commits fixes the flat encoding and decoding (and consequently, the zigzag) for large integers in the following ways:

  - It removes support for encoding and decoding i128 values.

  - It optionally (feature = "num-bigint") introduces encoding and decoding of large sized integers through the num-bigint::BigInt type.

  Without the feature enabled, it is still possible to encode and decode isize values; but the use of i128 is now prohibited (as it would overflow on boundaries) in favor of arbitrarily sized integers.

  The commit also introduces a property roundtrip for encoding and decoding large integers, which was missing and thus, failed to identify the overflow problem.

  See related issue: https://github.com/aiken-lang/aiken/issues/796