### PR TITLE
feat(hardano): Add Send + Sync to iterator returned by read_blocks_fr…

### DIFF
--- a/pallas-hardano/src/storage/immutable/mod.rs
+++ b/pallas-hardano/src/storage/immutable/mod.rs
@@ -200,7 +200,7 @@ pub fn read_blocks(dir: &Path) -> Result<impl Iterator<Item = FallibleBlock>, st
 pub fn read_blocks_from_point(
     dir: &Path,
     point: Point,
-) -> Result<Box<dyn Iterator<Item = FallibleBlock>>, Box<dyn std::error::Error>> {
+) -> Result<Box<dyn Iterator<Item = FallibleBlock> + Send + Sync>, Box<dyn std::error::Error>> {
     let names = build_stack_of_chunk_names(dir)?;
 
     match point {


### PR DESCRIPTION
Following up on https://github.com/txpipe/pallas/pull/372.

This pull request adds `Send + Sync` to the boxed iterator returned by `read_blocks_from_point` so it can be used in async contexts.