### PR TITLE
feat: implement stake snapshot local state query

### DIFF
--- a/examples/n2c-miniprotocols/src/main.rs
+++ b/examples/n2c-miniprotocols/src/main.rs
@@ -56,10 +56,8 @@ async fn do_localstate_query(client: &mut NodeClient) {
     println!("result: {:?}", result);
 
     // Stake pool ID/verification key hash (either Bech32-encoded or hex-encoded).
-    let pool_idx = hex::decode("fdb5834ba06eb4baafd50550d2dc9b3742d2c52cc5ee65bf8673823b").unwrap();
-
     // Empty list means all pools.
-    let pools = vec![Some(pool_idx.to_vec().into())];
+    let pools = vec![];
     let result = queries_v16::get_stake_snapshots(client, era, pools)
         .await
         .unwrap();

--- a/examples/n2c-miniprotocols/src/main.rs
+++ b/examples/n2c-miniprotocols/src/main.rs
@@ -1,4 +1,5 @@
 use pallas::{
+    codec::utils::Bytes,
     ledger::{addresses::Address, traverse::MultiEraBlock},
     network::{
         facades::NodeClient,
@@ -54,7 +55,16 @@ async fn do_localstate_query(client: &mut NodeClient) {
     let result = queries_v16::get_current_pparams(client, era).await.unwrap();
     println!("result: {:?}", result);
 
-    let result = queries_v16::get_stake_snapshots(client, era).await.unwrap();
+    // Stake pool ID/verification key hash (either Bech32-encoded or hex-encoded).
+    let pool_idx: Bytes = hex::decode("fdb5834ba06eb4baafd50550d2dc9b3742d2c52cc5ee65bf8673823b")
+        .unwrap()
+        .into();
+
+    // Empty list means all pools.
+    let pools = vec![Some(pool_idx.to_vec().into())];
+    let result = queries_v16::get_stake_snapshots(client, era, pools)
+        .await
+        .unwrap();
     println!("result: {:?}", result);
 
     client.send_release().await.unwrap();

--- a/examples/n2c-miniprotocols/src/main.rs
+++ b/examples/n2c-miniprotocols/src/main.rs
@@ -55,7 +55,7 @@ async fn do_localstate_query(client: &mut NodeClient) {
     let result = queries_v16::get_current_pparams(client, era).await.unwrap();
     println!("result: {:?}", result);
 
-    // Stake pool ID/verification key hash (either Bech32-encoded or hex-encoded).
+    // Stake pool ID/verification key hash (either Bech32-decoded or hex-decoded).
     // Empty list means all pools.
     let pools = vec![];
     let result = queries_v16::get_stake_snapshots(client, era, pools)

--- a/examples/n2c-miniprotocols/src/main.rs
+++ b/examples/n2c-miniprotocols/src/main.rs
@@ -56,9 +56,7 @@ async fn do_localstate_query(client: &mut NodeClient) {
     println!("result: {:?}", result);
 
     // Stake pool ID/verification key hash (either Bech32-encoded or hex-encoded).
-    let pool_idx: Bytes = hex::decode("fdb5834ba06eb4baafd50550d2dc9b3742d2c52cc5ee65bf8673823b")
-        .unwrap()
-        .into();
+    let pool_idx = hex::decode("fdb5834ba06eb4baafd50550d2dc9b3742d2c52cc5ee65bf8673823b").unwrap();
 
     // Empty list means all pools.
     let pools = vec![Some(pool_idx.to_vec().into())];

--- a/examples/n2c-miniprotocols/src/main.rs
+++ b/examples/n2c-miniprotocols/src/main.rs
@@ -1,5 +1,4 @@
 use pallas::{
-    codec::utils::Bytes,
     ledger::{addresses::Address, traverse::MultiEraBlock},
     network::{
         facades::NodeClient,

--- a/examples/n2c-miniprotocols/src/main.rs
+++ b/examples/n2c-miniprotocols/src/main.rs
@@ -54,6 +54,9 @@ async fn do_localstate_query(client: &mut NodeClient) {
     let result = queries_v16::get_current_pparams(client, era).await.unwrap();
     println!("result: {:?}", result);
 
+    let result = queries_v16::get_stake_snapshots(client, era).await.unwrap();
+    println!("result: {:?}", result);
+
     client.send_release().await.unwrap();
 }
 

--- a/examples/n2c-miniprotocols/src/main.rs
+++ b/examples/n2c-miniprotocols/src/main.rs
@@ -56,7 +56,7 @@ async fn do_localstate_query(client: &mut NodeClient) {
     println!("result: {:?}", result);
 
     // Stake pool ID/verification key hash (either Bech32-decoded or hex-decoded).
-    // Empty list means all pools.
+    // Empty Vec means all pools.
     let pools = vec![];
     let result = queries_v16::get_stake_snapshots(client, era, pools)
         .await

--- a/pallas-codec/src/utils.rs
+++ b/pallas-codec/src/utils.rs
@@ -1,4 +1,4 @@
-use minicbor::{data::Tag, display, Decode, Encode};
+use minicbor::{data::Tag, Decode, Encode};
 use serde::{Deserialize, Serialize};
 use std::{fmt, hash::Hash as StdHash, ops::Deref};
 
@@ -682,8 +682,6 @@ impl AnyCbor {
         T: Encode<()>,
     {
         let inner = minicbor::to_vec(other).unwrap();
-        let code = format!("{}", display(&inner));
-        println!("code1: {}", code);
         Self { inner }
     }
 
@@ -691,8 +689,6 @@ impl AnyCbor {
     where
         for<'b> T: Decode<'b, ()>,
     {
-        let code = format!("{}", display(&self.inner));
-        println!("code1: {}", code);
         minicbor::decode(&self.inner)
     }
 }

--- a/pallas-codec/src/utils.rs
+++ b/pallas-codec/src/utils.rs
@@ -1,4 +1,4 @@
-use minicbor::{data::Tag, Decode, Encode};
+use minicbor::{data::Tag, display, Decode, Encode};
 use serde::{Deserialize, Serialize};
 use std::{fmt, hash::Hash as StdHash, ops::Deref};
 
@@ -682,6 +682,8 @@ impl AnyCbor {
         T: Encode<()>,
     {
         let inner = minicbor::to_vec(other).unwrap();
+        let code = format!("{}", display(&inner));
+        println!("code1: {}", code);
         Self { inner }
     }
 
@@ -689,6 +691,8 @@ impl AnyCbor {
     where
         for<'b> T: Decode<'b, ()>,
     {
+        let code = format!("{}", display(&self.inner));
+        println!("code1: {}", code);
         minicbor::decode(&self.inner)
     }
 }

--- a/pallas-network/src/miniprotocols/localstate/queries_v16/codec.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/codec.rs
@@ -97,6 +97,12 @@ impl Encode<()> for BlockQuery {
             BlockQuery::GetStakeSnapshots(pools) => {
                 e.array(2)?;
                 e.u16(20)?;
+
+                if !pools.is_empty() {
+                    e.array(Vec::len(pools) as u64)?;
+                    e.tag(Tag::Unassigned(258))?;
+                }
+
                 e.encode(pools)?;
             }
             BlockQuery::GetPoolDistr(x) => {

--- a/pallas-network/src/miniprotocols/localstate/queries_v16/codec.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/codec.rs
@@ -94,10 +94,10 @@ impl Encode<()> for BlockQuery {
                 e.u16(19)?;
                 e.encode(x)?;
             }
-            BlockQuery::GetStakeSnapshots(x) => {
+            BlockQuery::GetStakeSnapshots(pools) => {
                 e.array(2)?;
                 e.u16(20)?;
-                e.encode(x)?;
+                e.encode(pools)?;
             }
             BlockQuery::GetPoolDistr(x) => {
                 e.array(2)?;
@@ -143,7 +143,7 @@ impl<'b> Decode<'b, ()> for BlockQuery {
             // 17 => Ok(Self::GetStakePoolParams(())),
             18 => Ok(Self::GetRewardInfoPools),
             // 19 => Ok(Self::GetPoolState(())),
-            // 20 => Ok(Self::GetStakeSnapshots(())),
+            20 => Ok(Self::GetStakeSnapshots(d.decode()?)),
             // 21 => Ok(Self::GetPoolDistr(())),
             // 22 => Ok(Self::GetStakeDelegDeposits(())),
             // 23 => Ok(Self::GetConstitutionHash),

--- a/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
@@ -210,9 +210,7 @@ pub type Addr = Bytes;
 
 pub type Addrs = Vec<Addr>;
 
-// pub type Pools = Option<Vec<Hash<28>>>;
-// pub type Pools = Vec<Hash<28>>;
-pub type Pools = Vec<Vec<u8>>;
+pub type Pools = Vec<Option<Bytes>>;
 
 pub type Coin = AnyUInt;
 
@@ -307,6 +305,7 @@ pub struct Stakes {
     pub snapshot_go_pool: u64,
 }
 
+/// Get the current tip of the ledger.
 pub async fn get_chain_point(client: &mut Client) -> Result<Point, ClientError> {
     let query = Request::GetChainPoint;
     let result = client.query(query).await?;
@@ -314,6 +313,7 @@ pub async fn get_chain_point(client: &mut Client) -> Result<Point, ClientError> 
     Ok(result)
 }
 
+/// Get the current era.
 pub async fn get_current_era(client: &mut Client) -> Result<Era, ClientError> {
     let query = HardForkQuery::GetCurrentEra;
     let query = LedgerQuery::HardForkQuery(query);
@@ -323,6 +323,7 @@ pub async fn get_current_era(client: &mut Client) -> Result<Era, ClientError> {
     Ok(result)
 }
 
+/// Get the system start time.
 pub async fn get_system_start(client: &mut Client) -> Result<SystemStart, ClientError> {
     let query = Request::GetSystemStart;
     let result = client.query(query).await?;
@@ -330,6 +331,7 @@ pub async fn get_system_start(client: &mut Client) -> Result<SystemStart, Client
     Ok(result)
 }
 
+/// Get the current protocol parameters.
 pub async fn get_current_pparams(
     client: &mut Client,
     era: u16,
@@ -342,6 +344,7 @@ pub async fn get_current_pparams(
     Ok(result)
 }
 
+/// Get the block number for the current tip.
 pub async fn get_block_epoch_number(client: &mut Client, era: u16) -> Result<u32, ClientError> {
     let query = BlockQuery::GetEpochNo;
     let query = LedgerQuery::BlockQuery(era, query);
@@ -351,6 +354,7 @@ pub async fn get_block_epoch_number(client: &mut Client, era: u16) -> Result<u32
     Ok(result)
 }
 
+/// Get the current stake distribution for the given era.
 pub async fn get_stake_distribution(
     client: &mut Client,
     era: u16,
@@ -363,6 +367,7 @@ pub async fn get_stake_distribution(
     Ok(result)
 }
 
+/// Get the UTxO set for the given era.
 pub async fn get_utxo_by_address(
     client: &mut Client,
     era: u16,
@@ -376,15 +381,15 @@ pub async fn get_utxo_by_address(
     Ok(result)
 }
 
+/// Get stake snapshots for the given era and stake pools.
+/// If `pools` are empty, all pools are queried.
+/// Otherwise, only the specified pool is queried.
+/// Note: This Query is limited by 1 pool per request.
 pub async fn get_stake_snapshots(
     client: &mut Client,
     era: u16,
+    pools: Vec<Option<Bytes>>,
 ) -> Result<StakeSnapshot, ClientError> {
-    let h = hex::decode("ff7b882facd434ac990c4293aa60f3b8a8016e7ad51644939597e90c").unwrap();
-    let pool_id_bytes = b"pool1lec5sxj3hzwz0f0t597r3g52a6lryv0v3vu3n382u6qpuqquhw6".to_vec();
-    let hash_bytes = Hash::<28>::from(h.as_slice());
-    let pools = Vec::from([]);
-    // let pools = TagWrap::<_, 258>::new(pools);
     let query = BlockQuery::GetStakeSnapshots(pools);
     let query = LedgerQuery::BlockQuery(era, query);
     let query = Request::LedgerQuery(query);


### PR DESCRIPTION
In case we search for specific pools: currently we have [one](https://github.com/IntersectMBO/ouroboros-consensus/blob/63fa2385a360eff10208c09f8ec055a13dae1984/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs#L550) pool per request limit. [Empty](https://github.com/IntersectMBO/ouroboros-consensus/blob/63fa2385a360eff10208c09f8ec055a13dae1984/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs#L554) pools means all pools.

the `cardano-cli` has the same behavior due to this limitation.

fixes #395 