### PR TITLE
feat(network): implement background keep-alive loop

### DIFF
--- a/pallas-network/src/miniprotocols/keepalive/client.rs
+++ b/pallas-network/src/miniprotocols/keepalive/client.rs
@@ -53,7 +53,7 @@ impl Client {
     fn has_agency(&self) -> bool {
         match &self.0 {
             State::Client => true,
-            State::Server => false,
+            State::Server(..) => false,
             State::Done => false,
         }
     }
@@ -84,7 +84,7 @@ impl Client {
 
     fn assert_inbound_state(&self, msg: &Message) -> Result<(), ClientError> {
         match (&self.0, msg) {
-            (State::Server, Message::ResponseKeepAlive(..)) => Ok(()),
+            (State::Server(..), Message::ResponseKeepAlive(..)) => Ok(()),
             _ => Err(ClientError::InvalidInbound),
         }
     }
@@ -108,32 +108,38 @@ impl Client {
         Ok(msg)
     }
 
-    pub async fn send_keepalive(&mut self) -> Result<(), ClientError> {
+    pub async fn send_keepalive_request(&mut self) -> Result<(), ClientError> {
         // generate random cookie value
-        let cookie = rand::thread_rng().gen::<KeepAliveCookie>();
+        let cookie = rand::thread_rng().gen::<Cookie>();
         let msg = Message::KeepAlive(cookie);
         self.send_message(&msg).await?;
-        self.2.saved_cookie = cookie;
-        self.0 = State::Server;
+        self.0 = State::Server(cookie);
         debug!("sent keepalive message with cookie {}", cookie);
-
-        self.recv_while_sending_keepalive().await?;
 
         Ok(())
     }
 
-    async fn recv_while_sending_keepalive(&mut self) -> Result<(), ClientError> {
+    pub async fn recv_keepalive_response(&mut self) -> Result<(), ClientError> {
         match self.recv_message().await? {
             Message::ResponseKeepAlive(cookie) => {
                 debug!("received keepalive response with cookie {}", cookie);
-                if cookie == self.2.saved_cookie {
-                    self.0 = State::Client;
-                    Ok(())
-                } else {
-                    Err(ClientError::KeepAliveCookieMismatch)
+                match self.state() {
+                    State::Server(expected) if *expected == cookie => {
+                        self.0 = State::Client;
+                        Ok(())
+                    }
+                    State::Server(..) => Err(ClientError::KeepAliveCookieMismatch),
+                    _ => unreachable!(),
                 }
             }
             _ => Err(ClientError::InvalidInbound),
         }
+    }
+
+    pub async fn keepalive_roundtrip(&mut self) -> Result<(), ClientError> {
+        self.send_keepalive_request().await?;
+        self.recv_keepalive_response().await?;
+
+        Ok(())
     }
 }

--- a/pallas-network/src/miniprotocols/keepalive/client.rs
+++ b/pallas-network/src/miniprotocols/keepalive/client.rs
@@ -27,19 +27,11 @@ pub enum ClientError {
     Plexer(multiplexer::Error),
 }
 
-pub struct KeepAliveSharedState {
-    saved_cookie: u16,
-}
-
-pub struct Client(State, multiplexer::ChannelBuffer, KeepAliveSharedState);
+pub struct Client(State, multiplexer::ChannelBuffer);
 
 impl Client {
     pub fn new(channel: multiplexer::AgentChannel) -> Self {
-        Self(
-            State::Client,
-            multiplexer::ChannelBuffer::new(channel),
-            KeepAliveSharedState { saved_cookie: 0 },
-        )
+        Self(State::Client, multiplexer::ChannelBuffer::new(channel))
     }
 
     pub fn state(&self) -> &State {

--- a/pallas-network/src/miniprotocols/keepalive/protocol.rs
+++ b/pallas-network/src/miniprotocols/keepalive/protocol.rs
@@ -1,15 +1,15 @@
-pub type KeepAliveCookie = u16;
+pub type Cookie = u16;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum State {
     Client,
-    Server,
+    Server(Cookie),
     Done,
 }
 
 #[derive(Debug, Clone)]
 pub enum Message {
-    KeepAlive(KeepAliveCookie),
-    ResponseKeepAlive(KeepAliveCookie),
+    KeepAlive(Cookie),
+    ResponseKeepAlive(Cookie),
     Done,
 }

--- a/pallas-network/src/miniprotocols/keepalive/server.rs
+++ b/pallas-network/src/miniprotocols/keepalive/server.rs
@@ -113,14 +113,11 @@ impl Server {
     }
 
     pub async fn send_keepalive_response(&mut self) -> Result<(), ServerError> {
-        match self.state().clone() {
-            State::Server(cookie) => {
-                let msg = Message::ResponseKeepAlive(cookie);
-                self.send_message(&msg).await?;
-                self.0 = State::Client;
-                debug!("sent keepalive response message with cookie {}", cookie);
-            }
-            _ => (),
+        if let State::Server(cookie) = self.state().clone() {
+            let msg = Message::ResponseKeepAlive(cookie);
+            self.send_message(&msg).await?;
+            self.0 = State::Client;
+            debug!("sent keepalive response message with cookie {}", cookie);
         }
 
         Ok(())


### PR DESCRIPTION
In this PR we introduce a background keep-alive loop as part of the PeerClient facade. This avoids the need for upper layers to implement their own logic, which is pretty standard.

On following PRs we'll introduce a way to configure the keep-alive interval and a way to skip it altogether.