### PR TITLE
Add an extra ergonomic method for n2c chainsync

### DIFF
--- a/examples/n2c-miniprotocols/src/main.rs
+++ b/examples/n2c-miniprotocols/src/main.rs
@@ -96,7 +96,7 @@ async fn do_chainsync(client: &mut NodeClient) {
     info!("intersected point is {:?}", point);
 
     loop {
-        let next = client.chainsync().request_next().await.unwrap();
+        let next = client.chainsync().request_or_await_next().await.unwrap();
         match next {
             chainsync::NextResponse::RollForward(h, _) => {
                 let block_number = MultiEraBlock::decode(&h).unwrap().number();

--- a/pallas-network/src/miniprotocols/chainsync/client.rs
+++ b/pallas-network/src/miniprotocols/chainsync/client.rs
@@ -286,7 +286,7 @@ where
     ///
     /// Returns an error if the message cannot be sent, or if the inbound
     /// message is invalid
-    pub async fn request_or_await_next(&mut self) -> Result<NextResponse<O>, Error> {
+    pub async fn request_or_await_next(&mut self) -> Result<NextResponse<O>, ClientError> {
         if self.has_agency() {
             self.request_next().await
         } else {

--- a/pallas-network/src/miniprotocols/chainsync/client.rs
+++ b/pallas-network/src/miniprotocols/chainsync/client.rs
@@ -281,10 +281,11 @@ where
     }
 
     /// Either requests the next block, or waits for one to become available.
-    /// 
+    ///
     /// # Errors
-    /// 
-    /// Returns an error if the message cannot be sent, or if the inbound message is invalid
+    ///
+    /// Returns an error if the message cannot be sent, or if the inbound
+    /// message is invalid
     pub async fn request_or_await_next(&mut self) -> Result<NextResponse<O>, Error> {
         if self.has_agency() {
             self.request_next().await

--- a/pallas-network/src/miniprotocols/chainsync/client.rs
+++ b/pallas-network/src/miniprotocols/chainsync/client.rs
@@ -280,6 +280,19 @@ where
         self.recv_while_can_await().await
     }
 
+    /// Either requests the next block, or waits for one to become available.
+    /// 
+    /// # Errors
+    /// 
+    /// Returns an error if the message cannot be sent, or if the inbound message is invalid
+    pub async fn request_or_await_next(&mut self) -> Result<NextResponse<O>, Error> {
+        if self.has_agency() {
+            self.request_next().await
+        } else {
+            self.recv_while_must_reply().await
+        }
+    }
+
     /// Attempt to intersect the chain at its origin (genesis block)
     ///
     /// # Errors


### PR DESCRIPTION
When actually consuming the chainsync client, initially the consumer
should call request_next repeatedly. However, once you are caught up,
you will get an "Await" response, which says we've requested the next
block, but the server doesn't have one for us, and will let us know when
one is available. If we request_next again, it fails.

In fact, even the example was misleading in this way!

The correct way to consume it was to check if you have agency, and if
so, either await or recieve.

If you tried to do this, though, especially when mixing it with other
future things (like select! on a cancellation token), then things could
get messy, because even though they return the same type, the impl
Future instances were opaque to the compiler.

This convenience method makes it nice and simple to idiomatically just
consume the next block as appropriate, and plays well with select!