### PR TITLE
Fix tx size in pallas-applying

### DIFF
--- a/pallas-applying/src/alonzo.rs
+++ b/pallas-applying/src/alonzo.rs
@@ -36,16 +36,16 @@ pub fn validate_alonzo_tx(
     network_id: &u8,
 ) -> ValidationResult {
     let tx_body: &TransactionBody = &mtx.transaction_body;
-    let size: &u32 = &get_alonzo_comp_tx_size(tx_body).ok_or(Alonzo(UnknownTxSize))?;
+    let size: u32 = get_alonzo_comp_tx_size(mtx);
     check_ins_not_empty(tx_body)?;
     check_ins_and_collateral_in_utxos(tx_body, utxos)?;
     check_tx_validity_interval(tx_body, mtx, block_slot)?;
-    check_fee(tx_body, size, mtx, utxos, prot_pps)?;
+    check_fee(tx_body, &size, mtx, utxos, prot_pps)?;
     check_preservation_of_value(tx_body, utxos)?;
     check_min_lovelace(tx_body, prot_pps)?;
     check_output_val_size(tx_body, prot_pps)?;
     check_network_id(tx_body, network_id)?;
-    check_tx_size(size, prot_pps)?;
+    check_tx_size(&size, prot_pps)?;
     check_tx_ex_units(mtx, prot_pps)?;
     check_witness_set(mtx, utxos)?;
     check_languages(mtx, prot_pps)?;

--- a/pallas-applying/src/babbage.rs
+++ b/pallas-applying/src/babbage.rs
@@ -38,16 +38,16 @@ pub fn validate_babbage_tx(
     network_id: &u8,
 ) -> ValidationResult {
     let tx_body: &MintedTransactionBody = &mtx.transaction_body.clone();
-    let size: &u32 = &get_babbage_tx_size(tx_body).ok_or(Babbage(UnknownTxSize))?;
+    let size: u32 = get_babbage_tx_size(mtx).ok_or(Babbage(UnknownTxSize))?;
     check_ins_not_empty(tx_body)?;
     check_all_ins_in_utxos(tx_body, utxos)?;
     check_tx_validity_interval(tx_body, block_slot)?;
-    check_fee(tx_body, size, mtx, utxos, prot_pps)?;
+    check_fee(tx_body, &size, mtx, utxos, prot_pps)?;
     check_preservation_of_value(tx_body, utxos)?;
     check_min_lovelace(tx_body, prot_pps)?;
     check_output_val_size(tx_body, prot_pps)?;
     check_network_id(tx_body, network_id)?;
-    check_tx_size(size, prot_pps)?;
+    check_tx_size(&size, prot_pps)?;
     check_tx_ex_units(mtx, prot_pps)?;
     check_minting(tx_body, mtx)?;
     check_well_formedness(tx_body, mtx)?;

--- a/pallas-applying/src/shelley_ma.rs
+++ b/pallas-applying/src/shelley_ma.rs
@@ -31,14 +31,14 @@ pub fn validate_shelley_ma_tx(
 ) -> ValidationResult {
     let tx_body: &TransactionBody = &mtx.transaction_body;
     let tx_wits: &MintedWitnessSet = &mtx.transaction_witness_set;
-    let size: &u32 = &get_alonzo_comp_tx_size(tx_body).ok_or(ShelleyMA(UnknownTxSize))?;
+    let size: u32 = get_alonzo_comp_tx_size(mtx);
     check_ins_not_empty(tx_body)?;
     check_ins_in_utxos(tx_body, utxos)?;
     check_ttl(tx_body, block_slot)?;
-    check_tx_size(size, prot_pps)?;
+    check_tx_size(&size, prot_pps)?;
     check_min_lovelace(tx_body, prot_pps, era)?;
     check_preservation_of_value(tx_body, utxos, era)?;
-    check_fees(tx_body, size, prot_pps)?;
+    check_fees(tx_body, &size, prot_pps)?;
     check_network_id(tx_body, network_id)?;
     check_metadata(tx_body, mtx)?;
     check_witnesses(tx_body, tx_wits, utxos)?;

--- a/pallas-applying/src/utils.rs
+++ b/pallas-applying/src/utils.rs
@@ -15,7 +15,7 @@ use pallas_primitives::{
         AssetName, AuxiliaryData, Coin, MintedTx as AlonzoMintedTx, Multiasset, NativeScript,
         NetworkId, PlutusScript, PolicyId, VKeyWitness, Value,
     },
-    babbage::{MintedTransactionBody, MintedTx as BabbageMintedTx, PlutusV2Script},
+    babbage::{MintedTx as BabbageMintedTx, PlutusV2Script},
 };
 use pallas_traverse::{MultiEraInput, MultiEraOutput};
 use std::collections::HashMap;
@@ -38,9 +38,9 @@ pub fn get_alonzo_comp_tx_size(mtx: &AlonzoMintedTx) -> u32 {
     }
 }
 
-pub fn get_babbage_tx_size(tx_body: &MintedTransactionBody) -> Option<u32> {
+pub fn get_babbage_tx_size(mtx: &BabbageMintedTx) -> Option<u32> {
     let mut buff: Vec<u8> = Vec::new();
-    match encode(tx_body, &mut buff) {
+    match encode(mtx, &mut buff) {
         Ok(()) => Some(buff.len() as u32),
         Err(_) => None,
     }


### PR DESCRIPTION
Fix the computation of the size of a transaction by additionally adding the witness set CBOR length and the auxiliary data CBOR length