### PR TITLE
fix: Exclude last chunk files during immutable db read

### DIFF
--- a/pallas-hardano/src/storage/immutable/mod.rs
+++ b/pallas-hardano/src/storage/immutable/mod.rs
@@ -119,6 +119,10 @@ fn build_stack_of_chunk_names(dir: &Path) -> Result<ChunkNameSack, std::io::Erro
 
     chunks.sort();
     chunks.reverse();
+    // According to this docs https://mithril.network/doc/glossary/#immutable-file-number,
+    // the last chunk files are not really immutable.
+    // So to preserve only immutable data the last chunk files are omitted.
+    chunks.pop();
 
     Ok(chunks)
 }

--- a/pallas-hardano/src/storage/immutable/mod.rs
+++ b/pallas-hardano/src/storage/immutable/mod.rs
@@ -118,11 +118,11 @@ fn build_stack_of_chunk_names(dir: &Path) -> Result<ChunkNameSack, std::io::Erro
         .collect::<Vec<_>>();
 
     chunks.sort();
-    chunks.reverse();
     // According to this docs https://mithril.network/doc/glossary/#immutable-file-number,
     // the last chunk files are not really immutable.
     // So to preserve only immutable data the last chunk files are omitted.
     chunks.pop();
+    chunks.reverse();
 
     Ok(chunks)
 }


### PR DESCRIPTION
We have found that according to this docs https://mithril.network/doc/glossary/#immutable-file-number.
Last chunk files of the immutable db is not really immutable.
And as a consequence last chunk files also could have an invalid and corrupted data, which we have faced with some mithrill snapshots (Basically that case also described here https://github.com/txpipe/pallas/pull/426).
This solution suggests just to exclude the last chunk files during the read, to preserve an expected state from the immutable storage, that's it's finalised state.