### PR TITLE
feat(traverse): Decode Conway block headers properly

### DIFF
--- a/examples/n2n-miniprotocols/src/main.rs
+++ b/examples/n2n-miniprotocols/src/main.rs
@@ -78,7 +78,7 @@ async fn do_chainsync(
                                 tracing::info!("epoch boundary");
                                 None
                             }
-                            MultiEraHeader::AlonzoCompatible(_) | MultiEraHeader::Babbage(_) => {
+                            MultiEraHeader::ShelleyCompatible(_) | MultiEraHeader::BabbageCompatible(_) => {
                                 if next_log.elapsed().as_secs() > 1 {
                                     tracing::info!("chainsync block header: {}", number);
                                     next_log = Instant::now();

--- a/pallas-network/src/facades.rs
+++ b/pallas-network/src/facades.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 use std::path::Path;
 use std::time::Duration;
 use thiserror::Error;
-use tracing::{debug, error, warn};
+use tracing::{debug, error};
 
 use tokio::net::{TcpListener, ToSocketAddrs};
 
@@ -67,7 +67,7 @@ impl KeepAliveLoop {
 
         loop {
             interval.tick().await;
-            warn!("sending keepalive request");
+            debug!("sending keepalive request");
 
             client
                 .keepalive_roundtrip()

--- a/pallas-traverse/src/block.rs
+++ b/pallas-traverse/src/block.rs
@@ -90,10 +90,10 @@ impl<'b> MultiEraBlock<'b> {
             }
             MultiEraBlock::Byron(x) => MultiEraHeader::Byron(Cow::Borrowed(&x.header)),
             MultiEraBlock::AlonzoCompatible(x, _) => {
-                MultiEraHeader::AlonzoCompatible(Cow::Borrowed(&x.header))
+                MultiEraHeader::ShelleyCompatible(Cow::Borrowed(&x.header))
             }
-            MultiEraBlock::Babbage(x) => MultiEraHeader::Babbage(Cow::Borrowed(&x.header)),
-            MultiEraBlock::Conway(x) => MultiEraHeader::Babbage(Cow::Borrowed(&x.header)),
+            MultiEraBlock::Babbage(x) => MultiEraHeader::BabbageCompatible(Cow::Borrowed(&x.header)),
+            MultiEraBlock::Conway(x) => MultiEraHeader::BabbageCompatible(Cow::Borrowed(&x.header)),
         }
     }
 

--- a/pallas-traverse/src/lib.rs
+++ b/pallas-traverse/src/lib.rs
@@ -62,8 +62,8 @@ pub enum Feature {
 #[derive(Debug)]
 pub enum MultiEraHeader<'b> {
     EpochBoundary(Cow<'b, KeepRaw<'b, byron::EbbHead>>),
-    AlonzoCompatible(Cow<'b, KeepRaw<'b, alonzo::Header>>),
-    Babbage(Cow<'b, KeepRaw<'b, babbage::Header>>),
+    ShelleyCompatible(Cow<'b, KeepRaw<'b, alonzo::Header>>),
+    BabbageCompatible(Cow<'b, KeepRaw<'b, babbage::Header>>),
     Byron(Cow<'b, KeepRaw<'b, byron::BlockHead>>),
 }
 


### PR DESCRIPTION
Updates:
Ensure we can parse block header values of 5..6 as BabbageCompatible for both Babbage and Conway eras. The previous code had a Conway header falling back and attempting to parse as AlonzoCompatible.

Refactoring:
I changed AlonzoCompatible -> ShelleyCompatible for the block headers. BlockHeaders represent forward compatibility. In other words, we only get a new category for headers named after the first Era in which it changed.

Babbage -> BabbageCompatible since it now also includes conway BlockHeaders.

So, shelley, allegra, mary, alonzo blocks contain block headers that are shelley compatible.

babbage and conway blocks contain block headers that are babbage compatible.