### PR TITLE
ci: fix gmp build on windows

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,14 +11,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macOS-latest]
-        rust: [stable]
+        include:
+          - os: ubuntu-latest
+            rust: stable
+          - os: macOS-latest
+            rust: stable
+          - os: windows-latest
+            rust: stable-x86_64-pc-windows-gnu
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+
+      - uses: msys2/setup-msys2@v2
+        if: runner.os == 'Windows'
+        with:
+          install: diffutils m4 make mingw-w64-x86_64-gcc
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1

--- a/pallas-math/Cargo.toml
+++ b/pallas-math/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["Andrew Westberg <andrewwestberg@gmail.com>"]
 
 
 [dependencies]
-# rug = "1.24.1"
+rug = "1.24.1"
 
 [dev-dependencies]
 quickcheck = "1.0"


### PR DESCRIPTION
The rug -> gmp dep fails to build on windows because it requires msys2 instead of mvsc.

This PR adjusts the target used in the rust toolchain setup to `stable-x86_64-pc-windows-gnu` which takes care of the setup for msys2, but it still doesn't work because there are package dependencies that need to be installed inside msys2 (which I'm not clear how to do).