### PR TITLE
Include native_bytes in PlutusData

### DIFF
--- a/pallas-utxorpc/src/lib.rs
+++ b/pallas-utxorpc/src/lib.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, ops::Deref};
 
 use pallas_codec::utils::KeyValuePairs;
 use pallas_crypto::hash::Hash;
-use pallas_primitives::{alonzo, babbage, conway};
+use pallas_primitives::{alonzo, babbage, conway, Fragment};
 use pallas_traverse as trv;
 
 use trv::OriginalHash;
@@ -455,6 +455,7 @@ impl<C: LedgerContext> Mapper<C> {
         };
 
         u5c::PlutusData {
+            native_bytes: x.encode_fragment().expect("must have raw bytes").into(),
             plutus_data: inner.into(),
         }
     }


### PR DESCRIPTION
Depends on the spec updates [here](https://github.com/utxorpc/spec/pull/111); Technically this doesn't round trip / honor the bytes from the block itself, so could have encoding / hash issues, so we might want to do a larger refactor