### PR TITLE
chore(utxorpc): update u5c spec to v0.8.0

### DIFF
--- a/pallas-utxorpc/Cargo.toml
+++ b/pallas-utxorpc/Cargo.toml
@@ -16,7 +16,7 @@ pallas-primitives = { version = "=0.29.0", path = "../pallas-primitives" }
 pallas-codec = { version = "=0.29.0", path = "../pallas-codec" }
 pallas-crypto = { version = "=0.29.0", path = "../pallas-crypto" }
 
-utxorpc-spec = { version = "0.7.0" }
+utxorpc-spec = { version = "0.8.0" }
 
 [dev-dependencies]
 hex = "0.4.3"


### PR DESCRIPTION
This PR updates u5c spec dependecy to v0.8.0, updates the mapping logic to support the new schema changes.