### PR TITLE
0.30.0+patch

### DIFF
--- a/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
@@ -127,10 +127,10 @@ pub struct CostMdls {
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct ExUnitPrices {
     #[n(0)]
-    mem_price: PositiveInterval,
+    pub mem_price: PositiveInterval,
 
     #[n(1)]
-    step_price: PositiveInterval,
+    pub step_price: PositiveInterval,
 }
 
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]

--- a/pallas-primitives/src/conway/model.rs
+++ b/pallas-primitives/src/conway/model.rs
@@ -177,7 +177,7 @@ pub enum Certificate {
     ResignCommitteeCold(CommitteeColdCredential, Nullable<Anchor>),
     RegDRepCert(DRepCredential, Coin, Nullable<Anchor>),
     UnRegDRepCert(DRepCredential, Coin),
-    UpdateDRepCert(StakeCredential, Nullable<Anchor>),
+    UpdateDRepCert(DRepCredential, Nullable<Anchor>),
 }
 
 impl<'b, C> minicbor::decode::Decode<'b, C> for Certificate {

--- a/pallas-primitives/src/conway/model.rs
+++ b/pallas-primitives/src/conway/model.rs
@@ -1301,10 +1301,10 @@ pub use crate::alonzo::ExUnits;
 #[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct ExUnitPrices {
     #[n(0)]
-    mem_price: RationalNumber,
+    pub mem_price: RationalNumber,
 
     #[n(1)]
-    step_price: RationalNumber,
+    pub step_price: RationalNumber,
 }
 
 #[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone, Copy)]


### PR DESCRIPTION
- :round_pushpin: **Expose private struct fields for ExUnitPrices.**
  
- :round_pushpin: **Fix UpdateDRepCert variant argument.**
    They are isomorphic, but for the sake of correctness, it's better that way.
