### PR TITLE
refactor: support roundtrip encoding for script data hash components

### DIFF
--- a/pallas-applying/src/alonzo.rs
+++ b/pallas-applying/src/alonzo.rs
@@ -566,24 +566,22 @@ fn mk_plutus_script_redeemer_pointers(
                     }
                 }
             }
-            match mint {
-                Some(minted_value) => {
-                    let sorted_policies: Vec<PolicyId> = sort_policies(minted_value);
-                    for (index, policy) in sorted_policies.iter().enumerate() {
-                        for plutus_script in plutus_scripts.iter() {
-                            let hashed_script: PolicyId =
-                                compute_plutus_v1_script_hash(plutus_script);
-                            if *policy == hashed_script {
-                                res.push(RedeemerPointer {
-                                    tag: RedeemerTag::Mint,
-                                    index: index as u32,
-                                })
-                            }
+
+            if let Some(minted_value) = mint {
+                let sorted_policies: Vec<PolicyId> = sort_policies(minted_value);
+                for (index, policy) in sorted_policies.iter().enumerate() {
+                    for plutus_script in plutus_scripts.iter() {
+                        let hashed_script: PolicyId = compute_plutus_v1_script_hash(plutus_script);
+                        if *policy == hashed_script {
+                            res.push(RedeemerPointer {
+                                tag: RedeemerTag::Mint,
+                                index: index as u32,
+                            })
                         }
                     }
                 }
-                None => (),
             }
+
             res
         }
         None => Vec::new(),
@@ -727,10 +725,11 @@ fn check_vkey_input_wits(
     let tx_hash: &Vec<u8> = &Vec::from(mtx.transaction_body.original_hash().as_ref());
     let mut inputs_and_collaterals: Vec<TransactionInput> = Vec::new();
     inputs_and_collaterals.extend(tx_body.inputs.clone());
-    match &tx_body.collateral {
-        Some(collaterals) => inputs_and_collaterals.extend(collaterals.clone()),
-        None => (),
+
+    if let Some(collaterals) = &tx_body.collateral {
+        inputs_and_collaterals.extend(collaterals.clone());
     }
+
     for input in inputs_and_collaterals.iter() {
         match utxos.get(&MultiEraInput::from_alonzo_compatible(input)) {
             Some(multi_era_output) => {

--- a/pallas-applying/tests/alonzo.rs
+++ b/pallas-applying/tests/alonzo.rs
@@ -27,6 +27,8 @@ use std::borrow::Cow;
 
 #[cfg(test)]
 mod alonzo_tests {
+    use pallas_primitives::MaybeIndefArray;
+
     use super::*;
 
     #[test]
@@ -2046,7 +2048,7 @@ mod alonzo_tests {
         );
         let mut tx_wits: MintedWitnessSet = mtx.transaction_witness_set.unwrap().clone();
         let old_datum: KeepRaw<PlutusData> = tx_wits.plutus_data.unwrap().pop().unwrap();
-        let new_datum: PlutusData = PlutusData::Array(Vec::new());
+        let new_datum: PlutusData = PlutusData::Array(MaybeIndefArray::Def(Vec::new()));
         let mut new_datum_buf: Vec<u8> = Vec::new();
         let _ = encode(new_datum, &mut new_datum_buf);
         let keep_raw_new_datum: KeepRaw<PlutusData> =
@@ -2171,7 +2173,7 @@ mod alonzo_tests {
         let new_redeemer: Redeemer = Redeemer {
             tag: RedeemerTag::Spend,
             index: 15,
-            data: PlutusData::Array(Vec::new()),
+            data: PlutusData::Array(MaybeIndefArray::Def(Vec::new())),
             ex_units: ExUnits { mem: 0, steps: 0 },
         };
         tx_wits.redeemer = Some(vec![old_redeemer, new_redeemer]);

--- a/pallas-applying/tests/babbage.rs
+++ b/pallas-applying/tests/babbage.rs
@@ -29,6 +29,8 @@ use std::borrow::Cow;
 
 #[cfg(test)]
 mod babbage_tests {
+    use pallas_primitives::MaybeIndefArray;
+
     use super::*;
 
     #[test]
@@ -2150,7 +2152,7 @@ mod babbage_tests {
         add_collateral_babbage(&mtx.transaction_body, &mut utxos, collateral_info);
         let mut tx_wits: MintedWitnessSet = mtx.transaction_witness_set.unwrap().clone();
         let old_datum: KeepRaw<PlutusData> = tx_wits.plutus_data.unwrap().pop().unwrap();
-        let new_datum: PlutusData = PlutusData::Array(Vec::new());
+        let new_datum: PlutusData = PlutusData::Array(MaybeIndefArray::Def(Vec::new()));
         let mut new_datum_buf: Vec<u8> = Vec::new();
         let _ = encode(new_datum, &mut new_datum_buf);
         let keep_raw_new_datum: KeepRaw<PlutusData> =
@@ -2245,7 +2247,7 @@ mod babbage_tests {
         let new_redeemer: Redeemer = Redeemer {
             tag: RedeemerTag::Spend,
             index: 15,
-            data: PlutusData::Array(Vec::new()),
+            data: PlutusData::Array(MaybeIndefArray::Def(Vec::new())),
             ex_units: ExUnits { mem: 0, steps: 0 },
         };
         tx_wits.redeemer = Some(vec![old_redeemer, new_redeemer]);

--- a/pallas-primitives/src/conway/model.rs
+++ b/pallas-primitives/src/conway/model.rs
@@ -3,9 +3,8 @@
 //! Handcrafted, idiomatic rust artifacts based on based on the [Conway CDDL](https://github.com/IntersectMBO/cardano-ledger/blob/master/eras/conway/impl/cddl-files/conway.cddl) file in IntersectMBO repo.
 
 use serde::{Deserialize, Serialize};
-use std::ops::Deref;
 
-use pallas_codec::minicbor::{self, decode::Error, Decode, Encode};
+use pallas_codec::minicbor::{self, Decode, Encode};
 use pallas_codec::utils::CborWrap;
 
 pub use crate::{
@@ -1278,22 +1277,15 @@ pub struct RedeemersValue {
     pub ex_units: ExUnits,
 }
 
-// TODO: Redeemers needs to be KeepRaw because of script data hash
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct Redeemers(NonEmptyKeyValuePairs<RedeemersKey, RedeemersValue>);
-
-impl Deref for Redeemers {
-    type Target = NonEmptyKeyValuePairs<RedeemersKey, RedeemersValue>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
+pub enum Redeemers {
+    List(MaybeIndefArray<Redeemer>),
+    Map(NonEmptyKeyValuePairs<RedeemersKey, RedeemersValue>),
 }
 
 impl From<NonEmptyKeyValuePairs<RedeemersKey, RedeemersValue>> for Redeemers {
     fn from(value: NonEmptyKeyValuePairs<RedeemersKey, RedeemersValue>) -> Self {
-        Redeemers(value)
+        Redeemers::Map(value)
     }
 }
 
@@ -1301,30 +1293,10 @@ impl<'b, C> minicbor::Decode<'b, C> for Redeemers {
     fn decode(d: &mut minicbor::Decoder<'b>, ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
         match d.datatype()? {
             minicbor::data::Type::Array | minicbor::data::Type::ArrayIndef => {
-                let redeemers: Vec<Redeemer> = d.decode_with(ctx)?;
-
-                let kvs = redeemers
-                    .into_iter()
-                    .map(|x| {
-                        (
-                            RedeemersKey {
-                                tag: x.tag,
-                                index: x.index,
-                            },
-                            RedeemersValue {
-                                data: x.data,
-                                ex_units: x.ex_units,
-                            },
-                        )
-                    })
-                    .collect::<Vec<_>>()
-                    .try_into()
-                    .map_err(|_| Error::message("decoding empty redeemers"))?;
-
-                Ok(Self(kvs))
+                Ok(Self::List(d.decode_with(ctx)?))
             }
             minicbor::data::Type::Map | minicbor::data::Type::MapIndef => {
-                Ok(Self(d.decode_with(ctx)?))
+                Ok(Self::Map(d.decode_with(ctx)?))
             }
             _ => Err(minicbor::decode::Error::message(
                 "invalid type for redeemers struct",
@@ -1339,7 +1311,10 @@ impl<C> minicbor::Encode<C> for Redeemers {
         e: &mut minicbor::Encoder<W>,
         ctx: &mut C,
     ) -> Result<(), minicbor::encode::Error<W::Error>> {
-        e.encode_with(&self.0, ctx)?;
+        match self {
+            Self::List(x) => e.encode_with(x, ctx)?,
+            Self::Map(x) => e.encode_with(x, ctx)?,
+        };
 
         Ok(())
     }

--- a/pallas-traverse/src/hashes.rs
+++ b/pallas-traverse/src/hashes.rs
@@ -182,7 +182,7 @@ mod tests {
     use crate::{Era, MultiEraTx};
 
     use super::{ComputeHash, OriginalHash};
-    use pallas_codec::utils::Int;
+    use pallas_codec::utils::{Int, MaybeIndefArray};
     use pallas_codec::{minicbor, utils::Bytes};
     use pallas_crypto::hash::Hash;
     use pallas_crypto::key::ed25519::PublicKey;
@@ -283,26 +283,26 @@ mod tests {
         let pd = alonzo::PlutusData::Constr(alonzo::Constr::<alonzo::PlutusData> {
             tag: 1280,
             any_constructor: None,
-            fields: vec![
+            fields: MaybeIndefArray::Indef(vec![
                 alonzo::PlutusData::BigInt(alonzo::BigInt::Int(Int::from(4))),
                 alonzo::PlutusData::Constr(alonzo::Constr::<alonzo::PlutusData> {
                     tag: 124,
                     any_constructor: None,
-                    fields: vec![
+                    fields: MaybeIndefArray::Indef(vec![
                         alonzo::PlutusData::BigInt(alonzo::BigInt::Int(Int::from(-4))),
                         alonzo::PlutusData::Constr(alonzo::Constr::<alonzo::PlutusData> {
                             tag: 102,
                             any_constructor: Some(453),
-                            fields: vec![
+                            fields: MaybeIndefArray::Indef(vec![
                                 alonzo::PlutusData::BigInt(alonzo::BigInt::Int(Int::from(2))),
                                 alonzo::PlutusData::BigInt(alonzo::BigInt::Int(Int::from(3434))),
-                            ],
+                            ]),
                         }),
                         alonzo::PlutusData::BigInt(alonzo::BigInt::Int(Int::from(-11828293))),
-                    ],
+                    ]),
                 }),
                 alonzo::PlutusData::BigInt(alonzo::BigInt::Int(Int::from(11828293))),
-            ],
+            ]),
         });
 
         // if you need to try this out in the cardano-cli, uncomment this line to see

--- a/pallas-traverse/src/redeemers.rs
+++ b/pallas-traverse/src/redeemers.rs
@@ -65,4 +65,17 @@ impl<'b> MultiEraRedeemer<'b> {
             Box::new(Cow::Borrowed(redeemers_val)),
         )
     }
+
+    pub fn from_conway_deprecated(redeemer: &'b conway::Redeemer) -> Self {
+        Self::Conway(
+            Box::new(Cow::Owned(conway::RedeemersKey {
+                tag: redeemer.tag,
+                index: redeemer.index,
+            })),
+            Box::new(Cow::Owned(conway::RedeemersValue {
+                data: redeemer.data.clone(),
+                ex_units: redeemer.ex_units,
+            })),
+        )
+    }
 }

--- a/pallas-txbuilder/src/transaction/serialise.rs
+++ b/pallas-txbuilder/src/transaction/serialise.rs
@@ -395,7 +395,7 @@ mod tests {
     use std::str::FromStr;
 
     use pallas_addresses::Address as PallasAddress;
-    use pallas_primitives::{babbage::PlutusData, Fragment};
+    use pallas_primitives::{babbage::PlutusData, Fragment, MaybeIndefArray};
 
     use crate::transaction::{model::*, Bytes64, DatumBytes, DatumHash, Hash28, TransactionStatus};
 
@@ -473,8 +473,8 @@ mod tests {
             ),
             datums: Some(datums),
             redeemers: Some(Redeemers::from_map(vec![
-                (RedeemerPurpose::Spend(Input { tx_hash: Bytes32([4; 32]), txo_index: 1 }), (Bytes(PlutusData::Array(vec![]).encode_fragment().unwrap()), Some(ExUnits { mem: 1337, steps: 7331 }))),
-                (RedeemerPurpose::Mint(Hash28([5; 28])), (Bytes(PlutusData::Array(vec![]).encode_fragment().unwrap()), None)),
+                (RedeemerPurpose::Spend(Input { tx_hash: Bytes32([4; 32]), txo_index: 1 }), (Bytes(PlutusData::Array(MaybeIndefArray::Def(vec![])).encode_fragment().unwrap()), Some(ExUnits { mem: 1337, steps: 7331 }))),
+                (RedeemerPurpose::Mint(Hash28([5; 28])), (Bytes(PlutusData::Array(MaybeIndefArray::Def(vec![])).encode_fragment().unwrap()), None)),
             ].into_iter().collect::<HashMap<_, _>>())),
             signature_amount_override: Some(5),
             change_address: Some(Address(PallasAddress::from_str("addr1g9ekml92qyvzrjmawxkh64r2w5xr6mg9ngfmxh2khsmdrcudevsft64mf887333adamant").unwrap())),


### PR DESCRIPTION
Computing "script data hash" requires redemeers, witness-set datums and language views.

To make the hash consistent across encoding roundtrips, this PR replaces some internal structs in the primitives with CBOR-aware structs (eg: MaybeIndexArray).

A following PR will introduce the hash compute logic.