### PR TITLE
Fix invalid serialization of Conway transactions when there are no redeemers

### DIFF
--- a/pallas-txbuilder/src/conway.rs
+++ b/pallas-txbuilder/src/conway.rs
@@ -265,7 +265,11 @@ impl BuildConway for StagingTransaction {
                 plutus_v2_script: NonEmptySet::from_vec(plutus_v2_script),
                 plutus_v3_script: NonEmptySet::from_vec(plutus_v3_script),
                 plutus_data: NonEmptySet::from_vec(plutus_data),
-                redeemer: Some(witness_set_redeemers),
+                redeemer: if redeemers.is_empty() {
+                    None
+                } else {
+                    Some(witness_set_redeemers)
+                },
             },
             success: true,               // TODO
             auxiliary_data: None.into(), // TODO


### PR DESCRIPTION
Babbage allowed for empty redeemer arrays in the witness set, but Conway does not. If there are no redeemers, field `5` should not be included. This PR changes the logic to only include redeemers when the set of redeemers is non-empty.