### PR TITLE
feat(math): Replace math library - malachite -> dashu

### DIFF
--- a/pallas-math/Cargo.toml
+++ b/pallas-math/Cargo.toml
@@ -12,8 +12,8 @@ authors = ["Andrew Westberg <andrewwestberg@gmail.com>"]
 exclude = ["tests/data/*"]
 
 [dependencies]
-malachite = "0.4.16"
-malachite-base = "0.4.16"
+dashu-int = "0.4.1"
+dashu-base = "0.4.1"
 regex = "1.10.5"
 thiserror = "1.0.61"
 

--- a/pallas-math/src/lib.rs
+++ b/pallas-math/src/lib.rs
@@ -1,2 +1,2 @@
 pub mod math;
-pub mod math_malachite;
+pub mod math_dashu;

--- a/pallas-math/src/math.rs
+++ b/pallas-math/src/math.rs
@@ -7,7 +7,7 @@ use std::ops::{Div, Mul, Neg, Sub};
 use std::sync::LazyLock;
 use thiserror::Error;
 
-pub type FixedDecimal = crate::math_malachite::Decimal;
+pub type FixedDecimal = crate::math_dashu::Decimal;
 
 pub static ZERO: LazyLock<FixedDecimal> = LazyLock::new(|| FixedDecimal::from(0u64));
 pub static MINUS_ONE: LazyLock<FixedDecimal> = LazyLock::new(|| FixedDecimal::from(-1i64));
@@ -95,7 +95,7 @@ pub struct ExpCmpOrdering {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use malachite_base::num::arithmetic::traits::Abs;
+    use dashu_base::Abs;
     use proptest::prelude::Strategy;
     use proptest::proptest;
     use std::fs::File;


### PR DESCRIPTION
Malachite has a bad license for our open-source project. 

https://github.com/mhogrefe/malachite/issues/52#issuecomment-2406980210

This replaces our bigint implementation with dashu that has a nicer license. It's not quite as fast, but it will work for now. The fastest would be gmp or Rug based on gmp, but that relies on native code that doesn't compile on windows.

We need to ensure we maintain windows compatibility for the Amaru project and the possibility of full-node wallets.