### PR TITLE
fix(network): correct PoolDistr and update ProtocolParam

### DIFF
--- a/examples/n2c-miniprotocols/src/main.rs
+++ b/examples/n2c-miniprotocols/src/main.rs
@@ -83,8 +83,8 @@ async fn do_localstate_query(client: &mut NodeClient) {
 
 async fn do_chainsync(client: &mut NodeClient) {
     let known_points = vec![Point::Specific(
-        43847831u64,
-        hex::decode("15b9eeee849dd6386d3770b0745e0450190f7560e5159b1b3ab13b14b2684a45").unwrap(),
+        77110778u64,
+        hex::decode("18e6eeaa592c42113280ba47a0829355e6bed1c9ce67cce4be502d6031d0679a").unwrap(),
     )];
 
     let (point, _) = client

--- a/examples/n2c-miniprotocols/src/main.rs
+++ b/examples/n2c-miniprotocols/src/main.rs
@@ -14,7 +14,6 @@ use pallas::{
     crypto::hash::Hash,
 };
 use tracing::info;
-use hex::FromHex;
 
 use hex::FromHex;
 

--- a/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
@@ -111,6 +111,7 @@ pub type PositiveInterval = RationalNumber;
 
 pub type ProtocolVersionMajor = u64;
 pub type ProtocolVersionMinor = u64;
+pub type ProtocolVersion = (ProtocolVersionMajor, ProtocolVersionMinor);
 
 pub type CostModel = Vec<i64>;
 
@@ -169,26 +170,24 @@ pub struct ProtocolParam {
     #[n(11)]
     pub treasury_growth_rate: Option<UnitInterval>,
     #[n(12)]
-    pub protocol_version_major: Option<ProtocolVersionMajor>,
+    pub protocol_version: Option<ProtocolVersion>,
     #[n(13)]
-    pub protocol_version_minor: Option<ProtocolVersionMinor>,
-    #[n(14)]
     pub min_pool_cost: Option<Coin>,
-    #[n(15)]
+    #[n(14)]
     pub ada_per_utxo_byte: Option<Coin>,
-    #[n(16)]
+    #[n(15)]
     pub cost_models_for_script_languages: Option<CostMdls>,
-    #[n(17)]
+    #[n(16)]
     pub execution_costs: Option<ExUnitPrices>,
-    #[n(18)]
+    #[n(17)]
     pub max_tx_ex_units: Option<ExUnits>,
-    #[n(19)]
+    #[n(18)]
     pub max_block_ex_units: Option<ExUnits>,
-    #[n(20)]
+    #[n(19)]
     pub max_value_size: Option<u32>,
-    #[n(21)]
+    #[n(20)]
     pub collateral_percentage: Option<u32>,
-    #[n(22)]
+    #[n(21)]
     pub max_collateral_inputs: Option<u32>,
 }
 
@@ -201,19 +200,21 @@ pub struct StakeDistribution {
 #[derive(Debug, Encode, Decode, PartialEq, Clone)]
 pub struct Pool {
     #[n(0)]
-    pub stakes: Fraction,
+    pub stakes: RationalNumber,
 
     #[n(1)]
     pub hashes: Bytes,
 }
 
+/// Type used at [GenesisConfig], which is a fraction that is CBOR-encoded
+/// as an untagged array.
 #[derive(Debug, Encode, Decode, PartialEq, Clone)]
 pub struct Fraction {
     #[n(0)]
     pub num: u64,
 
     #[n(1)]
-    pub dem: u64,
+    pub den: u64,
 }
 
 pub type Addr = Bytes;
@@ -316,7 +317,7 @@ pub struct Stakes {
 }
 
 #[derive(Debug, Encode, Decode, PartialEq)]
-pub struct Genesis {
+pub struct GenesisConfig {
     #[n(0)]
     pub system_start: SystemStart,
 
@@ -469,7 +470,7 @@ pub async fn get_cbor(
 pub async fn get_genesis_config(
     client: &mut Client,
     era: u16,
-) -> Result<Vec<Genesis>, ClientError> {
+) -> Result<Vec<GenesisConfig>, ClientError> {
     let query = BlockQuery::GetGenesisConfig;
     let query = LedgerQuery::BlockQuery(era, query);
     let query = Request::LedgerQuery(query);

--- a/pallas-network/tests/protocols.rs
+++ b/pallas-network/tests/protocols.rs
@@ -10,8 +10,8 @@ use pallas_network::miniprotocols::blockfetch::BlockRequest;
 use pallas_network::miniprotocols::chainsync::{ClientRequest, HeaderContent, Tip};
 use pallas_network::miniprotocols::handshake::n2n::VersionData;
 use pallas_network::miniprotocols::localstate::queries_v16::{
-    Addr, Addrs, ChainBlockNumber, Fraction, Genesis, Snapshots, Stakes, SystemStart, UnitInterval,
-    Value,
+    Addr, Addrs, ChainBlockNumber, Fraction, GenesisConfig, Snapshots, Stakes,
+    SystemStart, UnitInterval, Value, RationalNumber,
 };
 use pallas_network::miniprotocols::localstate::ClientQueryRequest;
 use pallas_network::miniprotocols::txsubmission::{EraTxBody, TxIdAndSize};
@@ -548,9 +548,9 @@ pub async fn local_state_query_server_and_client_happy_path() {
             );
             assert_eq!(*server.statequery().state(), localstate::State::Querying);
 
-            let fraction = Fraction { num: 10, dem: 20 };
+            let rational = RationalNumber { numerator: 10, denominator: 20 };
             let pool = localstate::queries_v16::Pool {
-                stakes: fraction.clone(),
+                stakes: rational.clone(),
                 hashes: b"pool1qv4qgv62s3ha74p0643nexee9zvcdydcyahqqnavhj90zheuykz"
                     .to_vec()
                     .into(),
@@ -667,8 +667,7 @@ pub async fn local_state_query_server_and_client_happy_path() {
                     numerator: 3,
                     denominator: 1000000,
                 }),
-                protocol_version_major: Some(5),
-                protocol_version_minor: Some(0),
+                protocol_version: Some((5,0)),
                 min_pool_cost: Some(AnyUInt::U32(340000000)),
                 ada_per_utxo_byte: Some(AnyUInt::U16(44)),
                 cost_models_for_script_languages: None,
@@ -745,7 +744,7 @@ pub async fn local_state_query_server_and_client_happy_path() {
 
             assert_eq!(*server.statequery().state(), localstate::State::Querying);
 
-            let genesis = vec![Genesis {
+            let genesis = vec![GenesisConfig {
                 system_start: SystemStart {
                     year: 2021,
                     day_of_year: 150,
@@ -753,7 +752,7 @@ pub async fn local_state_query_server_and_client_happy_path() {
                 },
                 network_magic: 42,
                 network_id: 42,
-                active_slots_coefficient: Fraction { num: 6, dem: 10 },
+                active_slots_coefficient: Fraction { num: 6, den: 10 },
                 security_param: 2160,
                 epoch_length: 432000,
                 slots_per_kes_period: 129600,
@@ -873,9 +872,9 @@ pub async fn local_state_query_server_and_client_happy_path() {
             .into_decode()
             .unwrap();
 
-        let fraction = Fraction { num: 10, dem: 20 };
+        let rational = RationalNumber { numerator: 10, denominator: 20 };
         let pool = localstate::queries_v16::Pool {
-            stakes: fraction.clone(),
+            stakes: rational.clone(),
             hashes: b"pool1qv4qgv62s3ha74p0643nexee9zvcdydcyahqqnavhj90zheuykz"
                 .to_vec()
                 .into(),
@@ -987,8 +986,7 @@ pub async fn local_state_query_server_and_client_happy_path() {
                     numerator: 3,
                     denominator: 1000000,
                 }),
-                protocol_version_major: Some(5),
-                protocol_version_minor: Some(0),
+                protocol_version: Some((5,0)),
                 min_pool_cost: Some(AnyUInt::U32(340000000)),
                 ada_per_utxo_byte: Some(AnyUInt::U16(44)),
                 cost_models_for_script_languages: None,
@@ -1050,7 +1048,7 @@ pub async fn local_state_query_server_and_client_happy_path() {
 
         client.statequery().send_query(request).await.unwrap();
 
-        let result: Vec<Genesis> = client
+        let result: Vec<GenesisConfig> = client
             .statequery()
             .recv_while_querying()
             .await
@@ -1058,7 +1056,7 @@ pub async fn local_state_query_server_and_client_happy_path() {
             .into_decode()
             .unwrap();
 
-        let genesis = vec![Genesis {
+        let genesis = vec![GenesisConfig {
             system_start: SystemStart {
                 year: 2021,
                 day_of_year: 150,
@@ -1066,7 +1064,7 @@ pub async fn local_state_query_server_and_client_happy_path() {
             },
             network_magic: 42,
             network_id: 42,
-            active_slots_coefficient: Fraction { num: 6, dem: 10 },
+            active_slots_coefficient: Fraction { num: 6, den: 10 },
             security_param: 2160,
             epoch_length: 432000,
             slots_per_kes_period: 129600,


### PR DESCRIPTION
A field of the `Pool` struct (corresponding to the node's `PoolDistr`) was a naively encoded rational number `Fraction`; this one is indeed needed in the genesis config struct, which I renamed from `Genesis` to the more explicit `GenesisConfig`. 

In the case of `ProtocolParam`, the `ProtocolVersion` is now a tuple `(major, minor)`.

Both corrections have an impact on the `examples/n2c-miniprotocols` folder; two broken examples there now run smoothly. In that folder, I moved the initial `Point` of the block-fetching performed by `do_chainsync` to a more recent moment in order to be able to witness the reaching of the chain tip.

This solves #496.