### PR TITLE
feat(network): implement `GetFilteredDelegationsAndRewardAccounts`

### DIFF
--- a/examples/n2c-miniprotocols/src/main.rs
+++ b/examples/n2c-miniprotocols/src/main.rs
@@ -33,13 +33,19 @@ async fn do_localstate_query(client: &mut NodeClient) {
     let era = queries_v16::get_current_era(client).await.unwrap();
     info!("result: {:?}", era);
 
-    // Getting delegation and rewards for preprod stake address
-    // `stake_test1uqfp3atrunssjk8a4w7lk3ct97wnscs4wc7v3ynnmx7ll7s2ea9p2`
+    // Getting delegation and rewards for preprod stake addresses:
+    let mut addrs = BTreeSet::new();
+    // 1. `stake_test1uqfp3atrunssjk8a4w7lk3ct97wnscs4wc7v3ynnmx7ll7s2ea9p2`
     let addr: Addr = <[u8; 28]>::from_hex(
         "1218F563E4E10958FDABBDFB470B2F9D386215763CC89273D9BDFFFA"
     ).unwrap().to_vec().into();
-    let mut addrs = BTreeSet::new();
     addrs.insert(StakeAddr::from((0x00, addr)));
+    // 2. `stake_test1uq2pnumhfrnnse0t3uwj4n0lhz58ehfhkdhr64ylptjhq9cyney6d`
+    let addr: Addr = <[u8; 28]>::from_hex(
+        "1419F37748E73865EB8F1D2ACDFFB8A87CDD37B36E3D549F0AE57017"
+    ).unwrap().to_vec().into();
+    addrs.insert(StakeAddr::from((0x00, addr)));
+
     let result = queries_v16::get_filtered_delegations_rewards(client, era, addrs)
         .await
         .unwrap();

--- a/examples/n2c-miniprotocols/src/main.rs
+++ b/examples/n2c-miniprotocols/src/main.rs
@@ -7,12 +7,14 @@ use pallas::{
         facades::NodeClient,
         miniprotocols::{
             chainsync,
-            localstate::queries_v16::{self, Addr, Addrs},
+            localstate::queries_v16::{self, Addr, Addrs, StakeAddr},
             Point, PRE_PRODUCTION_MAGIC,
         },
     },
 };
 use tracing::info;
+
+use hex::FromHex;
 
 async fn do_localstate_query(client: &mut NodeClient) {
     let client = client.statequery();
@@ -30,6 +32,20 @@ async fn do_localstate_query(client: &mut NodeClient) {
 
     let era = queries_v16::get_current_era(client).await.unwrap();
     info!("result: {:?}", era);
+
+    // Getting rewards and delegation for a stake address
+    // let addr = "stake_test1uqfp3atrunssjk8a4w7lk3ct97wnscs4wc7v3ynnmx7ll7s2ea9p2".to_string();
+    // let addr: Address = Address::from_bech32(&addr).unwrap();
+    // let addr: Addr = addr.to_vec().into();
+    let addr: Addr = <[u8; 28]>::from_hex(
+        "1218F563E4E10958FDABBDFB470B2F9D386215763CC89273D9BDFFFA"
+    ).unwrap().to_vec().into();
+    let mut addrs = BTreeSet::new();
+    addrs.insert(StakeAddr::from((0x00, addr)));
+    let result = queries_v16::get_filtered_delegations_rewards(client, era, addrs)
+        .await
+        .unwrap();
+    info!("result: {:?}", result);
 
     let result = queries_v16::get_block_epoch_number(client, era)
         .await

--- a/examples/n2c-miniprotocols/src/main.rs
+++ b/examples/n2c-miniprotocols/src/main.rs
@@ -33,10 +33,8 @@ async fn do_localstate_query(client: &mut NodeClient) {
     let era = queries_v16::get_current_era(client).await.unwrap();
     info!("result: {:?}", era);
 
-    // Getting rewards and delegation for a stake address
-    // let addr = "stake_test1uqfp3atrunssjk8a4w7lk3ct97wnscs4wc7v3ynnmx7ll7s2ea9p2".to_string();
-    // let addr: Address = Address::from_bech32(&addr).unwrap();
-    // let addr: Addr = addr.to_vec().into();
+    // Getting delegation and rewards for preprod stake address
+    // `stake_test1uqfp3atrunssjk8a4w7lk3ct97wnscs4wc7v3ynnmx7ll7s2ea9p2`
     let addr: Addr = <[u8; 28]>::from_hex(
         "1218F563E4E10958FDABBDFB470B2F9D386215763CC89273D9BDFFFA"
     ).unwrap().to_vec().into();

--- a/pallas-network/src/miniprotocols/localstate/client.rs
+++ b/pallas-network/src/miniprotocols/localstate/client.rs
@@ -202,6 +202,7 @@ impl GenericClient {
     {
         let request = AnyCbor::from_encode(request);
         let response = self.query_any(request).await?;
+
         response.into_decode().map_err(ClientError::InvalidCbor)
     }
 }

--- a/pallas-network/src/miniprotocols/localstate/queries_v16/codec.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/codec.rs
@@ -369,3 +369,29 @@ impl<C> minicbor::encode::Encode<C> for TransactionOutput {
         Ok(())
     }
 }
+
+impl<'b, C> minicbor::decode::Decode<'b, C> for FilteredDelegsRewards {
+    fn decode(d: &mut minicbor::Decoder<'b>, ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
+        d.array()?;
+        d.array()?;
+        Ok(FilteredDelegsRewards {
+            delegs: d.decode_with(ctx)?,
+            rewards: d.decode_with(ctx)?,
+        })
+    }
+}
+
+impl<C> minicbor::encode::Encode<C> for FilteredDelegsRewards {
+    fn encode<W: minicbor::encode::Write>(
+        &self,
+        e: &mut minicbor::Encoder<W>,
+        ctx: &mut C,
+    ) -> Result<(), minicbor::encode::Error<W::Error>> {
+        e.array(1)?;
+        e.array(2)?;
+        e.encode_with(self.delegs.clone(), ctx)?;
+        e.encode_with(self.rewards.clone(), ctx)?;
+
+        Ok(())
+    }
+}

--- a/pallas-network/src/miniprotocols/localstate/queries_v16/codec.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/codec.rs
@@ -139,7 +139,7 @@ impl<'b> Decode<'b, ()> for BlockQuery {
             // 7 => Ok(Self::GetUTxOWhole),
             // 8 => Ok(Self::DebugEpochState),
             9 => Ok(Self::GetCBOR(d.decode()?)),
-            // 10 => Ok(Self::GetFilteredDelegationsAndRewardAccounts(())),
+            10 => Ok(Self::GetFilteredDelegationsAndRewardAccounts(d.decode()?)),
             11 => Ok(Self::GetGenesisConfig),
             // 12 => Ok(Self::DebugNewEpochState),
             13 => Ok(Self::DebugChainDepState),

--- a/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
@@ -238,11 +238,10 @@ pub type StakeAddrs = BTreeSet<StakeAddr>;
 pub type Delegations = KeyValuePairs<StakeAddr, Bytes>;
 pub type RewardAccounts = KeyValuePairs<StakeAddr, u64>;
 
-// TODO: Destruct the tuple, define proper encoding.
-#[derive(Debug, Encode, Decode, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct FilteredDelegsRewards {
-    #[n(0)]
-    pub delegs_rewards: (Delegations, RewardAccounts),
+    pub delegs: Delegations,
+    pub rewards: RewardAccounts,
 }
 
 pub type Pools = BTreeSet<Bytes>;

--- a/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
@@ -32,7 +32,7 @@ pub enum BlockQuery {
     GetUTxOWhole,
     DebugEpochState,
     GetCBOR(Box<BlockQuery>),
-    GetFilteredDelegationsAndRewardAccounts(AnyCbor),
+    GetFilteredDelegationsAndRewardAccounts(StakeAddrs),
     GetGenesisConfig,
     DebugNewEpochState,
     DebugChainDepState,
@@ -219,6 +219,31 @@ pub struct Fraction {
 pub type Addr = Bytes;
 
 pub type Addrs = Vec<Addr>;
+
+#[derive(Debug, Encode, Decode, PartialEq, Eq, Clone, PartialOrd, Ord)]
+pub struct StakeAddr {
+    #[n(0)]
+    addr_type: u8,
+    #[n(1)]
+    payload: Addr,
+}
+
+impl From<(u8, Bytes)> for StakeAddr {
+    fn from((addr_type, payload): (u8, Bytes)) -> Self {
+        Self { addr_type, payload }
+    }
+}
+
+pub type StakeAddrs = BTreeSet<StakeAddr>;
+pub type Delegations = KeyValuePairs<StakeAddr, Bytes>;
+pub type RewardAccounts = KeyValuePairs<StakeAddr, u64>;
+
+// TODO: Destruct the tuple, define proper encoding.
+#[derive(Debug, Encode, Decode, PartialEq, Clone)]
+pub struct FilteredDelegsRewards {
+    #[n(0)]
+    pub delegs_rewards: (Delegations, RewardAccounts),
+}
 
 pub type Pools = BTreeSet<Bytes>;
 
@@ -471,6 +496,20 @@ pub async fn get_genesis_config(
     era: u16,
 ) -> Result<Vec<Genesis>, ClientError> {
     let query = BlockQuery::GetGenesisConfig;
+    let query = LedgerQuery::BlockQuery(era, query);
+    let query = Request::LedgerQuery(query);
+    let result = client.query(query).await?;
+
+    Ok(result)
+}
+
+/// Get the delegations and rewards for the given stake addresses.
+pub async fn get_filtered_delegations_rewards(
+    client: &mut Client,
+    era: u16,
+    addrs: StakeAddrs,
+) -> Result<FilteredDelegsRewards, ClientError> {
+    let query = BlockQuery::GetFilteredDelegationsAndRewardAccounts(addrs);
     let query = LedgerQuery::BlockQuery(era, query);
     let query = Request::LedgerQuery(query);
     let result = client.query(query).await?;


### PR DESCRIPTION
This PR implements the named query, along with its corresponding unit-test at `protocols.rs` and integration one at `examples/n2c-miniprotocols`.

I took the opportunity to streamline the imports at the test file, and to provide more informative panics. This comprises modifications through many LoC, but the main ones lie in two blocks starting at lines 790 and 1127, resp, of `protocols.rs`. We think that it should be reasonable to re-engineer this file, but further modifications will be part of another PR.