### PR TITLE
making changes to tx builder model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
-- **txbuilder:** use conway types for decode fragments during `add_signature` ([#xxx](url here))
-
 <a name="v0.30.1"></a>
 ## [v0.30.1] - 2024-08-25
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+- **txbuilder:** use conway types for decode fragments during `add_signature` ([#xxx](url here))
 
 <a name="v0.30.1"></a>
 ## [v0.30.1] - 2024-08-25

--- a/pallas-txbuilder/src/conway.rs
+++ b/pallas-txbuilder/src/conway.rs
@@ -230,7 +230,8 @@ impl BuildConway for StagingTransaction {
                 language_view,
             };
 
-            dbg!(&dta);
+            // if we need to debug then uncomment
+            // dbg!(&dta);
             dta.hash()
         });
 

--- a/pallas-txbuilder/src/conway.rs
+++ b/pallas-txbuilder/src/conway.rs
@@ -230,8 +230,6 @@ impl BuildConway for StagingTransaction {
                 language_view,
             };
 
-            // if we need to debug then uncomment
-            // dbg!(&dta);
             dta.hash()
         });
 

--- a/pallas-txbuilder/src/transaction/model.rs
+++ b/pallas-txbuilder/src/transaction/model.rs
@@ -3,7 +3,7 @@ use pallas_crypto::{
     hash::{Hash, Hasher},
     key::ed25519,
 };
-use pallas_primitives::{babbage, conway, Fragment, NonEmptySet};
+use pallas_primitives::{conway, Fragment, NonEmptySet};
 use pallas_wallet::PrivateKey;
 
 use std::{collections::HashMap, ops::Deref};
@@ -644,7 +644,7 @@ impl BuiltTransaction {
                     .map(|x| x.to_vec())
                     .unwrap_or_default();
 
-                vkey_witnesses.push(babbage::VKeyWitness {
+                vkey_witnesses.push(conway::VKeyWitness {
                     vkey: Vec::from(pubkey.as_ref()).into(),
                     signature: Vec::from(signature.as_ref()).into(),
                 });
@@ -682,17 +682,17 @@ impl BuiltTransaction {
                 self.signatures = Some(new_sigs);
 
                 // TODO: chance for serialisation round trip issues?
-                let mut tx = babbage::Tx::decode_fragment(&self.tx_bytes.0)
+                let mut tx = conway::Tx::decode_fragment(&self.tx_bytes.0)
                     .map_err(|_| TxBuilderError::CorruptedTxBytes)?;
 
-                let mut vkey_witnesses = tx.transaction_witness_set.vkeywitness.unwrap_or_default();
+                let mut vkey_witnesses  = tx.transaction_witness_set.vkeywitness.unwrap().to_vec();
 
-                vkey_witnesses.push(babbage::VKeyWitness {
+                vkey_witnesses.push(conway::VKeyWitness {
                     vkey: Vec::from(pub_key.as_ref()).into(),
                     signature: Vec::from(signature.as_ref()).into(),
                 });
 
-                tx.transaction_witness_set.vkeywitness = Some(vkey_witnesses);
+                tx.transaction_witness_set.vkeywitness = Some(NonEmptySet::from_vec(vkey_witnesses).unwrap());
 
                 self.tx_bytes = tx.encode_fragment().unwrap().into();
             }
@@ -719,14 +719,14 @@ impl BuiltTransaction {
                 self.signatures = Some(new_sigs);
 
                 // TODO: chance for serialisation round trip issues?
-                let mut tx = babbage::Tx::decode_fragment(&self.tx_bytes.0)
+                let mut tx = conway::Tx::decode_fragment(&self.tx_bytes.0)
                     .map_err(|_| TxBuilderError::CorruptedTxBytes)?;
 
-                let mut vkey_witnesses = tx.transaction_witness_set.vkeywitness.unwrap_or_default();
+                let mut vkey_witnesses = tx.transaction_witness_set.vkeywitness.unwrap().to_vec();
 
                 vkey_witnesses.retain(|x| *x.vkey != pk.0.to_vec());
 
-                tx.transaction_witness_set.vkeywitness = Some(vkey_witnesses);
+                tx.transaction_witness_set.vkeywitness = Some(NonEmptySet::from_vec(vkey_witnesses).unwrap());
 
                 self.tx_bytes = tx.encode_fragment().unwrap().into();
             }

--- a/pallas-txbuilder/src/transaction/model.rs
+++ b/pallas-txbuilder/src/transaction/model.rs
@@ -726,7 +726,11 @@ impl BuiltTransaction {
                 let mut tx = conway::Tx::decode_fragment(&self.tx_bytes.0)
                     .map_err(|_| TxBuilderError::CorruptedTxBytes)?;
 
-                let mut vkey_witnesses = tx.transaction_witness_set.vkeywitness.unwrap().to_vec();
+                    let mut vkey_witnesses = tx
+                    .transaction_witness_set
+                    .vkeywitness
+                    .map(|x| x.to_vec())
+                    .unwrap_or_default();
 
                 vkey_witnesses.retain(|x| *x.vkey != pk.0.to_vec());
 


### PR DESCRIPTION
Adding a signature to a conway era transaction causes a `called `Result::unwrap()` on an `Err` value: CorruptedTxBytes` error.

```rust
let signed_tx_cbor = tx
    // called `Result::unwrap()` on an `Err` value: CorruptedTxBytes
    .add_signature(witness_public_key, witness_vector)
    .unwrap()
    .tx_bytes;
```

This error comes from line 685 in model.rs of the txbuilder.

If you change the `babbage` call into a `conway` call then it does not throw the error. 

This PR changes the `babbage` to `conway` on all the things. Also, it adjusts the witness building as pushing to a set is not possible and requires coverting back to a vector then back to an empty set.

This PR passes all current tests. There is no open issue on this topic as it brought up in discord.