### PR TITLE
chore: update utxorpc-spec version `0.14.0` and update redeemer mapper

### DIFF
--- a/pallas-utxorpc/Cargo.toml
+++ b/pallas-utxorpc/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["Santiago Carmuega <santiago@carmuega.me>"]
 
 [dependencies]
 # utxorpc-spec = { path = "../../../utxorpc/spec/gen/rust" }
-utxorpc-spec = { version = "0.11.0" }
+utxorpc-spec = { version = "0.14.0" }
 
 pallas-traverse = { version = "=0.31.0", path = "../pallas-traverse" }
 pallas-primitives = { version = "=0.31.0", path = "../pallas-primitives" }


### PR DESCRIPTION
This updates utxorpc-spec version dependency to version `0.14.0`.
Also update the redeemer mapper function according to the new spec.
