### PR TITLE
chore(utxorpc): update spec to version 0.15.0 and add new protocol params to params mapper

### DIFF
--- a/pallas-utxorpc/Cargo.toml
+++ b/pallas-utxorpc/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["Santiago Carmuega <santiago@carmuega.me>"]
 
 [dependencies]
 # utxorpc-spec = { path = "../../../utxorpc/spec/gen/rust" }
-utxorpc-spec = { version = "0.14.0" }
+utxorpc-spec = { version = "0.15.0" }
 
 pallas-traverse = { version = "=0.31.0", path = "../pallas-traverse" }
 pallas-primitives = { version = "=0.31.0", path = "../pallas-primitives" }

--- a/pallas-utxorpc/src/params.rs
+++ b/pallas-utxorpc/src/params.rs
@@ -1,4 +1,5 @@
 use pallas_applying::MultiEraProtocolParameters;
+use pallas_primitives::UnitInterval;
 use utxorpc_spec::utxorpc::v1alpha::cardano as u5c;
 
 use crate::{LedgerContext, Mapper};
@@ -219,6 +220,35 @@ impl<C: LedgerContext> Mapper<C> {
                     numerator: params.minfee_refscript_cost_per_byte.numerator as i32,
                     denominator: params.minfee_refscript_cost_per_byte.denominator as u32,
                 }),
+                pool_voting_thresholds: Some(u5c::VotingThresholds{
+                    thresholds: vec![
+                        to_u5c_rational(&params.pool_voting_thresholds.motion_no_confidence),
+                        to_u5c_rational(&params.pool_voting_thresholds.committee_normal),
+                        to_u5c_rational(&params.pool_voting_thresholds.committee_no_confidence),
+                        to_u5c_rational(&params.pool_voting_thresholds.hard_fork_initiation),
+                        to_u5c_rational(&params.pool_voting_thresholds.security_voting_threshold),
+                    ]
+                }),
+                drep_voting_thresholds: Some(u5c::VotingThresholds{
+                    thresholds: vec![
+                        to_u5c_rational(&params.drep_voting_thresholds.motion_no_confidence),
+                        to_u5c_rational(&params.drep_voting_thresholds.committee_normal),
+                        to_u5c_rational(&params.drep_voting_thresholds.committee_no_confidence),
+                        to_u5c_rational(&params.drep_voting_thresholds.update_constitution),
+                        to_u5c_rational(&params.drep_voting_thresholds.hard_fork_initiation),
+                        to_u5c_rational(&params.drep_voting_thresholds.pp_network_group),
+                        to_u5c_rational(&params.drep_voting_thresholds.pp_economic_group),
+                        to_u5c_rational(&params.drep_voting_thresholds.pp_technical_group),
+                        to_u5c_rational(&params.drep_voting_thresholds.pp_governance_group),
+                        to_u5c_rational(&params.drep_voting_thresholds.treasury_withdrawal),
+                    ]
+                }),
+                min_committee_size: params.min_committee_size as u32,
+                committee_term_limit: params.committee_term_limit.into(),
+                governance_action_validity_period: params.governance_action_validity_period.into(),
+                governance_action_deposit: params.governance_action_deposit.into(),
+                drep_deposit: params.drep_deposit.into(),
+                drep_inactivity_period: params.drep_inactivity_period.into(),
                 cost_models: u5c::CostModels {
                     plutus_v1: params
                         .cost_models_for_script_languages
@@ -238,5 +268,12 @@ impl<C: LedgerContext> Mapper<C> {
             },
             _ => unimplemented!(),
         }
+    }
+}
+
+fn to_u5c_rational(interval: &UnitInterval) -> u5c::RationalNumber {
+    u5c::RationalNumber {
+        numerator: interval.numerator as i32,
+        denominator: interval.denominator as u32,
     }
 }

--- a/pallas-utxorpc/src/params.rs
+++ b/pallas-utxorpc/src/params.rs
@@ -222,25 +222,70 @@ impl<C: LedgerContext> Mapper<C> {
                 }),
                 pool_voting_thresholds: Some(u5c::VotingThresholds{
                     thresholds: vec![
-                        to_u5c_rational(&params.pool_voting_thresholds.motion_no_confidence),
-                        to_u5c_rational(&params.pool_voting_thresholds.committee_normal),
-                        to_u5c_rational(&params.pool_voting_thresholds.committee_no_confidence),
-                        to_u5c_rational(&params.pool_voting_thresholds.hard_fork_initiation),
-                        to_u5c_rational(&params.pool_voting_thresholds.security_voting_threshold),
+                        u5c::RationalNumber {
+                            numerator: params.pool_voting_thresholds.motion_no_confidence.numerator as i32,
+                            denominator: params.pool_voting_thresholds.motion_no_confidence.denominator as u32,
+                        },
+                        u5c::RationalNumber {
+                            numerator: params.pool_voting_thresholds.committee_normal.numerator as i32,
+                            denominator: params.pool_voting_thresholds.committee_normal.denominator as u32,
+                        },
+                        u5c::RationalNumber {
+                            numerator: params.pool_voting_thresholds.committee_no_confidence.numerator as i32,
+                            denominator: params.pool_voting_thresholds.committee_no_confidence.denominator as u32,
+                        },
+                        u5c::RationalNumber {
+                            numerator: params.pool_voting_thresholds.hard_fork_initiation.numerator as i32,
+                            denominator: params.pool_voting_thresholds.hard_fork_initiation.denominator as u32,
+                        },
+                        u5c::RationalNumber {
+                            numerator: params.pool_voting_thresholds.security_voting_threshold.numerator as i32,
+                            denominator: params.pool_voting_thresholds.security_voting_threshold.denominator as u32,
+                        },
                     ]
                 }),
                 drep_voting_thresholds: Some(u5c::VotingThresholds{
                     thresholds: vec![
-                        to_u5c_rational(&params.drep_voting_thresholds.motion_no_confidence),
-                        to_u5c_rational(&params.drep_voting_thresholds.committee_normal),
-                        to_u5c_rational(&params.drep_voting_thresholds.committee_no_confidence),
-                        to_u5c_rational(&params.drep_voting_thresholds.update_constitution),
-                        to_u5c_rational(&params.drep_voting_thresholds.hard_fork_initiation),
-                        to_u5c_rational(&params.drep_voting_thresholds.pp_network_group),
-                        to_u5c_rational(&params.drep_voting_thresholds.pp_economic_group),
-                        to_u5c_rational(&params.drep_voting_thresholds.pp_technical_group),
-                        to_u5c_rational(&params.drep_voting_thresholds.pp_governance_group),
-                        to_u5c_rational(&params.drep_voting_thresholds.treasury_withdrawal),
+                        u5c::RationalNumber {
+                            numerator: params.drep_voting_thresholds.motion_no_confidence.numerator as i32,
+                            denominator: params.drep_voting_thresholds.motion_no_confidence.denominator as u32,
+                        },
+                        u5c::RationalNumber {
+                            numerator: params.drep_voting_thresholds.committee_normal.numerator as i32,
+                            denominator: params.drep_voting_thresholds.committee_normal.denominator as u32,
+                        },
+                        u5c::RationalNumber {
+                            numerator: params.drep_voting_thresholds.committee_no_confidence.numerator as i32,
+                            denominator: params.drep_voting_thresholds.committee_no_confidence.denominator as u32,
+                        },
+                        u5c::RationalNumber {
+                            numerator: params.drep_voting_thresholds.update_constitution.numerator as i32,
+                            denominator: params.drep_voting_thresholds.update_constitution.denominator as u32,
+                        },
+                        u5c::RationalNumber {
+                            numerator: params.drep_voting_thresholds.hard_fork_initiation.numerator as i32,
+                            denominator: params.drep_voting_thresholds.hard_fork_initiation.denominator as u32,
+                        },
+                        u5c::RationalNumber {
+                            numerator: params.drep_voting_thresholds.pp_network_group.numerator as i32,
+                            denominator: params.drep_voting_thresholds.pp_network_group.denominator as u32,
+                        },
+                        u5c::RationalNumber {
+                            numerator: params.drep_voting_thresholds.pp_economic_group.numerator as i32,
+                            denominator: params.drep_voting_thresholds.pp_economic_group.denominator as u32,
+                        },
+                        u5c::RationalNumber {
+                            numerator: params.drep_voting_thresholds.pp_technical_group.numerator as i32,
+                            denominator: params.drep_voting_thresholds.pp_technical_group.denominator as u32,
+                        },
+                        u5c::RationalNumber {
+                            numerator: params.drep_voting_thresholds.pp_governance_group.numerator as i32,
+                            denominator: params.drep_voting_thresholds.pp_governance_group.denominator as u32,
+                        },
+                        u5c::RationalNumber {
+                            numerator: params.drep_voting_thresholds.treasury_withdrawal.numerator as i32,
+                            denominator: params.drep_voting_thresholds.treasury_withdrawal.denominator as u32,
+                        },
                     ]
                 }),
                 min_committee_size: params.min_committee_size as u32,
@@ -268,12 +313,5 @@ impl<C: LedgerContext> Mapper<C> {
             },
             _ => unimplemented!(),
         }
-    }
-}
-
-fn to_u5c_rational(interval: &UnitInterval) -> u5c::RationalNumber {
-    u5c::RationalNumber {
-        numerator: interval.numerator as i32,
-        denominator: interval.denominator as u32,
     }
 }

--- a/pallas-utxorpc/src/params.rs
+++ b/pallas-utxorpc/src/params.rs
@@ -215,6 +215,10 @@ impl<C: LedgerContext> Mapper<C> {
                     memory: params.max_block_ex_units.mem,
                     steps: params.max_block_ex_units.steps,
                 }),
+                min_fee_script_ref_cost_per_byte: Some(u5c::RationalNumber {
+                    numerator: params.minfee_refscript_cost_per_byte.numerator as i32,
+                    denominator: params.minfee_refscript_cost_per_byte.denominator as u32,
+                }),
                 cost_models: u5c::CostModels {
                     plutus_v1: params
                         .cost_models_for_script_languages


### PR DESCRIPTION
This updates the spec dependency version to 0.15.0
This also adds new protocol params to the mapper specifically the min_fee_script_ref_cost_per_byte and the new governance protocol params