### PR TITLE
Fix IntersectNotFound CBOR encoding

### DIFF
--- a/pallas-network/src/miniprotocols/chainsync/codec.rs
+++ b/pallas-network/src/miniprotocols/chainsync/codec.rs
@@ -73,7 +73,7 @@ where
                 Ok(())
             }
             Message::IntersectNotFound(tip) => {
-                e.array(1)?.u16(6)?;
+                e.array(2)?.u16(6)?;
                 e.encode(tip)?;
                 Ok(())
             }


### PR DESCRIPTION
IntersectNotFound carries both a label/tag and the tip of the node; so the size of the array must be of length 2. 

See also: https://github.com/IntersectMBO/ouroboros-network/blob/efb64c78b8eb56027d9af12e3e786c5261ad5bd3/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/ChainSync/Codec.hs#L144