### PR TITLE
Fix Shelley genesis parsing

### DIFF
--- a/test_data/golden-shelley-genesis.json
+++ b/test_data/golden-shelley-genesis.json
@@ -1,0 +1,93 @@
+{
+  "maxKESEvolutions": 28899,
+  "updateQuorum": 16991,
+  "protocolParams": {
+      "extraEntropy": {
+          "tag": "NeutralNonce"
+      },
+      "maxBlockHeaderSize": 17569,
+      "poolDeposit": 0,
+      "minUTxOValue": 0,
+      "minFeeB": 0,
+      "a0": 0.0,
+      "minPoolCost": 0,
+      "rho": 0.0,
+      "tau": 0.0,
+      "nOpt": 100,
+      "protocolVersion": {
+          "minor": 0,
+          "major": 2
+      },
+      "eMax": 0,
+      "keyDeposit": 0,
+      "decentralisationParam": 1.9e-2,
+      "maxTxSize": 2048,
+      "maxBlockBodySize": 239857,
+      "minFeeA": 0
+  },
+  "slotsPerKESPeriod": 8541,
+  "genDelegs": {
+      "38e7c5986a34f334e19b712c0aa525146dab8f0ff889b2ad16894241": {
+          "vrf": "fce31c6f3187531ee4a39aa743c24d22275f415a8895e9cd22c30c8a25cdef0d",
+          "delegate": "e6960dd671ee8d73de1a83d1345b661165dcddeba99623beef2f157a"
+      }
+  },
+  "staking": {
+      "stake": {
+          "83a192dec0e8da2188e520d0c536a69a747cf173a3df16a6daa94d86": "649eda82bf644d34a6925f24ea4c4c36d27e51de1b44ef47e3560be7"
+      },
+      "pools": {
+          "f583a45e4947c102091b96170ef50ef0cf8edb62666193a2163247bb": {
+              "rewardAccount": {
+                  "network": "Testnet",
+                  "credential": {
+                      "keyHash": "4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a"
+                  }
+              },
+              "relays": [
+                  {
+                      "single host address": {
+                          "port": 1234,
+                          "IPv6": "2001:db8:a::123",
+                          "IPv4": "0.0.0.0"
+                      }
+                  },
+                  {
+                      "single host name": {
+                          "port": null,
+                          "dnsName": "cool.domain.com"
+                      }
+                  },
+                  {
+                      "multi host name": {
+                          "dnsName": "cool.domain.com"
+                      }
+                  }
+              ],
+              "vrf": "68f9cfd33ac8f044facc664db5aa1b73c0b0f5435b85e7b520bb2f1a92f02999",
+              "publicKey": "4e130c0bdeb7768edf2e8f85007fd52073e3dc1871f4c47f9dfca92e",
+              "pledge": 1,
+              "cost": 5,
+              "margin": 0.25,
+              "metadata": {
+                  "hash": "31303061627b7d31303061627b7d",
+                  "url": "best.pool.com"
+              },
+              "owners": [
+                  "4e88cc2d27c364aaf90648a87dfb95f8ee103ba67fa1f12f5e86c42a"
+              ]
+          }
+      }
+  },
+  "networkMagic": 4036000900,
+  "maxLovelaceSupply": 71,
+  "systemStart": "2009-02-13T23:13:09Z",
+  "epochLength": 1215,
+  "networkId": "Testnet",
+  "slotLength": 8,
+  "activeSlotsCoeff": 0.259,
+  "securityParam": 120842,
+  "initialFunds": {
+      "00e1bade2ab9465a24fd5eaa4b7388303917338f853a48b11a5fc9964af5ca93fb6516ebde3d150b3e2acb1909532730de33832ffb229cb20d": 12157196
+  }
+}


### PR DESCRIPTION
This fixes the Shelley part of #296

Notably,
- fix the type for `pools`
- fix the type for `initial_funds`

Additionally, this PR adds a new `shelley_utxos` helper function to help unblock this Dolos issue: https://github.com/txpipe/dolos/issues/427

## Background

This PR introduces a new "golden" test, which is taken from the Haskell codebase [here](https://github.com/IntersectMBO/cardano-ledger/blob/ff526dfe6460ae5a6ba398b091d6da52b539b285/eras/shelley/test-suite/test/Golden/ShelleyGenesis)

Notably, you can find the original code for this serialization logic in the Haskell codebase at the following:
- pool parsing [here](https://github.com/IntersectMBO/cardano-ledger/blob/ff526dfe6460ae5a6ba398b091d6da52b539b285/libs/cardano-ledger-core/src/Cardano/Ledger/PoolParams.hs#L231-L243)
- initial funds UTXO parsing [here](https://github.com/IntersectMBO/cardano-ledger/blob/ff526dfe6460ae5a6ba398b091d6da52b539b285/eras/shelley/impl/src/Cardano/Ledger/Shelley/Transition.hs#L447-L455)
