### PR TITLE
feat(network): add is_peer_sharing field to PeerClient and expose VersionData fields

### DIFF
--- a/pallas-network/src/facades.rs
+++ b/pallas-network/src/facades.rs
@@ -106,6 +106,7 @@ pub struct PeerClient {
     pub blockfetch: blockfetch::Client,
     pub txsubmission: txsubmission::Client,
     pub peersharing: peersharing::Client,
+    pub is_peer_sharing: bool,
 }
 
 impl PeerClient {
@@ -154,6 +155,10 @@ impl PeerClient {
             blockfetch: blockfetch::Client::new(bf_channel),
             txsubmission: txsubmission::Client::new(txsub_channel),
             peersharing: peersharing::Client::new(peersharing_channel),
+            is_peer_sharing: match handshake {
+                Confirmation::Accepted(_, data) => data.peer_sharing.unwrap_or(0) != 0,
+                _ => false,
+            },
         };
 
         Ok(client)

--- a/pallas-network/src/facades.rs
+++ b/pallas-network/src/facades.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 use std::path::Path;
 use std::time::Duration;
+use pallas_codec::minicbor;
 use thiserror::Error;
 use tracing::{debug, error};
 
@@ -136,12 +137,14 @@ impl PeerClient {
         let plexer = plexer.spawn();
 
         let versions = handshake::n2n::VersionTable::v7_and_above(magic, peer_sharing);
-
+        let versions_cbor = minicbor::to_vec(&versions).unwrap();
+        println!("versions_cbor: {:?}", hex::encode(versions_cbor));
+        println!("handshaking with versions: {:?}", versions);
         let handshake = handshake
             .handshake(versions)
             .await
             .map_err(Error::HandshakeProtocol)?;
-
+        println!("handshake: {:?}", handshake);
         if let handshake::Confirmation::Rejected(reason) = handshake {
             error!(?reason, "handshake refused");
             return Err(Error::IncompatibleVersion);

--- a/pallas-network/src/miniprotocols/handshake/client.rs
+++ b/pallas-network/src/miniprotocols/handshake/client.rs
@@ -107,7 +107,10 @@ where
             Message::Accept(v, m) => {
                 self.0 = State::Done;
                 debug!("handshake accepted");
-
+                // log v and m
+                println!("handshake accepted");
+                println!("v: {:?}", v);
+                println!("m: {:?}", m);
                 Ok(Confirmation::Accepted(v, m))
             }
             Message::Refuse(r) => {

--- a/pallas-network/src/miniprotocols/handshake/n2n.rs
+++ b/pallas-network/src/miniprotocols/handshake/n2n.rs
@@ -145,10 +145,10 @@ impl VersionTable {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct VersionData {
-    network_magic: u64,
-    initiator_only_diffusion_mode: bool,
-    peer_sharing: Option<u8>,
-    query: Option<bool>,
+    pub network_magic: u64,
+    pub initiator_only_diffusion_mode: bool,
+    pub peer_sharing: Option<u8>,
+    pub query: Option<bool>,
 }
 
 impl VersionData {

--- a/pallas-network/src/miniprotocols/handshake/n2n.rs
+++ b/pallas-network/src/miniprotocols/handshake/n2n.rs
@@ -13,20 +13,21 @@ const PROTOCOL_V12: u64 = 12;
 const PROTOCOL_V13: u64 = 13;
 
 const PEER_SHARING_DISABLED: u8 = 0;
+const PEER_SHARING_ENABLED: u8 = 1;
 
 impl VersionTable {
     #[deprecated(note = "no longer supported by spec")]
-    pub fn v4_and_above(network_magic: u64) -> VersionTable {
+    pub fn v4_and_above(network_magic: u64, peer_sharing: bool) -> VersionTable {
         // Older versions are not supported anymore (removed from network-spec.pdf).
         // Try not to break compatibility with older pallas users.
-        Self::v7_and_above(network_magic)
+        Self::v7_and_above(network_magic, peer_sharing)
     }
 
     #[deprecated(note = "no longer supported by spec")]
-    pub fn v6_and_above(network_magic: u64) -> VersionTable {
+    pub fn v6_and_above(network_magic: u64, peer_sharing: bool) -> VersionTable {
         // Older versions are not supported anymore (removed from network-spec.pdf).
         // Try not to break compatibility with older pallas users.
-        Self::v7_and_above(network_magic)
+        Self::v7_and_above(network_magic, peer_sharing)
     }
 
     pub fn v7_to_v10(network_magic: u64) -> VersionTable {
@@ -54,7 +55,7 @@ impl VersionTable {
         VersionTable { values }
     }
 
-    pub fn v7_and_above(network_magic: u64) -> VersionTable {
+    pub fn v7_and_above(network_magic: u64, peer_sharing: bool) -> VersionTable {
         let values = vec![
             (
                 PROTOCOL_V7,
@@ -77,7 +78,10 @@ impl VersionTable {
                 VersionData::new(
                     network_magic,
                     true,
-                    Some(PEER_SHARING_DISABLED),
+                    match peer_sharing {
+                        true => Some(PEER_SHARING_ENABLED),
+                        false => Some(PEER_SHARING_DISABLED),
+                    },
                     Some(false),
                 ),
             ),
@@ -86,7 +90,10 @@ impl VersionTable {
                 VersionData::new(
                     network_magic,
                     true,
-                    Some(PEER_SHARING_DISABLED),
+                    match peer_sharing {
+                        true => Some(PEER_SHARING_ENABLED),
+                        false => Some(PEER_SHARING_DISABLED),
+                    },
                     Some(false),
                 ),
             ),
@@ -95,7 +102,10 @@ impl VersionTable {
                 VersionData::new(
                     network_magic,
                     true,
-                    Some(PEER_SHARING_DISABLED),
+                    match peer_sharing {
+                        true => Some(PEER_SHARING_ENABLED),
+                        false => Some(PEER_SHARING_DISABLED),
+                    },
                     Some(false),
                 ),
             ),
@@ -106,14 +116,17 @@ impl VersionTable {
         VersionTable { values }
     }
 
-    pub fn v11_and_above(network_magic: u64) -> VersionTable {
+    pub fn v11_and_above(network_magic: u64, peer_sharing: bool) -> VersionTable {
         let values = vec![
             (
                 PROTOCOL_V11,
                 VersionData::new(
                     network_magic,
                     true,
-                    Some(PEER_SHARING_DISABLED),
+                    match peer_sharing {
+                        true => Some(PEER_SHARING_ENABLED),
+                        false => Some(PEER_SHARING_DISABLED),
+                    },
                     Some(false),
                 ),
             ),
@@ -122,7 +135,10 @@ impl VersionTable {
                 VersionData::new(
                     network_magic,
                     true,
-                    Some(PEER_SHARING_DISABLED),
+                    match peer_sharing {
+                        true => Some(PEER_SHARING_ENABLED),
+                        false => Some(PEER_SHARING_DISABLED),
+                    },
                     Some(false),
                 ),
             ),
@@ -131,7 +147,10 @@ impl VersionTable {
                 VersionData::new(
                     network_magic,
                     true,
-                    Some(PEER_SHARING_DISABLED),
+                    match peer_sharing {
+                        true => Some(PEER_SHARING_ENABLED),
+                        false => Some(PEER_SHARING_DISABLED),
+                    },
                     Some(false),
                 ),
             ),

--- a/pallas-network/src/multiplexer.rs
+++ b/pallas-network/src/multiplexer.rs
@@ -547,12 +547,16 @@ impl ChannelBuffer {
     where
         M: Fragment,
     {
+        println!("recv_full_msg");
+        println!("temp.len() = {}", self.temp.len());
         trace!(len = self.temp.len(), "waiting for full message");
 
         if !self.temp.is_empty() {
             trace!("buffer has data from previous payload");
 
             if let Some(msg) = try_decode_message::<M>(&mut self.temp)? {
+                //log the self.temp in hex
+                trace!("buffered data: {}", hex::encode(&self.temp));
                 debug!("decoding done");
                 return Ok(msg);
             }
@@ -561,7 +565,8 @@ impl ChannelBuffer {
         loop {
             let chunk = self.channel.dequeue_chunk().await?;
             self.temp.extend(chunk);
-
+            //log the self.temp in hex
+            println!("buffered data: {}", hex::encode(&self.temp));
             if let Some(msg) = try_decode_message::<M>(&mut self.temp)? {
                 debug!("decoding done");
                 return Ok(msg);

--- a/pallas-network/tests/protocols.rs
+++ b/pallas-network/tests/protocols.rs
@@ -199,7 +199,7 @@ pub async fn blockfetch_server_and_client_happy_path() {
         async move {
             // server setup
 
-            let mut peer_server = PeerServer::accept(&listener, 0).await.unwrap();
+            let mut peer_server = PeerServer::accept(&listener, 0, false).await.unwrap();
 
             let server_bf = peer_server.blockfetch();
 
@@ -1465,7 +1465,7 @@ pub async fn txsubmission_server_and_client_happy_path_n2n() {
     let server = tokio::spawn({
         let test_txs = test_txs.clone();
         async move {
-            let mut peer_server = PeerServer::accept(&server_listener, 0).await.unwrap();
+            let mut peer_server = PeerServer::accept(&server_listener, 0, false).await.unwrap();
 
             let server_txsub = peer_server.txsubmission();
 
@@ -1738,7 +1738,7 @@ pub async fn peer_sharing_server_and_client_happy_path() {
         async move {
             // server setup
 
-            let mut peer_server = PeerServer::accept(&listener, 0).await.unwrap();
+            let mut peer_server = PeerServer::accept(&listener, 0, false).await.unwrap();
 
             let server_ps = peer_server.peersharing();
 


### PR DESCRIPTION
This PR tries to expose peer sharing boolean protocol level flag to the peer client as this is a signal to the client users if peersharing queries can be executed or otherwise the server rejects it / no point to try to query.