### PR TITLE
feat(network): peer client version table query support

### DIFF
--- a/pallas-network/src/facades.rs
+++ b/pallas-network/src/facades.rs
@@ -160,7 +160,7 @@ impl PeerClient {
         Ok(client)
     }
 
-    pub async fn query(
+    pub async fn handshake_query(
         addr: impl ToSocketAddrs,
         magic: u64,
     ) -> Result<VersionTable<VersionData>, Error> {

--- a/pallas-network/src/facades.rs
+++ b/pallas-network/src/facades.rs
@@ -173,6 +173,8 @@ impl PeerClient {
         let channel = plexer.subscribe_client(PROTOCOL_N2N_HANDSHAKE);
         let mut handshake = handshake::Client::new(channel);
 
+        let _plexer = plexer.spawn();
+
         let versions = handshake::n2n::VersionTable::v7_and_above_with_query(magic, true);
 
         let handshake = handshake

--- a/pallas-network/src/facades.rs
+++ b/pallas-network/src/facades.rs
@@ -9,7 +9,8 @@ use tokio::net::{TcpListener, ToSocketAddrs};
 #[cfg(unix)]
 use tokio::net::{unix::SocketAddr as UnixSocketAddr, UnixListener};
 
-use crate::miniprotocols::handshake::{n2c, n2n, Confirmation, VersionNumber};
+use crate::miniprotocols::handshake::n2n::VersionData;
+use crate::miniprotocols::handshake::{n2c, n2n, Confirmation, VersionNumber, VersionTable};
 
 use crate::miniprotocols::{
     blockfetch, chainsync, handshake, keepalive, localstate, localtxsubmission, peersharing,
@@ -157,6 +158,44 @@ impl PeerClient {
         };
 
         Ok(client)
+    }
+
+    pub async fn query(
+        addr: impl ToSocketAddrs,
+        magic: u64,
+    ) -> Result<VersionTable<VersionData>, Error> {
+        let bearer = Bearer::connect_tcp(addr)
+            .await
+            .map_err(Error::ConnectFailure)?;
+
+        let mut plexer = multiplexer::Plexer::new(bearer);
+
+        let channel = plexer.subscribe_client(PROTOCOL_N2N_HANDSHAKE);
+        let mut handshake = handshake::Client::new(channel);
+
+        let versions = handshake::n2n::VersionTable::v7_and_above_with_query(magic, true);
+
+        let handshake = handshake
+            .handshake(versions)
+            .await
+            .map_err(Error::HandshakeProtocol)?;
+
+        let version_table = match handshake {
+            handshake::Confirmation::QueryReply(version_table) => {
+                debug!("handshake query reply received");
+                version_table
+            }
+            handshake::Confirmation::Accepted(_, _) => {
+                error!("handshake accepted when we expected query reply");
+                return Err(Error::HandshakeProtocol(handshake::Error::InvalidInbound));
+            }
+            handshake::Confirmation::Rejected(reason) => {
+                error!(?reason, "handshake refused");
+                return Err(Error::IncompatibleVersion);
+            }
+        };
+
+        Ok(version_table)
     }
 
     pub fn chainsync(&mut self) -> &mut chainsync::N2NClient {

--- a/pallas-network/src/miniprotocols/handshake/n2n.rs
+++ b/pallas-network/src/miniprotocols/handshake/n2n.rs
@@ -55,6 +55,10 @@ impl VersionTable {
     }
 
     pub fn v7_and_above(network_magic: u64) -> VersionTable {
+        Self::v7_and_above_with_query(network_magic, false)
+    }
+
+    pub fn v7_and_above_with_query(network_magic: u64, query: bool) -> VersionTable {
         let values = vec![
             (
                 PROTOCOL_V7,
@@ -78,7 +82,7 @@ impl VersionTable {
                     network_magic,
                     true,
                     Some(PEER_SHARING_DISABLED),
-                    Some(false),
+                    Some(query),
                 ),
             ),
             (
@@ -87,7 +91,7 @@ impl VersionTable {
                     network_magic,
                     true,
                     Some(PEER_SHARING_DISABLED),
-                    Some(false),
+                    Some(query),
                 ),
             ),
             (
@@ -96,7 +100,7 @@ impl VersionTable {
                     network_magic,
                     true,
                     Some(PEER_SHARING_DISABLED),
-                    Some(false),
+                    Some(query),
                 ),
             ),
         ]
@@ -107,6 +111,10 @@ impl VersionTable {
     }
 
     pub fn v11_and_above(network_magic: u64) -> VersionTable {
+        Self::v11_and_above_with_query(network_magic, false)
+    }
+
+    pub fn v11_and_above_with_query(network_magic: u64, query: bool) -> VersionTable {
         let values = vec![
             (
                 PROTOCOL_V11,
@@ -114,7 +122,7 @@ impl VersionTable {
                     network_magic,
                     true,
                     Some(PEER_SHARING_DISABLED),
-                    Some(false),
+                    Some(query),
                 ),
             ),
             (
@@ -123,7 +131,7 @@ impl VersionTable {
                     network_magic,
                     true,
                     Some(PEER_SHARING_DISABLED),
-                    Some(false),
+                    Some(query),
                 ),
             ),
             (
@@ -132,7 +140,7 @@ impl VersionTable {
                     network_magic,
                     true,
                     Some(PEER_SHARING_DISABLED),
-                    Some(false),
+                    Some(query),
                 ),
             ),
         ]

--- a/pallas-network/src/miniprotocols/handshake/n2n.rs
+++ b/pallas-network/src/miniprotocols/handshake/n2n.rs
@@ -153,10 +153,10 @@ impl VersionTable {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct VersionData {
-    network_magic: u64,
-    initiator_only_diffusion_mode: bool,
-    peer_sharing: Option<u8>,
-    query: Option<bool>,
+    pub network_magic: u64,
+    pub initiator_only_diffusion_mode: bool,
+    pub peer_sharing: Option<u8>,
+    pub query: Option<bool>,
 }
 
 impl VersionData {


### PR DESCRIPTION
## REASON FOR THIS PR

### Issue
- The handshake mini-protocol only replies with `MsgAcceptVersion` and `MsgRefuse` currently.
- Upon testing, the negotiated version doesn't inherit the actual PeerSharing config of the server
- So there was no actual way for us to know if the peer server has peersharing capabilities
- We needed a way for us to know the peer server's supported version table and version data
- We can only do that if the server replies with `QueryReply`
- ***However, if we merely add an option for us to do queries to the current setup, the connection closes as soon as a Query Reply is expected.***
- ***Thus, we need a separate function for it that connects only to perform a `query handshake`.***
- This specific feature is particularly useful for the peersharing mini-protocol implementation in Boros.

### Solution
- Create a query function inside peer client that connects to the given peer address and network magic
- Instead of subscribing to multiple channels, we only subscribe to handshake mini-protocol
- We negotiate with our own version table that has a `query = true`
- For our version table to support querying, we also need to update the version table to accept a query boolean param
- We return the supported version table from the peer server and we expect it to be a Query Reply.