### PR TITLE
Change PoolMetadata.hash type to Bytes

### DIFF
--- a/pallas-applying/tests/shelley_ma.rs
+++ b/pallas-applying/tests/shelley_ma.rs
@@ -321,10 +321,10 @@ mod shelley_ma_tests {
             .to_vec(),
             pool_metadata: Nullable::Some(PoolMetadata {
                 url: "https://cardapool.com/a.json".to_string(),
-                hash: Hash::from_str(
-                    "01F708549816C9A075FF96E9682C11A5F5C7F4E147862A663BDEECE0716AB76E",
-                )
-                .unwrap(),
+                hash: "01F708549816C9A075FF96E9682C11A5F5C7F4E147862A663BDEECE0716AB76E"
+                    .to_string()
+                    .try_into()
+                    .unwrap(),
             }),
         }
     }

--- a/pallas-primitives/src/lib.rs
+++ b/pallas-primitives/src/lib.rs
@@ -206,7 +206,7 @@ pub struct PoolMetadata {
     pub hash: PoolMetadataHash,
 }
 
-pub type PoolMetadataHash = Hash<32>;
+pub type PoolMetadataHash = Bytes;
 
 pub type Port = u32;
 


### PR DESCRIPTION
In the `ledger` code base, `PoolMetadata`'s hash field is defined as a `ByteString` of any length. Although at runtime it is expected to get 32 bytes long hash, the datatype is not limited to it. We are getting empty hashes while using the `Arbitrary` instances to test our Rust code. This causes CBOR decoding to fail.

We created a PR against the `ledger` codebase but It got rejected [here](https://github.com/IntersectMBO/cardano-ledger/pull/4870#pullrequestreview-2597267579)

So here the PR for changing the field to `Bytes`. This change is not a breaking one.

cc @michalrus 