### PR TITLE
chore: dependencies cleanup

### DIFF
--- a/examples/block-decode/Cargo.toml
+++ b/examples/block-decode/Cargo.toml
@@ -8,5 +8,4 @@ publish = false
 
 [dependencies]
 pallas = { path = "../../pallas" }
-net2 = "0.2.37"
 hex = "0.4.3"

--- a/examples/block-download/Cargo.toml
+++ b/examples/block-download/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 
 [dependencies]
 pallas = { path = "../../pallas" }
-net2 = "0.2.37"
 hex = "0.4.3"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"

--- a/examples/n2c-miniprotocols/Cargo.toml
+++ b/examples/n2c-miniprotocols/Cargo.toml
@@ -8,9 +8,7 @@ publish = false
 
 [dependencies]
 pallas = { path = "../../pallas" }
-net2 = "0.2.37"
 hex = "0.4.3"
-log = "0.4.16"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 tokio = { version = "1.27.0", features = ["rt-multi-thread"] }

--- a/examples/n2n-miniprotocols/Cargo.toml
+++ b/examples/n2n-miniprotocols/Cargo.toml
@@ -8,11 +8,9 @@ publish = false
 
 [dependencies]
 pallas = { path = "../../pallas" }
-net2 = "0.2.37"
 hex = "0.4.3"
 log = "0.4.16"
 thiserror = "1.0.31"
-futures = "0.3.29"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 tokio = { version = "1.27.0", features = ["rt-multi-thread"] }

--- a/pallas-applying/Cargo.toml
+++ b/pallas-applying/Cargo.toml
@@ -18,7 +18,6 @@ pallas-codec = { version = "=0.32.0", path = "../pallas-codec" }
 pallas-crypto = { version = "=0.32.0", path = "../pallas-crypto" }
 pallas-primitives = { version = "=0.32.0", path = "../pallas-primitives" }
 pallas-traverse = { version = "=0.32.0", path = "../pallas-traverse" }
-rand = "0.8"
 hex = "0.4"
 chrono = "0.4.39"
 thiserror = "1.0.49"

--- a/pallas-configs/Cargo.toml
+++ b/pallas-configs/Cargo.toml
@@ -11,10 +11,8 @@ readme = "README.md"
 authors = ["Santiago Carmuega <santiago@carmuega.me>"]
 
 [dependencies]
-hex = "0.4.3"
 pallas-addresses = { version = "=0.32.0", path = "../pallas-addresses" }
 pallas-crypto = { version = "=0.32.0", path = "../pallas-crypto" }
-pallas-codec = { version = "=0.32.0", path = "../pallas-codec" }
 pallas-primitives = { version = "=0.32.0", path = "../pallas-primitives" }
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
 serde_json = { version = "1.0.79", optional = true }

--- a/pallas-crypto/Cargo.toml
+++ b/pallas-crypto/Cargo.toml
@@ -17,11 +17,9 @@ thiserror = "1.0"
 rand_core = "0.6"
 pallas-codec = { version = "=0.32.0", path = "../pallas-codec" }
 serde = "1.0.143"
-zeroize = "1.8.1"
 
 [dev-dependencies]
 itertools = "0.13"
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
-rand = "0.8"
 serde_test = "1.0.143"

--- a/pallas-math/Cargo.toml
+++ b/pallas-math/Cargo.toml
@@ -18,7 +18,4 @@ regex = "1.10.5"
 thiserror = "1.0.61"
 
 [dev-dependencies]
-quickcheck = "1.0"
-quickcheck_macros = "1.0"
-rand = "0.8"
 proptest = "1.5"

--- a/pallas-primitives/Cargo.toml
+++ b/pallas-primitives/Cargo.toml
@@ -15,11 +15,8 @@ authors = [
 
 [dependencies]
 hex = "0.4.3"
-log = "0.4.14"
 pallas-crypto = { version = "=0.32.0", path = "../pallas-crypto" }
 pallas-codec = { version = "=0.32.0", path = "../pallas-codec" }
-base58 = "0.2.0"
-bech32 = "0.9.0"
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
 serde_json = { version = "1.0.79", optional = true }
 


### PR DESCRIPTION
Remove some now unused dependencies. I used [cargo-machete](https://github.com/bnjbvr/cargo-machete) to identify those.

Also note that `pallas-bech32` is not part of root `Cargo.toml` workspace members. Unclear if that's expected.