### PR TITLE
feat(codec): allow KeepRaw to own its data

### DIFF
--- a/pallas-applying/src/utils.rs
+++ b/pallas-applying/src/utils.rs
@@ -7,13 +7,11 @@ pub use environment::*;
 use pallas_addresses::{Address, ShelleyAddress, ShelleyPaymentPart};
 use pallas_codec::{
     minicbor::encode,
-    utils::{Bytes, KeepRaw, KeyValuePairs, Nullable},
+    utils::{Bytes, KeyValuePairs, Nullable},
 };
 use pallas_crypto::key::ed25519::{PublicKey, Signature};
 use pallas_primitives::{
-    alonzo::{
-        AuxiliaryData, MintedTx as AlonzoMintedTx, Multiasset, NativeScript, VKeyWitness, Value,
-    },
+    alonzo::{MintedTx as AlonzoMintedTx, Multiasset, NativeScript, VKeyWitness, Value},
     babbage::MintedTx as BabbageMintedTx,
     conway::{MintedTx as ConwayMintedTx, Multiasset as ConwayMultiasset, Value as ConwayValue},
     AddrKeyhash, AssetName, Coin, Epoch, GenesisDelegateHash, Genesishash, NetworkId,
@@ -661,21 +659,15 @@ pub fn is_byron_address(address: &[u8]) -> bool {
 }
 
 pub fn aux_data_from_alonzo_minted_tx<'a>(mtx: &'a AlonzoMintedTx) -> Option<&'a [u8]> {
-    Option::<KeepRaw<AuxiliaryData>>::from((mtx.auxiliary_data).clone())
-        .as_ref()
-        .map(KeepRaw::raw_cbor)
+    mtx.auxiliary_data.as_ref().map(|x| x.raw_cbor()).into()
 }
 
 pub fn aux_data_from_babbage_minted_tx<'a>(mtx: &'a BabbageMintedTx) -> Option<&'a [u8]> {
-    Option::<KeepRaw<AuxiliaryData>>::from((mtx.auxiliary_data).clone())
-        .as_ref()
-        .map(KeepRaw::raw_cbor)
+    mtx.auxiliary_data.as_ref().map(|x| x.raw_cbor()).into()
 }
 
 pub fn aux_data_from_conway_minted_tx<'a>(mtx: &'a ConwayMintedTx) -> Option<&'a [u8]> {
-    Option::<KeepRaw<AuxiliaryData>>::from((mtx.auxiliary_data).clone())
-        .as_ref()
-        .map(KeepRaw::raw_cbor)
+    mtx.auxiliary_data.as_ref().map(|x| x.raw_cbor()).into()
 }
 
 pub fn get_val_size_in_words(val: &Value) -> u64 {

--- a/pallas-traverse/src/header.rs
+++ b/pallas-traverse/src/header.rs
@@ -31,7 +31,7 @@ impl<'b> MultiEraHeader<'b> {
         }
     }
 
-    pub fn cbor(&self) -> &'b [u8] {
+    pub fn cbor(&self) -> &[u8] {
         match self {
             MultiEraHeader::EpochBoundary(x) => x.raw_cbor(),
             MultiEraHeader::ShelleyCompatible(x) => x.raw_cbor(),
@@ -87,7 +87,7 @@ impl<'b> MultiEraHeader<'b> {
         }
     }
 
-    pub fn header_body_cbor(&self) -> Option<&'b [u8]> {
+    pub fn header_body_cbor(&self) -> Option<&[u8]> {
         match self {
             MultiEraHeader::ShelleyCompatible(x) => Some(x.header_body.raw_cbor()),
             MultiEraHeader::BabbageCompatible(x) => Some(x.header_body.raw_cbor()),


### PR DESCRIPTION
Make `KeepRaw` store the original data as a `Cow<'b, [u8]>` instead of a `&'b [u8]`, and add a `to_owned` method. Justification for this change is in #599, but tl;dr it lets you avoid awkward lifetime problems.

This is a breaking change, the `raw_cbor()` method now returns a `&[u8]` instead of a `&'b [u8]`. In practice, this means that a reference to the raw bytes can no longer outlive a reference to the structure itself. 

Also adds an `as_ref` method to the `Nullable<T>` helper, to fix a lifetime problem this changed introduced.