### PR TITLE
Cardano blueprint localstatequery tests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -48,14 +48,14 @@ jobs:
           toolchain: stable
 
       - name: Run cargo test
-        run: cargo test --release
+        run: cargo test --release --features blueprint
 
   lints:
     name: Lints
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,7 +1,8 @@
 # Based on https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
 
 on:
-  push: { }
+  push:
+  pull_request:
 
 name: Validate
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cardano-blueprint"]
+	path = cardano-blueprint
+	url = git@github.com:cardano-scaling/cardano-blueprint

--- a/pallas-codec/src/utils.rs
+++ b/pallas-codec/src/utils.rs
@@ -1495,6 +1495,13 @@ impl From<Int> for i128 {
     }
 }
 
+impl From<i32> for Int {
+    fn from(x: i32) -> Self {
+        let inner = minicbor::data::Int::from(x);
+        Self(inner)
+    }
+}
+
 impl From<i64> for Int {
     fn from(x: i64) -> Self {
         let inner = minicbor::data::Int::from(x);

--- a/pallas-network/Cargo.toml
+++ b/pallas-network/Cargo.toml
@@ -26,3 +26,5 @@ tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 tokio = { version = "1", features = ["full"] }
 
+[features]
+blueprint = []

--- a/pallas-network/src/miniprotocols/handshake/protocol.rs
+++ b/pallas-network/src/miniprotocols/handshake/protocol.rs
@@ -233,11 +233,12 @@ impl<'b> Decode<'b, ()> for RefuseReason {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "blueprint")]
     #[test]
     fn message_roundtrip() {
+        use super::Message;
         use pallas_codec::minicbor;
         use pallas_codec::utils;
-        use super::{Message};
 
         // XXX: Can we avoid repeating the test-data path?
         let test_messages = [

--- a/pallas-network/src/miniprotocols/handshake/protocol.rs
+++ b/pallas-network/src/miniprotocols/handshake/protocol.rs
@@ -230,3 +230,50 @@ impl<'b> Decode<'b, ()> for RefuseReason {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn message_roundtrip() {
+        use pallas_codec::minicbor;
+        use pallas_codec::utils;
+        use super::{Message};
+
+        // XXX: Can we avoid repeating the test-data path?
+        let test_messages = [
+            include_str!(
+                "../../../../cardano-blueprint/src/network/test-data/handshake-n2n/test-0"
+            ),
+            include_str!(
+                "../../../../cardano-blueprint/src/network/test-data/handshake-n2n/test-1"
+            ),
+            include_str!(
+                "../../../../cardano-blueprint/src/network/test-data/handshake-n2n/test-2"
+            ),
+            include_str!(
+                "../../../../cardano-blueprint/src/network/test-data/handshake-n2n/test-3"
+            ),
+            include_str!(
+                "../../../../cardano-blueprint/src/network/test-data/handshake-n2n/test-4"
+            ),
+        ];
+
+        for (idx, message_str) in test_messages.iter().enumerate() {
+            println!("Decoding test message {}", idx + 1);
+            let bytes =
+                hex::decode(message_str).unwrap_or_else(|_| panic!("bad message file {idx}"));
+
+            let message: Message<utils::AnyCbor> = minicbor::decode(&bytes[..])
+                .unwrap_or_else(|e| panic!("error decoding cbor for file {idx}: {e:?}"));
+            println!("Decoded message: {:#?}", message);
+
+            let bytes2 = minicbor::to_vec(message)
+                .unwrap_or_else(|e| panic!("error encoding cbor for file {idx}: {e:?}"));
+
+            assert!(
+                bytes.eq(&bytes2),
+                "re-encoded bytes didn't match original file {idx}"
+            );
+        }
+    }
+}

--- a/pallas-network/src/miniprotocols/localstate/codec.rs
+++ b/pallas-network/src/miniprotocols/localstate/codec.rs
@@ -153,10 +153,7 @@ pub mod tests {
         ];
         // TODO: DRY with other decode/encode roundtrips
         for (idx, message_str) in examples.iter().enumerate() {
-            println!(
-                "Decoding test message {idx}: {message_str} {}",
-                message_str.len()
-            );
+            println!("Decoding test message {idx}");
             let bytes = hex::decode(message_str)
                 .unwrap_or_else(|e| panic!("bad message file {idx}: {e:?}"));
 

--- a/pallas-network/src/miniprotocols/localstate/codec.rs
+++ b/pallas-network/src/miniprotocols/localstate/codec.rs
@@ -132,3 +132,45 @@ impl<'b> Decode<'b, ()> for Message {
         }
     }
 }
+
+#[cfg(test)]
+pub mod tests {
+    /// Decode/encode roundtrip tests for the localstate example queries/results.
+    #[test]
+    #[cfg(feature = "blueprint")]
+    fn test_api_example_roundtrip() {
+        use super::Message;
+        use pallas_codec::minicbor;
+
+        // TODO: scan for examples
+        let examples = [
+            include_str!(
+                "../../../../cardano-blueprint/src/api/examples/getSystemStart/query.cbor"
+            ),
+            include_str!(
+                "../../../../cardano-blueprint/src/api/examples/getSystemStart/result.cbor"
+            ),
+        ];
+        // TODO: DRY with other decode/encode roundtrips
+        for (idx, message_str) in examples.iter().enumerate() {
+            println!(
+                "Decoding test message {idx}: {message_str} {}",
+                message_str.len()
+            );
+            let bytes = hex::decode(message_str)
+                .unwrap_or_else(|e| panic!("bad message file {idx}: {e:?}"));
+
+            let message: Message = minicbor::decode(&bytes[..])
+                .unwrap_or_else(|e| panic!("error decoding cbor for file {idx}: {e:?}"));
+            println!("Decoded message: {:#?}", message);
+
+            let bytes2 = minicbor::to_vec(message)
+                .unwrap_or_else(|e| panic!("error encoding cbor for file {idx}: {e:?}"));
+
+            assert!(
+                bytes.eq(&bytes2),
+                "re-encoded bytes didn't match original file {idx}"
+            );
+        }
+    }
+}

--- a/pallas-network/src/miniprotocols/localstate/queries_v16/codec.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/codec.rs
@@ -818,7 +818,6 @@ pub mod tests {
                 "../../../../../cardano-blueprint/src/api/examples/getSystemStart/result.cbor"
             ),
         )];
-        // TODO: DRY with other decode/encode roundtrips
         for (idx, (query_str, result_str)) in examples.iter().enumerate() {
             println!("Roundtrip query {idx}");
             roundtrips_with(query_str, |q| match q {
@@ -839,9 +838,10 @@ pub mod tests {
             println!("Roundtrip result {idx}");
             roundtrips_with(result_str, |q| match q {
                 Message::Result(cbor) => {
-                    return minicbor::decode::<SystemStart>(&cbor[..]).unwrap_or_else(|e| {
+                    let result = minicbor::decode::<SystemStart>(&cbor[..]).unwrap_or_else(|e| {
                         panic!("error decoding cbor from query message: {e:?}")
                     });
+                    return Message::Result(AnyCbor::from_encode(result));
                 }
                 _ => panic!("unexpected message type"),
             });
@@ -869,9 +869,6 @@ pub mod tests {
         let bytes2 =
             minicbor::to_vec(result).unwrap_or_else(|e| panic!("error encoding cbor: {e:?}"));
 
-        assert!(
-            bytes.eq(&bytes2),
-            "re-encoded bytes didn't match original file"
-        );
+        assert_eq!(hex::encode(bytes), hex::encode(bytes2));
     }
 }

--- a/pallas-network/src/miniprotocols/localstate/queries_v16/codec.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/codec.rs
@@ -797,15 +797,18 @@ impl<'b, C> minicbor::Decode<'b, C> for CostModels {
 
 #[cfg(test)]
 pub mod tests {
-    use super::Request;
-    use crate::miniprotocols::localstate::Message;
     use pallas_codec::minicbor;
-    use pallas_codec::utils::AnyCbor;
 
     /// Decode/encode roundtrip tests for the localstate example queries/results.
     #[test]
     #[cfg(feature = "blueprint")]
     fn test_api_example_roundtrip() {
+        use crate::miniprotocols::localstate::{
+            queries_v16::{Request, SystemStart},
+            Message,
+        };
+        use pallas_codec::utils::AnyCbor;
+
         // TODO: scan for examples
         let examples = [(
             include_str!(
@@ -817,32 +820,58 @@ pub mod tests {
         )];
         // TODO: DRY with other decode/encode roundtrips
         for (idx, (query_str, result_str)) in examples.iter().enumerate() {
-            println!("Decoding query message {idx}");
-            let bytes =
-                hex::decode(query_str).unwrap_or_else(|e| panic!("bad message file {idx}: {e:?}"));
-
-            let message: Message = minicbor::decode(&bytes[..])
-                .unwrap_or_else(|e| panic!("error decoding cbor for file {idx}: {e:?}"));
-            println!("Decoded message: {:#?}", message);
-
-            let request: Request;
-            match message {
+            println!("Roundtrip query {idx}");
+            roundtrips_with(query_str, |q| match q {
                 Message::Query(cbor) => {
-                    request = minicbor::decode(&cbor[..]).unwrap_or_else(|e| {
+                    let request = minicbor::decode(&cbor[..]).unwrap_or_else(|e| {
                         panic!("error decoding cbor from query message: {e:?}")
                     });
-                    println!("Decoded request: {:#?}", request);
+                    match request {
+                        Request::GetSystemStart => {
+                            return Message::Query(AnyCbor::from_encode(request))
+                        }
+                        _ => panic!("unexpected query type"),
+                    }
                 }
                 _ => panic!("unexpected message type"),
-            }
+            });
 
-            let bytes2 = minicbor::to_vec(Message::Query(AnyCbor::from_encode(request)))
-                .unwrap_or_else(|e| panic!("error encoding cbor for file {idx}: {e:?}"));
-
-            assert!(
-                bytes.eq(&bytes2),
-                "re-encoded bytes didn't match original file {idx}"
-            );
+            println!("Roundtrip result {idx}");
+            roundtrips_with(result_str, |q| match q {
+                Message::Result(cbor) => {
+                    return minicbor::decode::<SystemStart>(&cbor[..]).unwrap_or_else(|e| {
+                        panic!("error decoding cbor from query message: {e:?}")
+                    });
+                }
+                _ => panic!("unexpected message type"),
+            });
         }
+    }
+
+    // TODO: DRY with other decode/encode roundtripss
+    /// Decode a value of type T, transform it to U and encode that again to form a roundtrip.
+    fn roundtrips_with<T, U>(message_str: &str, transform: fn(T) -> U)
+    where
+        T: for<'b> minicbor::Decode<'b, ()> + std::fmt::Debug,
+        U: std::fmt::Debug + minicbor::Encode<()>,
+    {
+        use pallas_codec::minicbor;
+
+        let bytes = hex::decode(message_str).unwrap_or_else(|e| panic!("bad message file: {e:?}"));
+
+        let value: T =
+            minicbor::decode(&bytes[..]).unwrap_or_else(|e| panic!("error decoding cbor: {e:?}"));
+        println!("Decoded value: {:#?}", value);
+
+        let result: U = transform(value);
+        println!("Transformed to: {:#?}", result);
+
+        let bytes2 =
+            minicbor::to_vec(result).unwrap_or_else(|e| panic!("error encoding cbor: {e:?}"));
+
+        assert!(
+            bytes.eq(&bytes2),
+            "re-encoded bytes didn't match original file"
+        );
     }
 }

--- a/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
@@ -214,13 +214,13 @@ pub enum Value {
 #[derive(Debug, Encode, Decode, PartialEq)]
 pub struct SystemStart {
     #[n(0)]
-    pub year: u32,
+    pub year: BigInt,
 
     #[n(1)]
-    pub day_of_year: u32,
+    pub day_of_year: i64,
 
     #[n(2)]
-    pub picoseconds_of_day: u64,
+    pub picoseconds_of_day: BigInt,
 }
 
 #[derive(Debug, Encode, Decode, PartialEq)]
@@ -740,6 +740,24 @@ pub enum BigInt {
     Int(Int),
     BigUInt(BoundedBytes),
     BigNInt(BoundedBytes),
+}
+
+impl From<Int> for BigInt {
+    fn from(value: Int) -> Self {
+        Self::Int(value)
+    }
+}
+
+impl From<i32> for BigInt {
+    fn from(x: i32) -> Self {
+        Self::Int(Int::from(x))
+    }
+}
+
+impl From<i64> for BigInt {
+    fn from(x: i64) -> Self {
+        Self::Int(Int::from(x))
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/pallas-network/tests/protocols.rs
+++ b/pallas-network/tests/protocols.rs
@@ -513,9 +513,9 @@ pub async fn local_state_query_server_and_client_happy_path() {
             assert_eq!(*server.statequery().state(), localstate::State::Querying);
 
             let result = AnyCbor::from_encode(SystemStart {
-                year: 2020,
+                year: 2020.into(),
                 day_of_year: 1,
-                picoseconds_of_day: 999999999,
+                picoseconds_of_day: 999999999.into(),
             });
 
             server.statequery().send_result(result).await.unwrap();
@@ -848,9 +848,9 @@ pub async fn local_state_query_server_and_client_happy_path() {
 
             let genesis = vec![GenesisConfig {
                 system_start: SystemStart {
-                    year: 2021,
+                    year: 2021.into(),
                     day_of_year: 150,
-                    picoseconds_of_day: 0,
+                    picoseconds_of_day: 0.into(),
                 },
                 network_magic: 42,
                 network_id: 42,
@@ -970,9 +970,9 @@ pub async fn local_state_query_server_and_client_happy_path() {
         assert_eq!(
             result,
             queries_v16::SystemStart {
-                year: 2020,
+                year: 2020.into(),
                 day_of_year: 1,
-                picoseconds_of_day: 999999999,
+                picoseconds_of_day: 999999999.into(),
             }
         );
 
@@ -1224,9 +1224,9 @@ pub async fn local_state_query_server_and_client_happy_path() {
 
         let genesis = vec![GenesisConfig {
             system_start: SystemStart {
-                year: 2021,
+                year: 2021.into(),
                 day_of_year: 150,
-                picoseconds_of_day: 0,
+                picoseconds_of_day: 0.into(),
             },
             network_magic: 42,
             network_id: 42,


### PR DESCRIPTION
Stacked with #587, review that first.

Explores how we can test the [LocalStateQuery API](https://github.com/cardano-scaling/cardano-blueprint/issues/25) that is being created in course of the blueprint initiative.

~~Note that the first (and only) API query example for `getSystemStart` is actually failing to decode the result, because the `year` is actually a big negative number = the rust implementation behaves different than the CDDL specification (I personally think unsigned numbers would be in fact nicer though .. or maybe even use `time` for this particular query result).~~
This PR now also fixes the `SystemStart` data type (incl. derived encoder + decoder)