### PR TITLE
Separate PParamsUpdate from ProtocolParam

### DIFF
--- a/examples/n2c-miniprotocols/src/main.rs
+++ b/examples/n2c-miniprotocols/src/main.rs
@@ -87,7 +87,6 @@ async fn do_localstate_query(client: &mut NodeClient) {
         .unwrap();
     info!("result: {:02x?}", result);
 
-    // This one is large (~120MB in preprod).
     let result = queries_v16::get_gov_state(client, era).await.unwrap();
     info!("result: {:02x?}", result);
 

--- a/examples/n2c-miniprotocols/src/main.rs
+++ b/examples/n2c-miniprotocols/src/main.rs
@@ -63,11 +63,10 @@ async fn do_localstate_query(client: &mut NodeClient) {
     let result = queries_v16::get_account_state(client, era).await.unwrap();
     info!("result: {:02x?}", result);
 
-    // Not yet available in the Cardano node to test.
-    // let result = queries_v16::get_big_ledger_snapshot(client, era)
-    //     .await
-    //     .unwrap();
-    // info!("result: {:02x?}", result);
+    let result = queries_v16::get_big_ledger_snapshot(client, era)
+        .await
+        .unwrap();
+    info!("result: {:02x?}", result);
 
     let tx_id =
         Hash::<32>::from_str("be1640dd2b3485e94703be5683c804d5051d96c12e1eaacc17c30e74de580ce5")
@@ -89,8 +88,8 @@ async fn do_localstate_query(client: &mut NodeClient) {
     info!("result: {:02x?}", result);
 
     // This one is large (~120MB in preprod).
-    // let result = queries_v16::get_gov_state(client, era).await.unwrap();
-    // info!("result: {:02x?}", result);
+    let result = queries_v16::get_gov_state(client, era).await.unwrap();
+    info!("result: {:02x?}", result);
 
     // CC Member cc_cold1zwn2tcqxl48g75gx9hzrzd3rdxe2gv2q408d32307gjk67cp3tktt
     let cold_bytes =

--- a/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
@@ -642,9 +642,9 @@ pub struct EnactState {
     #[n(1)]
     pub constitution: Constitution,
     #[n(2)]
-    pub cur_pparams: PParamsUpdate,
+    pub cur_pparams: ProtocolParam,
     #[n(3)]
-    pub prev_pparams: PParamsUpdate,
+    pub prev_pparams: ProtocolParam,
     #[n(4)]
     pub treasury: Coin,
     #[n(5)]
@@ -689,9 +689,9 @@ pub struct GovState {
     #[n(2)]
     pub constitution: Constitution,
     #[n(3)]
-    pub cur_pparams: PParamsUpdate,
+    pub cur_pparams: ProtocolParam,
     #[n(4)]
-    pub prev_pparams: PParamsUpdate,
+    pub prev_pparams: ProtocolParam,
     #[n(5)]
     pub future_pparams: FuturePParams,
     #[n(6)]

--- a/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
@@ -77,7 +77,75 @@ pub type Credential = StakeAddr;
 
 /// Updates to the protocol params as [in the Haskell sources](https://github.com/IntersectMBO/cardano-ledger/blob/d30a7ae828e802e98277c82e278e570955afc273/libs/cardano-ledger-core/src/Cardano/Ledger/Core/PParams.hs#L151)
 /// (via [`EraPParams`](https://github.com/IntersectMBO/cardano-ledger/blob/d30a7ae828e802e98277c82e278e570955afc273/libs/cardano-ledger-core/src/Cardano/Ledger/Core/PParams.hs#L255-L258)).
-pub type PParamsUpdate = ProtocolParam;
+/// Conway era protocol parameters, corresponding to [`ConwayPParams`](https://github.com/IntersectMBO/cardano-ledger/blob/d30a7ae828e802e98277c82e278e570955afc273/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs#L512-L579)
+/// in the Haskell sources.
+/// @todo: Encoding should be handled manually, Encode derive won't be correct.
+#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[cbor(map)]
+pub struct PParamsUpdate {
+    #[n(0)]
+    pub minfee_a: Option<u64>,
+    #[n(1)]
+    pub minfee_b: Option<u64>,
+    #[n(2)]
+    pub max_block_body_size: Option<u64>,
+    #[n(3)]
+    pub max_transaction_size: Option<u64>,
+    #[n(4)]
+    pub max_block_header_size: Option<u64>,
+    #[n(5)]
+    pub key_deposit: Option<Coin>,
+    #[n(6)]
+    pub pool_deposit: Option<Coin>,
+    #[n(7)]
+    pub maximum_epoch: Option<Epoch>,
+    #[n(8)]
+    pub desired_number_of_stake_pools: Option<u64>,
+    #[n(9)]
+    pub pool_pledge_influence: Option<RationalNumber>,
+    #[n(10)]
+    pub expansion_rate: Option<UnitInterval>,
+    #[n(11)]
+    pub treasury_growth_rate: Option<UnitInterval>,
+
+    #[n(16)]
+    pub min_pool_cost: Option<Coin>,
+    #[n(17)]
+    pub ada_per_utxo_byte: Option<Coin>,
+    #[n(18)]
+    pub cost_models_for_script_languages: Option<CostModels>,
+    #[n(19)]
+    pub execution_costs: Option<ExUnitPrices>,
+    #[n(20)]
+    pub max_tx_ex_units: Option<ExUnits>,
+    #[n(21)]
+    pub max_block_ex_units: Option<ExUnits>,
+    #[n(22)]
+    pub max_value_size: Option<u64>,
+    #[n(23)]
+    pub collateral_percentage: Option<u64>,
+    #[n(24)]
+    pub max_collateral_inputs: Option<u64>,
+
+    #[n(25)]
+    pub pool_voting_thresholds: Option<PoolVotingThresholds>,
+    #[n(26)]
+    pub drep_voting_thresholds: Option<DRepVotingThresholds>,
+    #[n(27)]
+    pub min_committee_size: Option<u64>,
+    #[n(28)]
+    pub committee_term_limit: Option<Epoch>,
+    #[n(29)]
+    pub governance_action_validity_period: Option<Epoch>,
+    #[n(30)]
+    pub governance_action_deposit: Option<Coin>,
+    #[n(31)]
+    pub drep_deposit: Option<Coin>,
+    #[n(32)]
+    pub drep_inactivity_period: Option<Epoch>,
+    #[n(33)]
+    pub minfee_refscript_cost_per_byte: Option<UnitInterval>,
+}
 
 /// Propoped updates to the protocol params as [in the Haskell sources](https://github.com/IntersectMBO/cardano-ledger/blob/d30a7ae828e802e98277c82e278e570955afc273/eras/shelley/impl/src/Cardano/Ledger/Shelley/PParams.hs#L510-L511).
 pub type ProposedPPUpdates = BTreeMap<Bytes, PParamsUpdate>;
@@ -323,7 +391,6 @@ pub struct DRepVotingThresholds {
 /// in the Haskell sources.
 /// @todo: Encoding should be handled manually, Encode derive won't be correct.
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
-#[cbor(map)]
 pub struct ProtocolParam {
     #[n(0)]
     pub minfee_a: Option<u64>,
@@ -349,43 +416,43 @@ pub struct ProtocolParam {
     pub expansion_rate: Option<UnitInterval>,
     #[n(11)]
     pub treasury_growth_rate: Option<UnitInterval>,
-
-    #[n(16)]
+    #[n(12)]
+    pub protocol_version: Option<ProtocolVersion>,
+    #[n(13)]
     pub min_pool_cost: Option<Coin>,
-    #[n(17)]
+    #[n(14)]
     pub ada_per_utxo_byte: Option<Coin>,
-    #[n(18)]
+    #[n(15)]
     pub cost_models_for_script_languages: Option<CostModels>,
-    #[n(19)]
+    #[n(16)]
     pub execution_costs: Option<ExUnitPrices>,
-    #[n(20)]
+    #[n(17)]
     pub max_tx_ex_units: Option<ExUnits>,
-    #[n(21)]
+    #[n(18)]
     pub max_block_ex_units: Option<ExUnits>,
-    #[n(22)]
+    #[n(19)]
     pub max_value_size: Option<u64>,
-    #[n(23)]
+    #[n(20)]
     pub collateral_percentage: Option<u64>,
-    #[n(24)]
+    #[n(21)]
     pub max_collateral_inputs: Option<u64>,
-
-    #[n(25)]
+    #[n(22)]
     pub pool_voting_thresholds: Option<PoolVotingThresholds>,
-    #[n(26)]
+    #[n(23)]
     pub drep_voting_thresholds: Option<DRepVotingThresholds>,
-    #[n(27)]
+    #[n(24)]
     pub min_committee_size: Option<u64>,
-    #[n(28)]
+    #[n(25)]
     pub committee_term_limit: Option<Epoch>,
-    #[n(29)]
+    #[n(26)]
     pub governance_action_validity_period: Option<Epoch>,
-    #[n(30)]
+    #[n(27)]
     pub governance_action_deposit: Option<Coin>,
-    #[n(31)]
+    #[n(28)]
     pub drep_deposit: Option<Coin>,
-    #[n(32)]
+    #[n(29)]
     pub drep_inactivity_period: Option<Epoch>,
-    #[n(33)]
+    #[n(30)]
     pub minfee_refscript_cost_per_byte: Option<UnitInterval>,
 }
 
@@ -575,9 +642,9 @@ pub struct EnactState {
     #[n(1)]
     pub constitution: Constitution,
     #[n(2)]
-    pub cur_pparams: ProtocolParam,
+    pub cur_pparams: PParamsUpdate,
     #[n(3)]
-    pub prev_pparams: ProtocolParam,
+    pub prev_pparams: PParamsUpdate,
     #[n(4)]
     pub treasury: Coin,
     #[n(5)]
@@ -606,8 +673,8 @@ pub type DRepPulsingState = AnyCbor;
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum FuturePParams {
     NoPParamsUpdate,
-    DefinitePParamsUpdate(ProtocolParam),
-    PotentialPParamsUpdate(SMaybe<ProtocolParam>),
+    DefinitePParamsUpdate(PParamsUpdate),
+    PotentialPParamsUpdate(SMaybe<PParamsUpdate>),
 }
 
 /// Governance state as defined [in the Haskell sources](https://github.com/IntersectMBO/cardano-ledger/blob/d30a7ae828e802e98277c82e278e570955afc273/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs#L241-L256)
@@ -622,9 +689,9 @@ pub struct GovState {
     #[n(2)]
     pub constitution: Constitution,
     #[n(3)]
-    pub cur_pparams: ProtocolParam,
+    pub cur_pparams: PParamsUpdate,
     #[n(4)]
-    pub prev_pparams: ProtocolParam,
+    pub prev_pparams: PParamsUpdate,
     #[n(5)]
     pub future_pparams: FuturePParams,
     #[n(6)]

--- a/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
@@ -384,7 +384,8 @@ pub struct DRepVotingThresholds {
     pub treasury_withdrawal: UnitInterval,
 }
 
-/// Conway era protocol parameters.
+/// Conway era protocol parameters, corresponding to [`ConwayPParams`](https://github.com/IntersectMBO/cardano-ledger/blob/d30a7ae828e802e98277c82e278e570955afc273/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs#L512-L579)
+/// in the Haskell sources.
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct ProtocolParam {
     #[n(0)]

--- a/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
@@ -387,8 +387,7 @@ pub struct DRepVotingThresholds {
     pub treasury_withdrawal: UnitInterval,
 }
 
-/// Conway era protocol parameters, corresponding to [`ConwayPParams`](https://github.com/IntersectMBO/cardano-ledger/blob/d30a7ae828e802e98277c82e278e570955afc273/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs#L512-L579)
-/// in the Haskell sources.
+/// Conway era protocol parameters.
 /// @todo: Encoding should be handled manually, Encode derive won't be correct.
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct ProtocolParam {

--- a/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
@@ -77,9 +77,6 @@ pub type Credential = StakeAddr;
 
 /// Updates to the protocol params as [in the Haskell sources](https://github.com/IntersectMBO/cardano-ledger/blob/d30a7ae828e802e98277c82e278e570955afc273/libs/cardano-ledger-core/src/Cardano/Ledger/Core/PParams.hs#L151)
 /// (via [`EraPParams`](https://github.com/IntersectMBO/cardano-ledger/blob/d30a7ae828e802e98277c82e278e570955afc273/libs/cardano-ledger-core/src/Cardano/Ledger/Core/PParams.hs#L255-L258)).
-/// Conway era protocol parameters, corresponding to [`ConwayPParams`](https://github.com/IntersectMBO/cardano-ledger/blob/d30a7ae828e802e98277c82e278e570955afc273/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs#L512-L579)
-/// in the Haskell sources.
-/// @todo: Encoding should be handled manually, Encode derive won't be correct.
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 #[cbor(map)]
 pub struct PParamsUpdate {
@@ -388,7 +385,6 @@ pub struct DRepVotingThresholds {
 }
 
 /// Conway era protocol parameters.
-/// @todo: Encoding should be handled manually, Encode derive won't be correct.
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct ProtocolParam {
     #[n(0)]

--- a/pallas-network/tests/protocols.rs
+++ b/pallas-network/tests/protocols.rs
@@ -1,9 +1,12 @@
 use hex::FromHex;
-use pallas_codec::utils::{AnyCbor, AnyUInt, Bytes, KeyValuePairs, Nullable};
+use pallas_codec::utils::{
+    AnyCbor, AnyUInt, Bytes, CborWrap, KeyValuePairs, MaybeIndefArray, Nullable,
+};
 use pallas_crypto::hash::Hash;
 use pallas_network::miniprotocols::localstate::queries_v16::{
-    self, Addr, Addrs, ChainBlockNumber, Fraction, GenesisConfig, PoolMetadata, PoolParams,
-    RationalNumber, Relay, StakeAddr, StakeSnapshots, Stakes, SystemStart, UnitInterval, Value,
+    self, Addr, Addrs, ChainBlockNumber, Constr, DatumOption, Fraction, GenesisConfig, PlutusData,
+    PoolMetadata, PoolParams, RationalNumber, Relay, StakeAddr, StakeSnapshots, Stakes,
+    SystemStart, UnitInterval, Value,
 };
 use pallas_network::miniprotocols::localtxsubmission::SMaybe;
 use pallas_network::{
@@ -618,10 +621,21 @@ pub async fn local_state_query_server_and_client_happy_path() {
             let transaction_id = Hash::from(txbytes);
             let index = AnyUInt::MajorByte(2);
             let lovelace = AnyUInt::MajorByte(2);
-            //let hex_datum = "9118D81879189F18D81879189F1858181C18C918CF18711866181E185316189118BA";
-            //let datum = hex::decode(hex_datum).unwrap().into();
-            //let tag = TagWrap::<_, 24>::new(datum);
-            let inline_datum = None;
+            let datum_cbor = PlutusData::Constr(Constr {
+                fields: MaybeIndefArray::Indef(vec![
+                    PlutusData::Constr(Constr {
+                        fields: MaybeIndefArray::Indef(vec![PlutusData::BigInt(
+                            queries_v16::BigInt::Int(3764868539.into()),
+                        )]),
+                        tag: 121,
+                        any_constructor: None,
+                    }),
+                    PlutusData::BigInt(queries_v16::BigInt::Int(1733882006000.into())),
+                ]),
+                tag: 121,
+                any_constructor: None,
+            });
+            let inline_datum = Some(DatumOption::Data(CborWrap(datum_cbor)));
             let values =
                 queries_v16::TransactionOutput::Current(queries_v16::PostAlonsoTransactionOutput {
                     address: b"addr_test1vr80076l3x5uw6n94nwhgmv7ssgy6muzf47ugn6z0l92rhg2mgtu0"
@@ -644,7 +658,6 @@ pub async fn local_state_query_server_and_client_happy_path() {
             server.statequery().send_result(result).await.unwrap();
 
             // server receives query from client
-            /* commented out temporarily
             let query: Vec<u8> = match server.statequery().recv_while_acquired().await.unwrap() {
                 ClientQueryRequest::Query(q) => q.unwrap(),
                 x => panic!(
@@ -680,10 +693,21 @@ pub async fn local_state_query_server_and_client_happy_path() {
             let transaction_id_2 = Hash::from(txbytes);
             let index_2 = AnyUInt::MajorByte(0);
             let lovelace = AnyUInt::U32(1_792_960);
-            //let hex_datum = "D8799FD8799F1AE06755BBFF1B00000193B36BC9F0FF";
-            //let datum = hex::decode(hex_datum).unwrap().into();
-            //let tag = TagWrap::<_, 24>::new(datum);
-            let inline_datum = None;
+            let datum_cbor = PlutusData::Constr(Constr {
+                fields: MaybeIndefArray::Indef(vec![
+                    PlutusData::Constr(Constr {
+                        fields: MaybeIndefArray::Indef(vec![PlutusData::BigInt(
+                            queries_v16::BigInt::Int(3764868539.into()),
+                        )]),
+                        tag: 121,
+                        any_constructor: None,
+                    }),
+                    PlutusData::BigInt(queries_v16::BigInt::Int(1733882006000.into())),
+                ]),
+                tag: 121,
+                any_constructor: None,
+            });
+            let inline_datum = Some(DatumOption::Data(CborWrap(datum_cbor)));
             let values_2 = localstate::queries_v16::TransactionOutput::Current(
                 localstate::queries_v16::PostAlonsoTransactionOutput {
                     address: Bytes::from(
@@ -715,7 +739,6 @@ pub async fn local_state_query_server_and_client_happy_path() {
 
             let result = AnyCbor::from_encode(utxos);
             server.statequery().send_result(result).await.unwrap();
-            */
             // server receives query from client
 
             let query: queries_v16::Request =
@@ -757,6 +780,7 @@ pub async fn local_state_query_server_and_client_happy_path() {
                     numerator: 3,
                     denominator: 1000000,
                 }),
+                protocol_version: Some((10, 0)),
                 min_pool_cost: Some(AnyUInt::U32(340000000)),
                 ada_per_utxo_byte: Some(AnyUInt::U16(44)),
                 cost_models_for_script_languages: None,
@@ -1058,10 +1082,21 @@ pub async fn local_state_query_server_and_client_happy_path() {
         let transaction_id = Hash::from(txbytes);
         let index = AnyUInt::MajorByte(2);
         let lovelace = AnyUInt::MajorByte(2);
-        //let hex_datum = "9118D81879189F18D81879189F1858181C18C918CF18711866181E185316189118BA";
-        //let datum = hex::decode(hex_datum).unwrap().into();
-        //let tag = TagWrap::<_, 24>::new(datum);
-        let inline_datum = None;
+        let datum_cbor = PlutusData::Constr(Constr {
+            fields: MaybeIndefArray::Indef(vec![
+                PlutusData::Constr(Constr {
+                    fields: MaybeIndefArray::Indef(vec![PlutusData::BigInt(
+                        queries_v16::BigInt::Int(3764868539.into()),
+                    )]),
+                    tag: 121,
+                    any_constructor: None,
+                }),
+                PlutusData::BigInt(queries_v16::BigInt::Int(1733882006000.into())),
+            ]),
+            tag: 121,
+            any_constructor: None,
+        });
+        let inline_datum = Some(DatumOption::Data(CborWrap(datum_cbor)));
         let values =
             queries_v16::TransactionOutput::Current(queries_v16::PostAlonsoTransactionOutput {
                 address: b"addr_test1vr80076l3x5uw6n94nwhgmv7ssgy6muzf47ugn6z0l92rhg2mgtu0"
@@ -1081,7 +1116,6 @@ pub async fn local_state_query_server_and_client_happy_path() {
         )]);
 
         assert_eq!(result, utxo);
-        /* commented out temporarily
         let request = AnyCbor::from_encode(localstate::queries_v16::Request::LedgerQuery(
             localstate::queries_v16::LedgerQuery::BlockQuery(
                 6,
@@ -1108,7 +1142,6 @@ pub async fn local_state_query_server_and_client_happy_path() {
         .unwrap();
 
         assert_eq!(result, utxo);
-        */
         let request = AnyCbor::from_encode(queries_v16::Request::LedgerQuery(
             queries_v16::LedgerQuery::BlockQuery(5, queries_v16::BlockQuery::GetCurrentPParams),
         ));
@@ -1147,6 +1180,7 @@ pub async fn local_state_query_server_and_client_happy_path() {
                     numerator: 3,
                     denominator: 1000000,
                 }),
+                protocol_version: Some((10, 0)),
                 min_pool_cost: Some(AnyUInt::U32(340000000)),
                 ada_per_utxo_byte: Some(AnyUInt::U16(44)),
                 cost_models_for_script_languages: None,


### PR DESCRIPTION
Fix some localstate queries which are treating `PParamsUpdate` and `ProtocolParam` as the same type. The former describes (potential) updates to protocol parameters, the latter describes the current or previous set of protocol parameters.

With this change, the n2c localstate queries in the examples directory all succeed. Without it they were hitting decoding errors.