### PR TITLE
Use HTTPS url for cardano-blueprint submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cardano-blueprint"]
 	path = cardano-blueprint
-	url = git@github.com:cardano-scaling/cardano-blueprint
+	url = https://github.com/cardano-scaling/cardano-blueprint.git


### PR DESCRIPTION
I tried updating my project to depend on the latest and greatest pallas commit, and [the build started failing](https://github.com/hyperledger/firefly-cardano/actions/runs/14669906929/job/41174115507?pr=36) because of a permission error:
```
 git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```

IME, the easiest way to get around these kinds of errors is to use https urls for submodules. So, switch the project to do that.

I can confirm that this fixes my project's build.