### PR TITLE
feat: n2c local message submission and notification mini protocols

### DIFF
--- a/pallas-network/src/facades.rs
+++ b/pallas-network/src/facades.rs
@@ -13,11 +13,12 @@ use crate::miniprotocols::handshake::n2n::VersionData;
 use crate::miniprotocols::handshake::{n2c, n2n, Confirmation, VersionNumber, VersionTable};
 
 use crate::miniprotocols::{
-    blockfetch, chainsync, handshake, keepalive, localstate, localtxsubmission, peersharing,
-    txmonitor, txsubmission, PROTOCOL_N2C_CHAIN_SYNC, PROTOCOL_N2C_HANDSHAKE,
-    PROTOCOL_N2C_STATE_QUERY, PROTOCOL_N2C_TX_MONITOR, PROTOCOL_N2C_TX_SUBMISSION,
-    PROTOCOL_N2N_BLOCK_FETCH, PROTOCOL_N2N_CHAIN_SYNC, PROTOCOL_N2N_HANDSHAKE,
-    PROTOCOL_N2N_KEEP_ALIVE, PROTOCOL_N2N_PEER_SHARING, PROTOCOL_N2N_TX_SUBMISSION,
+    blockfetch, chainsync, handshake, keepalive, localmsgsubmission, localstate, localtxsubmission,
+    peersharing, txmonitor, txsubmission, PROTOCOL_N2C_CHAIN_SYNC, PROTOCOL_N2C_HANDSHAKE,
+    PROTOCOL_N2C_MSG_SUBMISSION, PROTOCOL_N2C_STATE_QUERY, PROTOCOL_N2C_TX_MONITOR,
+    PROTOCOL_N2C_TX_SUBMISSION, PROTOCOL_N2N_BLOCK_FETCH, PROTOCOL_N2N_CHAIN_SYNC,
+    PROTOCOL_N2N_HANDSHAKE, PROTOCOL_N2N_KEEP_ALIVE, PROTOCOL_N2N_PEER_SHARING,
+    PROTOCOL_N2N_TX_SUBMISSION,
 };
 
 use crate::multiplexer::{self, Bearer, RunningPlexer};
@@ -344,6 +345,7 @@ pub struct NodeClient {
     statequery: localstate::Client,
     submission: localtxsubmission::Client,
     monitor: txmonitor::Client,
+    msg_submission: localmsgsubmission::Client,
 }
 
 impl NodeClient {
@@ -355,6 +357,7 @@ impl NodeClient {
         let sq_channel = plexer.subscribe_client(PROTOCOL_N2C_STATE_QUERY);
         let tx_channel = plexer.subscribe_client(PROTOCOL_N2C_TX_SUBMISSION);
         let mo_channel = plexer.subscribe_client(PROTOCOL_N2C_TX_MONITOR);
+        let msg_channel = plexer.subscribe_client(PROTOCOL_N2C_MSG_SUBMISSION);
 
         let plexer = plexer.spawn();
 
@@ -365,6 +368,7 @@ impl NodeClient {
             statequery: localstate::Client::new(sq_channel),
             submission: localtxsubmission::Client::new(tx_channel),
             monitor: txmonitor::Client::new(mo_channel),
+            msg_submission: localmsgsubmission::Client::new(msg_channel),
         }
     }
 
@@ -475,6 +479,10 @@ impl NodeClient {
 
     pub fn monitor(&mut self) -> &mut txmonitor::Client {
         &mut self.monitor
+    }
+
+    pub fn msg_submission(&mut self) -> &mut localmsgsubmission::Client {
+        &mut self.msg_submission
     }
 
     pub async fn abort(self) {

--- a/pallas-network/src/facades.rs
+++ b/pallas-network/src/facades.rs
@@ -490,6 +490,7 @@ pub struct NodeServer {
     pub handshake: handshake::N2CServer,
     pub chainsync: chainsync::N2CServer,
     pub statequery: localstate::Server,
+    pub localtxsubmission: localtxsubmission::Server,
     accepted_address: Option<UnixSocketAddr>,
     accpeted_version: Option<(VersionNumber, n2c::VersionData)>,
 }
@@ -502,10 +503,12 @@ impl NodeServer {
         let hs_channel = plexer.subscribe_server(PROTOCOL_N2C_HANDSHAKE);
         let cs_channel = plexer.subscribe_server(PROTOCOL_N2C_CHAIN_SYNC);
         let sq_channel = plexer.subscribe_server(PROTOCOL_N2C_STATE_QUERY);
+        let localtx_channel = plexer.subscribe_server(PROTOCOL_N2C_TX_SUBMISSION);
 
         let server_hs = handshake::Server::<n2c::VersionData>::new(hs_channel);
         let server_cs = chainsync::N2CServer::new(cs_channel);
         let server_sq = localstate::Server::new(sq_channel);
+        let server_localtx = localtxsubmission::Server::new(localtx_channel);
 
         let plexer = plexer.spawn();
 
@@ -514,6 +517,7 @@ impl NodeServer {
             handshake: server_hs,
             chainsync: server_cs,
             statequery: server_sq,
+            localtxsubmission: server_localtx,
             accepted_address: None,
             accpeted_version: None,
         }
@@ -552,6 +556,10 @@ impl NodeServer {
 
     pub fn statequery(&mut self) -> &mut localstate::Server {
         &mut self.statequery
+    }
+
+    pub fn localtxsubmission(&mut self) -> &mut localtxsubmission::Server {
+        &mut self.localtxsubmission
     }
 
     pub fn accepted_address(&self) -> Option<&UnixSocketAddr> {

--- a/pallas-network/src/facades.rs
+++ b/pallas-network/src/facades.rs
@@ -717,6 +717,7 @@ pub struct DmqServer {
     pub plexer: RunningPlexer,
     pub handshake: handshake::N2CServer,
     pub msg_notification: localmsgnotification::Server,
+    pub msg_submission: localmsgsubmission::Server,
     accepted_address: Option<UnixSocketAddr>,
     accpeted_version: Option<(VersionNumber, n2c::VersionData)>,
 }
@@ -728,9 +729,11 @@ impl DmqServer {
 
         let hs_channel = plexer.subscribe_server(PROTOCOL_N2C_HANDSHAKE);
         let msg_notification_channel = plexer.subscribe_server(PROTOCOL_N2C_MSG_NOTIFICATION);
+        let msg_submission_channel = plexer.subscribe_server(PROTOCOL_N2C_MSG_SUBMISSION);
 
         let server_hs = handshake::Server::<n2c::VersionData>::new(hs_channel);
         let server_msg_notification = localmsgnotification::Server::new(msg_notification_channel);
+        let server_msg_submission = localmsgsubmission::Server::new(msg_submission_channel);
 
         let plexer = plexer.spawn();
 
@@ -738,6 +741,7 @@ impl DmqServer {
             plexer,
             handshake: server_hs,
             msg_notification: server_msg_notification,
+            msg_submission: server_msg_submission,
             accepted_address: None,
             accpeted_version: None,
         }
@@ -772,6 +776,10 @@ impl DmqServer {
 
     pub fn msg_notification(&mut self) -> &mut localmsgnotification::Server {
         &mut self.msg_notification
+    }
+
+    pub fn msg_submission(&mut self) -> &mut localmsgsubmission::Server {
+        &mut self.msg_submission
     }
 
     pub fn accepted_address(&self) -> Option<&UnixSocketAddr> {

--- a/pallas-network/src/facades.rs
+++ b/pallas-network/src/facades.rs
@@ -588,3 +588,215 @@ impl NodeServer {
         self.plexer.abort().await
     }
 }
+
+/// Client of N2C DMQ (Decentralized Message Queue)
+///
+/// Described in [CIP-0137](https://github.com/cardano-scaling/CIPs/tree/master/CIP-0137)
+pub struct DmqClient {
+    plexer: RunningPlexer,
+    handshake: handshake::N2CClient,
+    msg_submission: localmsgsubmission::Client,
+    msg_notification: localmsgnotification::Client,
+}
+
+impl DmqClient {
+    pub fn new(bearer: Bearer) -> Self {
+        let mut plexer = multiplexer::Plexer::new(bearer);
+
+        let hs_channel = plexer.subscribe_client(PROTOCOL_N2C_HANDSHAKE);
+        let msg_submission_channel = plexer.subscribe_client(PROTOCOL_N2C_MSG_SUBMISSION);
+        let msg_notification_channel = plexer.subscribe_client(PROTOCOL_N2C_MSG_NOTIFICATION);
+
+        let plexer = plexer.spawn();
+
+        Self {
+            plexer,
+            handshake: handshake::Client::new(hs_channel),
+            msg_submission: localmsgsubmission::Client::new(msg_submission_channel),
+            msg_notification: localmsgnotification::Client::new(msg_notification_channel),
+        }
+    }
+
+    #[cfg(unix)]
+    pub async fn connect(path: impl AsRef<Path>, magic: u64) -> Result<Self, Error> {
+        let bearer = Bearer::connect_unix(path)
+            .await
+            .map_err(Error::ConnectFailure)?;
+
+        let mut client = Self::new(bearer);
+
+        let versions = handshake::n2c::VersionTable::v10_and_above(magic);
+
+        let handshake = client
+            .handshake()
+            .handshake(versions)
+            .await
+            .map_err(Error::HandshakeProtocol)?;
+
+        if let handshake::Confirmation::Rejected(reason) = handshake {
+            error!(?reason, "handshake refused");
+            return Err(Error::IncompatibleVersion);
+        }
+
+        Ok(client)
+    }
+
+    #[cfg(windows)]
+    pub async fn connect(
+        pipe_name: impl AsRef<std::ffi::OsStr>,
+        magic: u64,
+    ) -> Result<Self, Error> {
+        let pipe_name = pipe_name.as_ref().to_os_string();
+
+        let bearer = tokio::task::spawn_blocking(move || Bearer::connect_named_pipe(pipe_name))
+            .await
+            .expect("can't join tokio thread")
+            .map_err(Error::ConnectFailure)?;
+
+        let mut client = Self::new(bearer);
+
+        let versions = handshake::n2c::VersionTable::v10_and_above(magic);
+
+        let handshake = client
+            .handshake()
+            .handshake(versions)
+            .await
+            .map_err(Error::HandshakeProtocol)?;
+
+        if let handshake::Confirmation::Rejected(reason) = handshake {
+            error!(?reason, "handshake refused");
+            return Err(Error::IncompatibleVersion);
+        }
+
+        Ok(client)
+    }
+
+    #[cfg(unix)]
+    pub async fn handshake_query(
+        bearer: Bearer,
+        magic: u64,
+    ) -> Result<handshake::n2c::VersionTable, Error> {
+        let mut plexer = multiplexer::Plexer::new(bearer);
+
+        let hs_channel = plexer.subscribe_client(PROTOCOL_N2C_HANDSHAKE);
+
+        let plexer = plexer.spawn();
+
+        let versions = handshake::n2c::VersionTable::v15_with_query(magic);
+        let mut client = handshake::Client::new(hs_channel);
+
+        let handshake = client
+            .handshake(versions)
+            .await
+            .map_err(Error::HandshakeProtocol)?;
+
+        match handshake {
+            Confirmation::Accepted(_, _) => {
+                error!("handshake accepted when we expected query reply");
+                Err(Error::HandshakeProtocol(handshake::Error::InvalidInbound))
+            }
+            Confirmation::Rejected(reason) => {
+                error!(?reason, "handshake refused");
+                Err(Error::IncompatibleVersion)
+            }
+            Confirmation::QueryReply(version_table) => {
+                plexer.abort().await;
+                Ok(version_table)
+            }
+        }
+    }
+
+    pub fn handshake(&mut self) -> &mut handshake::N2CClient {
+        &mut self.handshake
+    }
+
+    pub fn msg_submission(&mut self) -> &mut localmsgsubmission::Client {
+        &mut self.msg_submission
+    }
+
+    pub fn msg_notification(&mut self) -> &mut localmsgnotification::Client {
+        &mut self.msg_notification
+    }
+
+    pub async fn abort(self) {
+        self.plexer.abort().await
+    }
+}
+
+/// Server of N2C DMQ (Decentralized Message Queue)
+///
+/// Described in [CIP-0137](https://github.com/cardano-scaling/CIPs/tree/master/CIP-0137)
+#[cfg(unix)]
+pub struct DmqServer {
+    pub plexer: RunningPlexer,
+    pub handshake: handshake::N2CServer,
+    pub msg_notification: localmsgnotification::Server,
+    accepted_address: Option<UnixSocketAddr>,
+    accpeted_version: Option<(VersionNumber, n2c::VersionData)>,
+}
+
+#[cfg(unix)]
+impl DmqServer {
+    pub async fn new(bearer: Bearer) -> Self {
+        let mut plexer = multiplexer::Plexer::new(bearer);
+
+        let hs_channel = plexer.subscribe_server(PROTOCOL_N2C_HANDSHAKE);
+        let msg_notification_channel = plexer.subscribe_server(PROTOCOL_N2C_MSG_NOTIFICATION);
+
+        let server_hs = handshake::Server::<n2c::VersionData>::new(hs_channel);
+        let server_msg_notification = localmsgnotification::Server::new(msg_notification_channel);
+
+        let plexer = plexer.spawn();
+
+        Self {
+            plexer,
+            handshake: server_hs,
+            msg_notification: server_msg_notification,
+            accepted_address: None,
+            accpeted_version: None,
+        }
+    }
+
+    pub async fn accept(listener: &UnixListener, magic: u64) -> Result<Self, Error> {
+        let (bearer, address) = Bearer::accept_unix(listener)
+            .await
+            .map_err(Error::ConnectFailure)?;
+
+        let mut client = Self::new(bearer).await;
+
+        let accepted_version = client
+            .handshake()
+            .handshake(n2c::VersionTable::v10_and_above(magic))
+            .await
+            .map_err(Error::HandshakeProtocol)?;
+
+        if let Some(version) = accepted_version {
+            client.accepted_address = Some(address);
+            client.accpeted_version = Some(version);
+            Ok(client)
+        } else {
+            client.abort().await;
+            Err(Error::IncompatibleVersion)
+        }
+    }
+
+    pub fn handshake(&mut self) -> &mut handshake::N2CServer {
+        &mut self.handshake
+    }
+
+    pub fn msg_notification(&mut self) -> &mut localmsgnotification::Server {
+        &mut self.msg_notification
+    }
+
+    pub fn accepted_address(&self) -> Option<&UnixSocketAddr> {
+        self.accepted_address.as_ref()
+    }
+
+    pub fn accepted_version(&self) -> Option<&(u64, n2c::VersionData)> {
+        self.accpeted_version.as_ref()
+    }
+
+    pub async fn abort(self) {
+        self.plexer.abort().await
+    }
+}

--- a/pallas-network/src/facades.rs
+++ b/pallas-network/src/facades.rs
@@ -569,7 +569,7 @@ impl NodeServer {
 
 /// Client of N2C DMQ (Decentralized Message Queue)
 ///
-/// Described in [CIP-0137](https://github.com/cardano-scaling/CIPs/tree/master/CIP-0137)
+/// Described in [CIP-0137](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0137)
 pub struct DmqClient {
     plexer: RunningPlexer,
     handshake: handshake::N2CClient,
@@ -703,7 +703,7 @@ impl DmqClient {
 
 /// Server of N2C DMQ (Decentralized Message Queue)
 ///
-/// Described in [CIP-0137](https://github.com/cardano-scaling/CIPs/tree/master/CIP-0137)
+/// Described in [CIP-0137](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0137)
 #[cfg(unix)]
 pub struct DmqServer {
     pub plexer: RunningPlexer,

--- a/pallas-network/src/miniprotocols/README.md
+++ b/pallas-network/src/miniprotocols/README.md
@@ -13,7 +13,7 @@ The following architectural decisions were made for this particular Rust impleme
 ## Development Status
 
 | mini-protocol                               | initiator | responder |
-| ------------------------------------------- |-----------| --------- |
+| ------------------------------------------- | --------- | --------- |
 | block-fetch                                 | done      | planned   |
 | chain-sync                                  | done      | planned   |
 | [handshake](src/handshake/README.md)        | done      | done      |
@@ -21,6 +21,7 @@ The following architectural decisions were made for this particular Rust impleme
 | [tx-submission](src/txsubmission/README.md) | done      | done      |
 | local tx monitor                            | done      | planned   |
 | local-tx-submission                         | done      | planned   |
+| local-msg-submission                        | done      | planned   |
 
 ## Implementation Details
 
@@ -73,7 +74,7 @@ let mut muxer = Multiplexer::setup(bearer, &[0]).unwrap();
 // get a handle for the (client-side) handhsake mini-protocol handle
 let mut channel = muxer.use_client_channel(pallas_miniprotocols::PROTOCOL_N2N_HANDSHAKE);
 
-// create a handshake client agent with an initial state 
+// create a handshake client agent with an initial state
 let agent = handshake::Client::initial(VersionTable::v4_and_above(MAINNET_MAGIC));
 
 // run the agent, which internally executes all the transitions

--- a/pallas-network/src/miniprotocols/README.md
+++ b/pallas-network/src/miniprotocols/README.md
@@ -22,6 +22,7 @@ The following architectural decisions were made for this particular Rust impleme
 | local tx monitor                            | done      | planned   |
 | local-tx-submission                         | done      | planned   |
 | local-msg-submission                        | done      | planned   |
+| local-msg-notification                      | done      | done      |
 
 ## Implementation Details
 

--- a/pallas-network/src/miniprotocols/README.md
+++ b/pallas-network/src/miniprotocols/README.md
@@ -20,8 +20,8 @@ The following architectural decisions were made for this particular Rust impleme
 | local-state                                 | done      | planned   |
 | [tx-submission](src/txsubmission/README.md) | done      | done      |
 | local tx monitor                            | done      | planned   |
-| local-tx-submission                         | done      | planned   |
-| local-msg-submission                        | done      | planned   |
+| local-tx-submission                         | done      | done      |
+| local-msg-submission                        | done      | done      |
 | local-msg-notification                      | done      | done      |
 
 ## Implementation Details

--- a/pallas-network/src/miniprotocols/common.rs
+++ b/pallas-network/src/miniprotocols/common.rs
@@ -74,6 +74,11 @@ pub const PROTOCOL_N2C_TX_MONITOR: u16 = 9;
 // TODO: use the final mini-protocol number once available
 pub const PROTOCOL_N2C_MSG_SUBMISSION: u16 = 1;
 
+/// Protocol channel number for node-to-client local message notification
+/// This protocol is available only on the DMQ node.
+// TODO: use the final mini-protocol number once available
+pub const PROTOCOL_N2C_MSG_NOTIFICATION: u16 = 2;
+
 /// A point within a chain
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub enum Point {

--- a/pallas-network/src/miniprotocols/common.rs
+++ b/pallas-network/src/miniprotocols/common.rs
@@ -69,6 +69,11 @@ pub const PROTOCOL_N2C_STATE_QUERY: u16 = 7;
 // Protocol channel number for node-to-client mempool monitor
 pub const PROTOCOL_N2C_TX_MONITOR: u16 = 9;
 
+/// Protocol channel number for node-to-client local message submission
+/// This protocol is available only on the DMQ node.
+// TODO: use the final mini-protocol number once available
+pub const PROTOCOL_N2C_MSG_SUBMISSION: u16 = 1;
+
 /// A point within a chain
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub enum Point {

--- a/pallas-network/src/miniprotocols/localmsgnotification/README.md
+++ b/pallas-network/src/miniprotocols/localmsgnotification/README.md
@@ -4,4 +4,4 @@
 
 The local message notification mini-protocol is used to receive messages from a local DMQ node.
 
-The full protocol is defined in the [CIP-0137](https://github.com/cardano-scaling/CIPs/tree/master/CIP-0137#local-message-notification-mini-protocol).
+The full protocol is defined in the [CIP-0137](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0137#local-message-notification-mini-protocol).

--- a/pallas-network/src/miniprotocols/localmsgnotification/README.md
+++ b/pallas-network/src/miniprotocols/localmsgnotification/README.md
@@ -1,0 +1,7 @@
+# LocalMsgNotification
+
+:warning: This is a work in progress and not yet fully implemented.
+
+The local message notification mini-protocol is used to receive messages from a local DMQ node.
+
+The full protocol is defined in the [CIP-0137](https://github.com/cardano-scaling/CIPs/tree/master/CIP-0137#local-message-notification-mini-protocol).

--- a/pallas-network/src/miniprotocols/localmsgnotification/client.rs
+++ b/pallas-network/src/miniprotocols/localmsgnotification/client.rs
@@ -1,0 +1,136 @@
+use pallas_codec::Fragment;
+
+use crate::{miniprotocols::localmsgsubmission::DmqMsg, multiplexer};
+
+use super::{protocol::Error, Message, State};
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Reply(pub Vec<DmqMsg>, pub bool);
+
+/// The DMQ client side of the local message notification protocol.
+pub struct Client(State, multiplexer::ChannelBuffer)
+where
+    Message: Fragment;
+
+impl Client
+where
+    Message: Fragment,
+{
+    pub fn new(channel: multiplexer::AgentChannel) -> Self {
+        Self(State::Idle, multiplexer::ChannelBuffer::new(channel))
+    }
+
+    pub fn state(&self) -> &State {
+        &self.0
+    }
+
+    pub fn is_done(&self) -> bool {
+        self.0 == State::Done
+    }
+
+    fn has_agency(&self) -> bool {
+        matches!(self.state(), State::Idle)
+    }
+
+    fn assert_agency_is_ours(&self) -> Result<(), Error> {
+        if !self.has_agency() {
+            Err(Error::AgencyIsTheirs)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn assert_agency_is_theirs(&self) -> Result<(), Error> {
+        if self.has_agency() {
+            Err(Error::AgencyIsOurs)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// As a client in a specific state, am I allowed to send this message?
+    fn assert_outbound_state(&self, msg: &Message) -> Result<(), Error> {
+        match (&self.0, msg) {
+            (State::Idle, Message::RequestMessagesNonBlocking) => Ok(()),
+            (State::Idle, Message::RequestMessagesBlocking) => Ok(()),
+            (State::Idle, Message::ClientDone) => Ok(()),
+            _ => Err(Error::InvalidOutbound),
+        }
+    }
+
+    /// As a client in a specific state, am I allowed to receive this message?
+    fn assert_inbound_state(&self, msg: &Message) -> Result<(), Error> {
+        match (&self.0, msg) {
+            (State::BusyNonBlocking, Message::ReplyMessagesNonBlocking(..)) => Ok(()),
+            (State::BusyBlocking, Message::ReplyMessagesBlocking(..)) => Ok(()),
+            _ => Err(Error::InvalidInbound),
+        }
+    }
+
+    pub async fn send_message(&mut self, msg: &Message) -> Result<(), Error> {
+        self.assert_agency_is_ours()?;
+        self.assert_outbound_state(msg)?;
+        self.1.send_msg_chunks(msg).await.map_err(Error::Plexer)?;
+
+        Ok(())
+    }
+
+    pub async fn recv_message(&mut self) -> Result<Message, Error> {
+        self.assert_agency_is_theirs()?;
+        let msg = self.1.recv_full_msg().await.map_err(Error::Plexer)?;
+        self.assert_inbound_state(&msg)?;
+
+        Ok(msg)
+    }
+
+    pub async fn send_request_messages_non_blocking(&mut self) -> Result<(), Error> {
+        let msg = Message::RequestMessagesNonBlocking;
+        self.send_message(&msg).await?;
+        self.0 = State::BusyNonBlocking;
+
+        Ok(())
+    }
+
+    pub async fn send_request_messages_blocking(&mut self) -> Result<(), Error> {
+        let msg = Message::RequestMessagesBlocking;
+        self.send_message(&msg).await?;
+        self.0 = State::BusyBlocking;
+
+        Ok(())
+    }
+
+    pub async fn recv_next_reply(&mut self) -> Result<Reply, Error> {
+        match self.recv_message().await? {
+            Message::ReplyMessagesNonBlocking(msgs, has_more) => {
+                self.0 = State::Idle;
+
+                Ok(Reply(msgs, has_more))
+            }
+            Message::ReplyMessagesBlocking(msgs) => {
+                self.0 = State::Idle;
+
+                Ok(Reply(msgs, false))
+            }
+            _ => Err(Error::InvalidInbound),
+        }
+    }
+
+    pub async fn recv_done(&mut self) -> Result<(), Error> {
+        match self.recv_message().await? {
+            Message::ServerDone => {
+                self.0 = State::Done;
+
+                Ok(())
+            }
+            _ => Err(Error::InvalidInbound),
+        }
+    }
+
+    pub async fn send_done(&mut self) -> Result<(), Error> {
+        let msg = Message::ClientDone;
+        self.send_message(&msg).await?;
+        self.0 = State::Done;
+
+        Ok(())
+    }
+}

--- a/pallas-network/src/miniprotocols/localmsgnotification/codec.rs
+++ b/pallas-network/src/miniprotocols/localmsgnotification/codec.rs
@@ -1,0 +1,75 @@
+use pallas_codec::minicbor::{decode, encode, Decode, Decoder, Encode, Encoder};
+
+use super::Message;
+
+impl Encode<()> for Message {
+    fn encode<W: encode::Write>(
+        &self,
+        e: &mut Encoder<W>,
+        _ctx: &mut (),
+    ) -> Result<(), encode::Error<W::Error>> {
+        match self {
+            Message::RequestMessagesNonBlocking => {
+                e.array(1)?.u16(0)?;
+                Ok(())
+            }
+            Message::ReplyMessagesNonBlocking(msgs, has_more) => {
+                e.array(3)?.u16(1)?;
+                e.begin_array()?;
+                for msg in msgs {
+                    e.encode(msg)?;
+                }
+                e.end()?;
+                e.bool(*has_more)?;
+                Ok(())
+            }
+            Message::RequestMessagesBlocking => {
+                e.array(1)?.u16(2)?;
+                Ok(())
+            }
+            Message::ReplyMessagesBlocking(msgs) => {
+                e.array(3)?.u16(3)?;
+                e.begin_array()?;
+                for msg in msgs {
+                    e.encode(msg)?;
+                }
+                e.end()?;
+                Ok(())
+            }
+            Message::ClientDone => {
+                e.array(1)?.u16(4)?;
+                Ok(())
+            }
+            Message::ServerDone => {
+                e.array(1)?.u16(5)?;
+                Ok(())
+            }
+        }
+    }
+}
+
+impl<'b> Decode<'b, ()> for Message {
+    fn decode(d: &mut Decoder<'b>, _ctx: &mut ()) -> Result<Self, decode::Error> {
+        d.array()?;
+        let label = d.u16()?;
+
+        match label {
+            0 => Ok(Message::RequestMessagesNonBlocking),
+            1 => {
+                let msgs = d.decode()?;
+                let has_more = d.bool()?;
+                Ok(Message::ReplyMessagesNonBlocking(msgs, has_more))
+            }
+            2 => Ok(Message::RequestMessagesBlocking),
+            3 => {
+                let msgs = d.decode()?;
+                Ok(Message::ReplyMessagesBlocking(msgs))
+            }
+            4 => Ok(Message::ClientDone),
+            5 => Ok(Message::ServerDone),
+            _ => Err(decode::Error::message(
+                "unknown variant for localmsgsubmission message",
+            )),
+        }
+    }
+}

--- a/pallas-network/src/miniprotocols/localmsgnotification/mod.rs
+++ b/pallas-network/src/miniprotocols/localmsgnotification/mod.rs
@@ -1,0 +1,8 @@
+mod client;
+mod codec;
+mod protocol;
+mod server;
+
+pub use client::*;
+pub use protocol::*;
+pub use server::*;

--- a/pallas-network/src/miniprotocols/localmsgnotification/protocol.rs
+++ b/pallas-network/src/miniprotocols/localmsgnotification/protocol.rs
@@ -1,0 +1,43 @@
+use thiserror::Error;
+
+use crate::miniprotocols::localmsgsubmission::DmqMsg;
+use crate::multiplexer;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("attempted to receive message while agency is ours")]
+    AgencyIsOurs,
+
+    #[error("attempted to send message while agency is theirs")]
+    AgencyIsTheirs,
+
+    #[error("inbound message is not valid for current state")]
+    InvalidInbound,
+
+    #[error("outbound message is not valid for current state")]
+    InvalidOutbound,
+
+    #[error("protocol is already initialized, no need to wait for init message")]
+    AlreadyInitialized,
+
+    #[error("error while sending or receiving data through the channel")]
+    Plexer(multiplexer::Error),
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum State {
+    Idle,
+    BusyBlocking,
+    BusyNonBlocking,
+    Done,
+}
+
+#[derive(Debug)]
+pub enum Message {
+    RequestMessagesNonBlocking,
+    ReplyMessagesNonBlocking(Vec<DmqMsg>, bool),
+    RequestMessagesBlocking,
+    ReplyMessagesBlocking(Vec<DmqMsg>),
+    ClientDone,
+    ServerDone,
+}

--- a/pallas-network/src/miniprotocols/localmsgnotification/server.rs
+++ b/pallas-network/src/miniprotocols/localmsgnotification/server.rs
@@ -1,0 +1,143 @@
+use pallas_codec::Fragment;
+
+use crate::{miniprotocols::localmsgsubmission::DmqMsg, multiplexer};
+
+use super::{protocol::Error, Message, State};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Request {
+    NonBlocking,
+    Blocking,
+}
+
+/// The DMQ server side of the local message notification protocol.
+pub struct Server(State, multiplexer::ChannelBuffer)
+where
+    Message: Fragment;
+
+impl Server
+where
+    Message: Fragment,
+{
+    pub fn new(channel: multiplexer::AgentChannel) -> Self {
+        Self(State::Idle, multiplexer::ChannelBuffer::new(channel))
+    }
+
+    pub fn state(&self) -> &State {
+        &self.0
+    }
+
+    pub fn is_done(&self) -> bool {
+        self.0 == State::Done
+    }
+
+    fn has_agency(&self) -> bool {
+        !matches!(self.state(), State::Idle)
+    }
+
+    fn assert_agency_is_ours(&self) -> Result<(), Error> {
+        if !self.has_agency() {
+            Err(Error::AgencyIsTheirs)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn assert_agency_is_theirs(&self) -> Result<(), Error> {
+        if self.has_agency() {
+            Err(Error::AgencyIsOurs)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// As a server in a specific state, am I allowed to send this message?
+    fn assert_outbound_state(&self, msg: &Message) -> Result<(), Error> {
+        match (&self.0, msg) {
+            (State::BusyNonBlocking, Message::ReplyMessagesNonBlocking(..)) => Ok(()),
+            (State::BusyBlocking, Message::ReplyMessagesBlocking(..)) => Ok(()),
+            _ => Err(Error::InvalidInbound),
+        }
+    }
+
+    /// As a server in a specific state, am I allowed to receive this message?
+    fn assert_inbound_state(&self, msg: &Message) -> Result<(), Error> {
+        match (&self.0, msg) {
+            (State::Idle, Message::RequestMessagesNonBlocking) => Ok(()),
+            (State::Idle, Message::RequestMessagesBlocking) => Ok(()),
+            (State::Idle, Message::ClientDone) => Ok(()),
+            _ => Err(Error::InvalidOutbound),
+        }
+    }
+
+    pub async fn send_message(&mut self, msg: &Message) -> Result<(), Error> {
+        self.assert_agency_is_ours()?;
+        self.assert_outbound_state(msg)?;
+        self.1.send_msg_chunks(msg).await.map_err(Error::Plexer)?;
+
+        Ok(())
+    }
+
+    pub async fn recv_message(&mut self) -> Result<Message, Error> {
+        self.assert_agency_is_theirs()?;
+        let msg = self.1.recv_full_msg().await.map_err(Error::Plexer)?;
+        self.assert_inbound_state(&msg)?;
+
+        Ok(msg)
+    }
+
+    pub async fn send_reply_messages_non_blocking(
+        &mut self,
+        msgs: Vec<DmqMsg>,
+        has_more: bool,
+    ) -> Result<(), Error> {
+        let msg = Message::ReplyMessagesNonBlocking(msgs, has_more);
+        self.send_message(&msg).await?;
+        self.0 = State::Idle;
+
+        Ok(())
+    }
+
+    pub async fn send_reply_messages_blocking(&mut self, msgs: Vec<DmqMsg>) -> Result<(), Error> {
+        let msg = Message::ReplyMessagesBlocking(msgs);
+        self.send_message(&msg).await?;
+        self.0 = State::Idle;
+
+        Ok(())
+    }
+
+    pub async fn recv_next_request(&mut self) -> Result<Request, Error> {
+        match self.recv_message().await? {
+            Message::RequestMessagesNonBlocking => {
+                self.0 = State::BusyNonBlocking;
+
+                Ok(Request::NonBlocking)
+            }
+            Message::RequestMessagesBlocking => {
+                self.0 = State::BusyBlocking;
+
+                Ok(Request::Blocking)
+            }
+            _ => Err(Error::InvalidInbound),
+        }
+    }
+
+    pub async fn recv_done(&mut self) -> Result<(), Error> {
+        match self.recv_message().await? {
+            Message::ClientDone => {
+                self.0 = State::Done;
+
+                Ok(())
+            }
+            _ => Err(Error::InvalidInbound),
+        }
+    }
+
+    pub async fn send_done(&mut self) -> Result<(), Error> {
+        let msg = Message::ServerDone;
+        self.send_message(&msg).await?;
+        self.0 = State::Done;
+
+        Ok(())
+    }
+}

--- a/pallas-network/src/miniprotocols/localmsgsubmission/README.md
+++ b/pallas-network/src/miniprotocols/localmsgsubmission/README.md
@@ -4,6 +4,6 @@
 
 The local message submission mini-protocol is used to submit messages to a local DMQ node.
 
-The full protocol is defined in the [CIP-0137](https://github.com/cardano-scaling/CIPs/tree/master/CIP-0137#local-message-submission-mini-protocol).
+The full protocol is defined in the [CIP-0137](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0137#local-message-submission-mini-protocol).
 
 Note: the implementation of this mini-protocol is based on the local transaction submission protocol generic implementation.

--- a/pallas-network/src/miniprotocols/localmsgsubmission/README.md
+++ b/pallas-network/src/miniprotocols/localmsgsubmission/README.md
@@ -1,0 +1,9 @@
+# LocalMsgSubmission
+
+:warning: This is a work in progress and not yet fully implemented.
+
+The local message submission mini-protocol is used to submit messages to a local DMQ node.
+
+The full protocol is defined in the [CIP-0137](https://github.com/cardano-scaling/CIPs/tree/master/CIP-0137#local-message-submission-mini-protocol).
+
+Note: the implementation of this mini-protocol is based on the local transaction submission protocol generic implementation.

--- a/pallas-network/src/miniprotocols/localmsgsubmission/client.rs
+++ b/pallas-network/src/miniprotocols/localmsgsubmission/client.rs
@@ -1,0 +1,6 @@
+use crate::miniprotocols::localtxsubmission::GenericClient;
+
+use super::{DmqMsg, DmqMsgValidationError};
+
+/// DMQ specific instantiation of LocalTxSubmission client.
+pub type Client = GenericClient<DmqMsg, DmqMsgValidationError>;

--- a/pallas-network/src/miniprotocols/localmsgsubmission/codec.rs
+++ b/pallas-network/src/miniprotocols/localmsgsubmission/codec.rs
@@ -1,0 +1,59 @@
+use pallas_codec::minicbor::{decode, encode, Decode, Decoder, Encode, Encoder};
+
+use super::{DmqMsg, DmqMsgValidationError};
+
+impl<'b> Decode<'b, ()> for DmqMsg {
+    fn decode(d: &mut Decoder<'b>, _ctx: &mut ()) -> Result<Self, decode::Error> {
+        d.array()?;
+        let msg_id = d.bytes()?.to_vec();
+        let msg_body = d.bytes()?.to_vec();
+        let block_number = d.u32()?;
+        let ttl = d.u16()?;
+        let kes_signature = d.bytes()?.to_vec();
+        let operational_certificate = d.bytes()?.to_vec();
+        Ok(DmqMsg {
+            msg_id,
+            msg_body,
+            block_number,
+            ttl,
+            kes_signature,
+            operational_certificate,
+        })
+    }
+}
+
+impl Encode<()> for DmqMsg {
+    fn encode<W: encode::Write>(
+        &self,
+        e: &mut Encoder<W>,
+        _ctx: &mut (),
+    ) -> Result<(), encode::Error<W::Error>> {
+        e.array(6)?;
+        e.bytes(&self.msg_id)?;
+        e.bytes(&self.msg_body)?;
+        e.u32(self.block_number)?;
+        e.u16(self.ttl)?;
+        e.bytes(&self.kes_signature)?;
+        e.bytes(&self.operational_certificate)?;
+
+        Ok(())
+    }
+}
+
+impl<'b, C> Decode<'b, C> for DmqMsgValidationError {
+    fn decode(d: &mut Decoder<'b>, _ctx: &mut C) -> Result<Self, decode::Error> {
+        Ok(DmqMsgValidationError(d.str()?.to_string()))
+    }
+}
+
+impl<C> Encode<C> for DmqMsgValidationError {
+    fn encode<W: encode::Write>(
+        &self,
+        e: &mut Encoder<W>,
+        _ctx: &mut C,
+    ) -> Result<(), encode::Error<W::Error>> {
+        e.str(&self.0)?;
+
+        Ok(())
+    }
+}

--- a/pallas-network/src/miniprotocols/localmsgsubmission/mod.rs
+++ b/pallas-network/src/miniprotocols/localmsgsubmission/mod.rs
@@ -1,6 +1,8 @@
 pub use client::*;
 pub use protocol::*;
+pub use server::*;
 
 mod client;
 mod codec;
 mod protocol;
+mod server;

--- a/pallas-network/src/miniprotocols/localmsgsubmission/mod.rs
+++ b/pallas-network/src/miniprotocols/localmsgsubmission/mod.rs
@@ -1,0 +1,6 @@
+pub use client::*;
+pub use protocol::*;
+
+mod client;
+mod codec;
+mod protocol;

--- a/pallas-network/src/miniprotocols/localmsgsubmission/protocol.rs
+++ b/pallas-network/src/miniprotocols/localmsgsubmission/protocol.rs
@@ -1,0 +1,31 @@
+/// The bytes of a message to be submitted to the local message submission protocol.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DmqMsg {
+    /// The message id.
+    pub msg_id: Vec<u8>,
+
+    /// The message body.
+    pub msg_body: Vec<u8>,
+
+    /// The block number at which the message is to be submitted.
+    pub block_number: u32,
+
+    /// The time to live for the message in number of blocks.
+    pub ttl: u16,
+
+    /// The KES signature of the message created by the SPO sending the message.
+    pub kes_signature: Vec<u8>,
+
+    /// The operational certificate of the SPO that created the message.
+    pub operational_certificate: Vec<u8>,
+}
+
+/// Reject reason.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DmqMsgValidationError(pub String);
+
+impl From<String> for DmqMsgValidationError {
+    fn from(string: String) -> DmqMsgValidationError {
+        DmqMsgValidationError(string)
+    }
+}

--- a/pallas-network/src/miniprotocols/localmsgsubmission/server.rs
+++ b/pallas-network/src/miniprotocols/localmsgsubmission/server.rs
@@ -1,0 +1,6 @@
+use crate::miniprotocols::localtxsubmission::GenericServer;
+
+use super::{DmqMsg, DmqMsgValidationError};
+
+/// DMQ specific instantiation of LocalTxSubmission server.
+pub type Server = GenericServer<DmqMsg, DmqMsgValidationError>;

--- a/pallas-network/src/miniprotocols/localtxsubmission/mod.rs
+++ b/pallas-network/src/miniprotocols/localtxsubmission/mod.rs
@@ -1,8 +1,10 @@
 pub use client::*;
 pub use protocol::*;
+pub use server::*;
 
 mod client;
 mod codec;
 mod protocol;
+mod server;
 
 pub mod primitives;

--- a/pallas-network/src/miniprotocols/localtxsubmission/protocol.rs
+++ b/pallas-network/src/miniprotocols/localtxsubmission/protocol.rs
@@ -1,12 +1,33 @@
+use thiserror::Error;
+
 use super::primitives::{Certificate, Credential, Language, StakeCredential, Voter};
 use crate::miniprotocols::localstate::queries_v16::{
     Anchor, GovAction, GovActionId, PolicyId, ProposalProcedure, ProtocolVersion, ScriptHash,
     TransactionInput, TransactionOutput, Value, Vote,
 };
 pub use crate::miniprotocols::localstate::queries_v16::{Coin, ExUnits, TaggedSet};
+use crate::multiplexer;
 use pallas_codec::minicbor::{self, Decode, Encode};
 use pallas_codec::utils::{AnyUInt, Bytes, NonEmptyKeyValuePairs, Nullable, Set};
 pub use pallas_crypto::hash::Hash;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("attempted to receive message while agency is ours")]
+    AgencyIsOurs,
+
+    #[error("attempted to send message while agency is theirs")]
+    AgencyIsTheirs,
+
+    #[error("inbound message is not valid for current state")]
+    InvalidInbound,
+
+    #[error("outbound message is not valid for current state")]
+    InvalidOutbound,
+
+    #[error("error while sending or receiving data through the channel")]
+    ChannelError(multiplexer::Error),
+}
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum State {

--- a/pallas-network/src/miniprotocols/localtxsubmission/server.rs
+++ b/pallas-network/src/miniprotocols/localtxsubmission/server.rs
@@ -1,31 +1,29 @@
 use std::marker::PhantomData;
 
-use tracing::debug;
-
 use pallas_codec::Fragment;
 
 use crate::miniprotocols::localtxsubmission::{EraTx, Message, State};
 use crate::multiplexer;
 
-use super::{Error, TxValidationError};
+use super::{Error, Response, TxValidationError};
 
-/// Cardano specific instantiation of LocalTxSubmission client.
-pub type Client = GenericClient<EraTx, TxValidationError>;
+/// Cardano specific instantiation of LocalTxSubmission server.
+pub type Server = GenericServer<EraTx, TxValidationError>;
 
-/// A generic Ouroboros client for submitting a generic transaction
-/// to a server, which possibly results in a generic rejection.
-pub struct GenericClient<Tx, Reject> {
+/// A generic Ouroboros server for submitting a generic transaction
+/// from a client, which possibly results in a generic rejection.
+pub struct GenericServer<Tx, Reject> {
     state: State,
     muxer: multiplexer::ChannelBuffer,
     pd_tx: PhantomData<Tx>,
     pd_reject: PhantomData<Reject>,
 }
 
-impl<Tx, Reject> GenericClient<Tx, Reject>
+impl<Tx, Reject> GenericServer<Tx, Reject>
 where
     Message<Tx, Reject>: Fragment,
 {
-    /// Constructs a new LocalTxSubmission `Client` instance.
+    /// Constructs a new LocalTxSubmission `Server` instance.
     ///
     /// # Arguments
     /// * `channel` - An instance of `multiplexer::AgentChannel` to be used for
@@ -39,42 +37,16 @@ where
         }
     }
 
-    /// Submits the given `tx` to the server.
-    ///
-    /// # Arguments
-    /// * `tx` - transaction to submit.
-    ///
-    /// # Errors
-    /// Returns an error if the agency is not ours or if the outbound state is
-    /// invalid.
-    pub async fn submit_tx(&mut self, tx: Tx) -> Result<Response<Reject>, Error> {
-        self.send_submit_tx(tx).await?;
-        self.recv_submit_tx_response().await
-    }
-
-    /// Terminates the protocol gracefully.
-    ///
-    /// # Errors
-    /// Returns an error if the agency is not ours or if the outbound state is
-    /// invalid.
-    pub async fn terminate_gracefully(&mut self) -> Result<(), Error> {
-        let msg = Message::Done;
-        self.send_message(&msg).await?;
-        self.state = State::Done;
-
-        Ok(())
-    }
-
-    /// Returns the current state of the client.
+    /// Returns the current state of the server.
     pub fn state(&self) -> &State {
         &self.state
     }
 
-    /// Checks if the client has agency.
+    /// Checks if the server has agency.
     fn has_agency(&self) -> bool {
         match self.state() {
-            State::Idle => true,
-            State::Busy | State::Done => false,
+            State::Idle => false,
+            State::Busy | State::Done => true,
         }
     }
 
@@ -94,17 +66,19 @@ where
         }
     }
 
+    /// As a server in a specific state, am I allowed to send this message?
     fn assert_outbound_state(&self, msg: &Message<Tx, Reject>) -> Result<(), Error> {
-        match (&self.state, msg) {
-            (State::Idle, Message::SubmitTx(_) | Message::Done) => Ok(()),
-            _ => Err(Error::InvalidOutbound),
-        }
-    }
-
-    fn assert_inbound_state(&self, msg: &Message<Tx, Reject>) -> Result<(), Error> {
         match (&self.state, msg) {
             (State::Busy, Message::AcceptTx | Message::RejectTx(_)) => Ok(()),
             _ => Err(Error::InvalidInbound),
+        }
+    }
+
+    /// As a server in a specific state, am I allowed to receive this message?
+    fn assert_inbound_state(&self, msg: &Message<Tx, Reject>) -> Result<(), Error> {
+        match (&self.state, msg) {
+            (State::Idle, Message::SubmitTx(_) | Message::Done) => Ok(()),
+            _ => Err(Error::InvalidOutbound),
         }
     }
 
@@ -148,39 +122,44 @@ where
         Ok(msg)
     }
 
-    /// Sends SubmitTx message to the server.
-    ///
-    /// # Arguments
-    /// * `tx` - transaction to submit.
-    ///
-    /// # Errors
-    /// Returns an error if the agency is not ours or if the outbound state is
-    /// invalid.
-    pub async fn send_submit_tx(&mut self, tx: Tx) -> Result<(), Error> {
-        let msg = Message::SubmitTx(tx);
-        self.send_message(&msg).await?;
-        self.state = State::Busy;
+    /// Sends SubmitTx response to the client.
+    pub async fn send_submit_tx_response(
+        &mut self,
+        response: Response<Reject>,
+    ) -> Result<(), Error> {
+        match response {
+            Response::Accepted => {
+                let msg = Message::AcceptTx;
+                self.send_message(&msg).await?;
+                self.state = State::Idle;
 
-        debug!("sent SubmitTx");
+                Ok(())
+            }
+            Response::Rejected(reject) => {
+                let msg = Message::RejectTx::<Tx, Reject>(reject);
+                self.send_message(&msg).await?;
+                self.state = State::Idle;
 
-        Ok(())
+                Ok(())
+            }
+        }
     }
 
-    /// Receives SubmitTx response from the server.
+    /// Receives next request from the client.
     ///
     /// # Errors
     /// Returns an error if the inbound message is invalid.
-    pub async fn recv_submit_tx_response(&mut self) -> Result<Response<Reject>, Error> {
-        debug!("waiting for SubmitTx response");
-
+    pub async fn recv_next_request(&mut self) -> Result<Request<Tx>, Error> {
         match self.recv_message().await? {
-            Message::AcceptTx => {
-                self.state = State::Idle;
-                Ok(Response::Accepted)
+            Message::SubmitTx(tx) => {
+                self.state = State::Busy;
+
+                Ok(Request::Submit(tx))
             }
-            Message::RejectTx(rejection) => {
-                self.state = State::Idle;
-                Ok(Response::Rejected(rejection))
+            Message::Done => {
+                self.state = State::Done;
+
+                Ok(Request::Done)
             }
             _ => Err(Error::InvalidInbound),
         }
@@ -188,7 +167,7 @@ where
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum Response<Reject> {
-    Accepted,
-    Rejected(Reject),
+pub enum Request<Tx> {
+    Submit(Tx),
+    Done,
 }

--- a/pallas-network/src/miniprotocols/mod.rs
+++ b/pallas-network/src/miniprotocols/mod.rs
@@ -6,6 +6,7 @@ pub mod blockfetch;
 pub mod chainsync;
 pub mod handshake;
 pub mod keepalive;
+pub mod localmsgnotification;
 pub mod localmsgsubmission;
 pub mod localstate;
 pub mod localtxsubmission;

--- a/pallas-network/src/miniprotocols/mod.rs
+++ b/pallas-network/src/miniprotocols/mod.rs
@@ -6,6 +6,7 @@ pub mod blockfetch;
 pub mod chainsync;
 pub mod handshake;
 pub mod keepalive;
+pub mod localmsgsubmission;
 pub mod localstate;
 pub mod localtxsubmission;
 pub mod peersharing;

--- a/pallas-network/tests/protocols.rs
+++ b/pallas-network/tests/protocols.rs
@@ -18,7 +18,7 @@ use pallas_network::{
         chainsync::{ClientRequest, HeaderContent, Tip},
         handshake,
         handshake::n2n::VersionData,
-        localstate,
+        localmsgnotification, localstate,
         localstate::ClientQueryRequest,
         peersharing,
         peersharing::PeerAddress,
@@ -1840,6 +1840,126 @@ pub async fn peer_sharing_server_and_client_happy_path() {
         client_ps.send_done().await.unwrap();
 
         assert!(client_ps.is_done())
+    });
+
+    tokio::try_join!(client, server).unwrap();
+}
+
+#[cfg(unix)]
+#[tokio::test]
+pub async fn local_message_notification_query_server_and_client_happy_path() {
+    use pallas_network::miniprotocols::localmsgsubmission::DmqMsg;
+
+    fn fake_msgs() -> Vec<DmqMsg> {
+        vec![
+            DmqMsg {
+                msg_id: vec![0, 1],
+                msg_body: vec![0, 1, 2],
+                block_number: 10,
+                ttl: 100,
+                kes_signature: vec![0, 1, 2, 3],
+                operational_certificate: vec![0, 1, 2, 3, 4],
+            },
+            DmqMsg {
+                msg_id: vec![1, 2],
+                msg_body: vec![1, 2, 3],
+                block_number: 11,
+                ttl: 100,
+                kes_signature: vec![1, 2, 3, 4],
+                operational_certificate: vec![1, 2, 3, 4, 5],
+            },
+        ]
+    }
+
+    let server = tokio::spawn({
+        async move {
+            // server setup
+            let socket_path = Path::new("node3.socket");
+            if socket_path.exists() {
+                fs::remove_file(socket_path).unwrap();
+            }
+            let listener = UnixListener::bind(socket_path).unwrap();
+            let mut server = pallas_network::facades::NodeServer::accept(&listener, 0)
+                .await
+                .unwrap();
+
+            // init local msg notification server
+            let server_msg = server.msg_notification();
+            assert_eq!(*server_msg.state(), localmsgnotification::State::Idle);
+
+            // server waits for non blocking request from client and replies to it
+            let request = server_msg.recv_next_request().await.unwrap();
+            assert_eq!(request, localmsgnotification::Request::NonBlocking);
+            assert_eq!(
+                *server_msg.state(),
+                localmsgnotification::State::BusyNonBlocking
+            );
+
+            server_msg
+                .send_reply_messages_non_blocking(fake_msgs(), true)
+                .await
+                .unwrap();
+            assert_eq!(*server_msg.state(), localmsgnotification::State::Idle);
+
+            // server waits for blocking request from client and replies to it
+            let request = server_msg.recv_next_request().await.unwrap();
+            assert_eq!(request, localmsgnotification::Request::Blocking);
+            assert_eq!(
+                *server_msg.state(),
+                localmsgnotification::State::BusyBlocking
+            );
+
+            server_msg
+                .send_reply_messages_blocking(fake_msgs())
+                .await
+                .unwrap();
+            assert_eq!(*server_msg.state(), localmsgnotification::State::Idle);
+
+            // server receives done from client
+            server_msg.recv_done().await.unwrap();
+            assert_eq!(*server_msg.state(), localmsgnotification::State::Done);
+        }
+    });
+
+    let client = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        // client setup
+        let socket_path = "node3.socket";
+        let mut client = NodeClient::connect(socket_path, 0).await.unwrap();
+
+        // init local msg notification client
+        let client_msg = client.msg_notification();
+        assert_eq!(*client_msg.state(), localmsgnotification::State::Idle);
+
+        // client sends a non blocking request to server and waits for a reply from the server
+        client_msg
+            .send_request_messages_non_blocking()
+            .await
+            .unwrap();
+        assert_eq!(
+            *client_msg.state(),
+            localmsgnotification::State::BusyNonBlocking
+        );
+
+        let reply = client_msg.recv_next_reply().await.unwrap();
+        assert_eq!(*client_msg.state(), localmsgnotification::State::Idle);
+        assert_eq!(reply, localmsgnotification::Reply(fake_msgs(), true));
+
+        // client sends a blocking request to server and waits for a reply from the server
+        client_msg.send_request_messages_blocking().await.unwrap();
+        assert_eq!(
+            *client_msg.state(),
+            localmsgnotification::State::BusyBlocking
+        );
+
+        let reply = client_msg.recv_next_reply().await.unwrap();
+        assert_eq!(*client_msg.state(), localmsgnotification::State::Idle);
+        assert_eq!(reply, localmsgnotification::Reply(fake_msgs(), false));
+
+        // client sends done to server
+        client_msg.send_done().await.unwrap();
+        assert_eq!(*client_msg.state(), localmsgnotification::State::Done);
     });
 
     tokio::try_join!(client, server).unwrap();

--- a/pallas-network/tests/protocols.rs
+++ b/pallas-network/tests/protocols.rs
@@ -1847,8 +1847,8 @@ pub async fn peer_sharing_server_and_client_happy_path() {
 
 #[cfg(unix)]
 #[tokio::test]
-pub async fn local_message_notification_query_server_and_client_happy_path() {
-    use pallas_network::miniprotocols::localmsgsubmission::DmqMsg;
+pub async fn local_message_notification_server_and_client_happy_path() {
+    use pallas_network::{facades::DmqClient, miniprotocols::localmsgsubmission::DmqMsg};
 
     fn fake_msgs() -> Vec<DmqMsg> {
         vec![
@@ -1879,7 +1879,7 @@ pub async fn local_message_notification_query_server_and_client_happy_path() {
                 fs::remove_file(socket_path).unwrap();
             }
             let listener = UnixListener::bind(socket_path).unwrap();
-            let mut server = pallas_network::facades::NodeServer::accept(&listener, 0)
+            let mut server = pallas_network::facades::DmqServer::accept(&listener, 0)
                 .await
                 .unwrap();
 
@@ -1926,7 +1926,7 @@ pub async fn local_message_notification_query_server_and_client_happy_path() {
 
         // client setup
         let socket_path = "node3.socket";
-        let mut client = NodeClient::connect(socket_path, 0).await.unwrap();
+        let mut client = DmqClient::connect(socket_path, 0).await.unwrap();
 
         // init local msg notification client
         let client_msg = client.msg_notification();


### PR DESCRIPTION
This PR includes the implementation of the **n2c DMQ ([Decentralized Message Queue - CIP-0137](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0137)) in `pallas-network`**:
- Added **n2c local message submission** mini-protocol:
  - Based on the implementation of the existing `GenericClient` of n2c local tx submission
  - Based on the implementation of the new `GenericServer` of n2c local tx submission
- Added **n2c local message notification** mini-protocol
- Updated **n2c local tx submission** mini-protocol with a `GenericServer` implementation
