### PR TITLE
Update paths to cardano-blueprint test data

### DIFF
--- a/pallas-network/src/miniprotocols/handshake/protocol.rs
+++ b/pallas-network/src/miniprotocols/handshake/protocol.rs
@@ -240,23 +240,21 @@ mod tests {
         use pallas_codec::minicbor;
         use pallas_codec::utils;
 
-        // XXX: Can we avoid repeating the test-data path?
+        macro_rules! include_test_msg {
+            ($path:literal) => {
+                include_str!(concat!(
+                    "../../../../cardano-blueprint/src/network/node-to-node/handshake/test-data/",
+                    $path
+                ))
+            };
+        }
+
         let test_messages = [
-            include_str!(
-                "../../../../cardano-blueprint/src/network/test-data/handshake-n2n/test-0"
-            ),
-            include_str!(
-                "../../../../cardano-blueprint/src/network/test-data/handshake-n2n/test-1"
-            ),
-            include_str!(
-                "../../../../cardano-blueprint/src/network/test-data/handshake-n2n/test-2"
-            ),
-            include_str!(
-                "../../../../cardano-blueprint/src/network/test-data/handshake-n2n/test-3"
-            ),
-            include_str!(
-                "../../../../cardano-blueprint/src/network/test-data/handshake-n2n/test-4"
-            ),
+            include_test_msg!("test-0"),
+            include_test_msg!("test-1"),
+            include_test_msg!("test-2"),
+            include_test_msg!("test-3"),
+            include_test_msg!("test-4"),
         ];
 
         for (idx, message_str) in test_messages.iter().enumerate() {

--- a/pallas-network/src/miniprotocols/localstate/codec.rs
+++ b/pallas-network/src/miniprotocols/localstate/codec.rs
@@ -143,14 +143,19 @@ pub mod tests {
     fn test_api_example_roundtrip() {
         use super::Message;
 
+        macro_rules! include_example {
+            ($path:literal) => {
+                include_str!(concat!(
+                    "../../../../cardano-blueprint/src/client/node-to-client/state-query/examples/",
+                    $path
+                ))
+            };
+        }
+
         // TODO: scan for examples
         let examples = [
-            include_str!(
-                "../../../../cardano-blueprint/src/api/examples/getSystemStart/query.cbor"
-            ),
-            include_str!(
-                "../../../../cardano-blueprint/src/api/examples/getSystemStart/result.cbor"
-            ),
+            include_example!("getSystemStart/query.cbor"),
+            include_example!("getSystemStart/result.cbor"),
         ];
         for (idx, message_str) in examples.iter().enumerate() {
             println!("Roundtrip test {idx}");

--- a/pallas-network/src/miniprotocols/localstate/queries_v16/codec.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/codec.rs
@@ -809,15 +809,23 @@ pub mod tests {
         };
         use pallas_codec::utils::AnyCbor;
 
-        // TODO: scan for examples
-        let examples = [(
-            include_str!(
-                "../../../../../cardano-blueprint/src/api/examples/getSystemStart/query.cbor"
-            ),
-            include_str!(
-                "../../../../../cardano-blueprint/src/api/examples/getSystemStart/result.cbor"
-            ),
-        )];
+        macro_rules! include_example_pair {
+            ($path:literal) => {
+                (include_str!(concat!(
+                    "../../../../../cardano-blueprint/src/client/node-to-client/state-query/examples/",
+                    $path,
+                    "/query.cbor"
+                ))
+                , include_str!(concat!(
+                    "../../../../../cardano-blueprint/src/client/node-to-client/state-query/examples/",
+                    $path,
+                    "/result.cbor"
+                ))
+                 )
+            };
+        }
+
+        let examples = [include_example_pair!("getSystemStart")];
         for (idx, (query_str, result_str)) in examples.iter().enumerate() {
             println!("Roundtrip query {idx}");
             roundtrips_with(query_str, |q| match q {


### PR DESCRIPTION
The paths moved upstream as we re-organized the network protocol cddls and example cbors.