### PR TITLE
fix: cost models into vec lexicographically

### DIFF
--- a/pallas-configs/src/alonzo.rs
+++ b/pallas-configs/src/alonzo.rs
@@ -77,7 +77,9 @@ pub struct CostModel(HashMap<String, i64>);
 
 impl From<CostModel> for Vec<i64> {
     fn from(value: CostModel) -> Self {
-        value.0.into_values().collect()
+        let mut entries: Vec<_> = value.0.into_iter().collect();
+        entries.sort_by_key(|(k, _)| k.clone());
+        entries.into_iter().map(|(_, v)| v).collect()
     }
 }
 


### PR DESCRIPTION
Values of cost models are supposed to be sorted in lexicographical manner. Consequences could be seen on the blaze provider of utxorpc  that got all cost models mixed up.