### PR TITLE
fix(network): add missing KES period in DMQ message

### DIFF
--- a/pallas-network/src/miniprotocols/localmsgsubmission/codec.rs
+++ b/pallas-network/src/miniprotocols/localmsgsubmission/codec.rs
@@ -11,6 +11,7 @@ impl<'b> Decode<'b, ()> for DmqMsg {
         let ttl = d.u16()?;
         let kes_signature = d.bytes()?.to_vec();
         let operational_certificate = d.bytes()?.to_vec();
+        let kes_period = d.u32()?;
         Ok(DmqMsg {
             msg_id,
             msg_body,
@@ -18,6 +19,7 @@ impl<'b> Decode<'b, ()> for DmqMsg {
             ttl,
             kes_signature,
             operational_certificate,
+            kes_period,
         })
     }
 }
@@ -35,6 +37,7 @@ impl Encode<()> for DmqMsg {
         e.u16(self.ttl)?;
         e.bytes(&self.kes_signature)?;
         e.bytes(&self.operational_certificate)?;
+        e.u32(self.kes_period)?;
 
         Ok(())
     }

--- a/pallas-network/src/miniprotocols/localmsgsubmission/protocol.rs
+++ b/pallas-network/src/miniprotocols/localmsgsubmission/protocol.rs
@@ -18,6 +18,9 @@ pub struct DmqMsg {
 
     /// The operational certificate of the SPO that created the message.
     pub operational_certificate: Vec<u8>,
+
+    /// The KES period at which the KES signature was created.
+    pub kes_period: u32,
 }
 
 /// Reject reason.

--- a/pallas-network/tests/protocols.rs
+++ b/pallas-network/tests/protocols.rs
@@ -1859,6 +1859,7 @@ pub async fn local_message_notification_server_and_client_happy_path() {
                 ttl: 100,
                 kes_signature: vec![0, 1, 2, 3],
                 operational_certificate: vec![0, 1, 2, 3, 4],
+                kes_period: 10,
             },
             DmqMsg {
                 msg_id: vec![1, 2],
@@ -1867,6 +1868,7 @@ pub async fn local_message_notification_server_and_client_happy_path() {
                 ttl: 100,
                 kes_signature: vec![1, 2, 3, 4],
                 operational_certificate: vec![1, 2, 3, 4, 5],
+                kes_period: 11,
             },
         ]
     }
@@ -1978,6 +1980,7 @@ pub async fn local_message_submission_server_and_client_happy_path() {
             ttl: 100,
             kes_signature: vec![0, 1, 2, 3],
             operational_certificate: vec![0, 1, 2, 3, 4],
+            kes_period: 10,
         }
     }
 


### PR DESCRIPTION
This PR includes a bug fix for the **n2c DMQ ([Decentralized Message Queue - CIP-0137](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0137)) in `pallas-network`**:
- Added a `kes_period` field to the `DmqMsg` struct (the KES period is needed to efficiently verify the KES signature).
