### PR TITLE
refactor(network): update DMQ message

### DIFF
--- a/pallas-network/src/miniprotocols/localmsgnotification/client.rs
+++ b/pallas-network/src/miniprotocols/localmsgnotification/client.rs
@@ -115,17 +115,6 @@ where
         }
     }
 
-    pub async fn recv_done(&mut self) -> Result<(), Error> {
-        match self.recv_message().await? {
-            Message::ServerDone => {
-                self.0 = State::Done;
-
-                Ok(())
-            }
-            _ => Err(Error::InvalidInbound),
-        }
-    }
-
     pub async fn send_done(&mut self) -> Result<(), Error> {
         let msg = Message::ClientDone;
         self.send_message(&msg).await?;

--- a/pallas-network/src/miniprotocols/localmsgnotification/codec.rs
+++ b/pallas-network/src/miniprotocols/localmsgnotification/codec.rs
@@ -42,10 +42,6 @@ impl Encode<()> for Message {
                 e.array(1)?.u16(3)?;
                 Ok(())
             }
-            Message::ServerDone => {
-                e.array(1)?.u16(4)?;
-                Ok(())
-            }
         }
     }
 }
@@ -73,7 +69,6 @@ impl<'b> Decode<'b, ()> for Message {
                 Ok(Message::ReplyMessagesBlocking(msgs))
             }
             3 => Ok(Message::ClientDone),
-            4 => Ok(Message::ServerDone),
             _ => Err(decode::Error::message(
                 "unknown variant for localmsgsubmission message",
             )),

--- a/pallas-network/src/miniprotocols/localmsgnotification/protocol.rs
+++ b/pallas-network/src/miniprotocols/localmsgnotification/protocol.rs
@@ -39,5 +39,4 @@ pub enum Message {
     RequestMessagesBlocking,
     ReplyMessagesBlocking(Vec<DmqMsg>),
     ClientDone,
-    ServerDone,
 }

--- a/pallas-network/src/miniprotocols/localmsgnotification/server.rs
+++ b/pallas-network/src/miniprotocols/localmsgnotification/server.rs
@@ -132,12 +132,4 @@ where
             _ => Err(Error::InvalidInbound),
         }
     }
-
-    pub async fn send_done(&mut self) -> Result<(), Error> {
-        let msg = Message::ServerDone;
-        self.send_message(&msg).await?;
-        self.0 = State::Done;
-
-        Ok(())
-    }
 }

--- a/pallas-network/src/miniprotocols/localmsgsubmission/codec.rs
+++ b/pallas-network/src/miniprotocols/localmsgsubmission/codec.rs
@@ -7,9 +7,13 @@ impl<'b> Decode<'b, ()> for DmqMsg {
         d.array()?;
         let payload = DmqMsgPayload::decode(d, _ctx)?;
         let kes_signature = d.bytes()?.to_vec();
+        let operational_certificate = d.bytes()?.to_vec();
+        let cold_verification_key = d.bytes()?.to_vec();
         Ok(DmqMsg {
             msg_payload: payload,
             kes_signature,
+            operational_certificate,
+            cold_verification_key,
         })
     }
 }
@@ -23,6 +27,8 @@ impl Encode<()> for DmqMsg {
         e.array(2)?;
         e.encode(&self.msg_payload)?;
         e.bytes(&self.kes_signature)?;
+        e.bytes(&self.operational_certificate)?;
+        e.bytes(&self.cold_verification_key)?;
 
         Ok(())
     }
@@ -34,15 +40,11 @@ impl<'b> Decode<'b, ()> for DmqMsgPayload {
         let msg_id = d.bytes()?.to_vec();
         let msg_body = d.bytes()?.to_vec();
         let kes_period = d.u64()?;
-        let operational_certificate = d.bytes()?.to_vec();
-        let cold_verification_key = d.bytes()?.to_vec();
         let expires_at = d.u32()?;
         Ok(DmqMsgPayload {
             msg_id,
             msg_body,
             kes_period,
-            operational_certificate,
-            cold_verification_key,
             expires_at,
         })
     }
@@ -58,8 +60,6 @@ impl Encode<()> for DmqMsgPayload {
         e.bytes(&self.msg_id)?;
         e.bytes(&self.msg_body)?;
         e.u64(self.kes_period)?;
-        e.bytes(&self.operational_certificate)?;
-        e.bytes(&self.cold_verification_key)?;
         e.u32(self.expires_at)?;
 
         Ok(())

--- a/pallas-network/src/miniprotocols/localmsgsubmission/codec.rs
+++ b/pallas-network/src/miniprotocols/localmsgsubmission/codec.rs
@@ -7,19 +7,19 @@ impl<'b> Decode<'b, ()> for DmqMsg {
         d.array()?;
         let msg_id = d.bytes()?.to_vec();
         let msg_body = d.bytes()?.to_vec();
-        let block_number = d.u32()?;
-        let ttl = d.u16()?;
         let kes_signature = d.bytes()?.to_vec();
+        let kes_period = d.u64()?;
         let operational_certificate = d.bytes()?.to_vec();
-        let kes_period = d.u32()?;
+        let cold_verification_key = d.bytes()?.to_vec();
+        let expires_at = d.u32()?;
         Ok(DmqMsg {
             msg_id,
             msg_body,
-            block_number,
-            ttl,
             kes_signature,
-            operational_certificate,
             kes_period,
+            operational_certificate,
+            cold_verification_key,
+            expires_at,
         })
     }
 }
@@ -30,14 +30,14 @@ impl Encode<()> for DmqMsg {
         e: &mut Encoder<W>,
         _ctx: &mut (),
     ) -> Result<(), encode::Error<W::Error>> {
-        e.array(6)?;
+        e.array(7)?;
         e.bytes(&self.msg_id)?;
         e.bytes(&self.msg_body)?;
-        e.u32(self.block_number)?;
-        e.u16(self.ttl)?;
         e.bytes(&self.kes_signature)?;
+        e.u64(self.kes_period)?;
         e.bytes(&self.operational_certificate)?;
-        e.u32(self.kes_period)?;
+        e.bytes(&self.cold_verification_key)?;
+        e.u32(self.expires_at)?;
 
         Ok(())
     }

--- a/pallas-network/src/miniprotocols/localmsgsubmission/protocol.rs
+++ b/pallas-network/src/miniprotocols/localmsgsubmission/protocol.rs
@@ -1,14 +1,23 @@
-/// The bytes of a message to be submitted to the local message submission protocol.
+/// A message to be sent by the local message submission protocol.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct DmqMsg {
+    /// The payload of the message.
+    pub msg_payload: DmqMsgPayload,
+
+    /// The KES signature of the message created by the SPO sending the message.
+    pub kes_signature: Vec<u8>,
+}
+
+/// The payload of a message to be submitted to the local message submission protocol.
+///
+/// Important: This message is not signed and should not be considered final.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DmqMsgPayload {
     /// The message id.
     pub msg_id: Vec<u8>,
 
     /// The message body.
     pub msg_body: Vec<u8>,
-
-    /// The KES signature of the message created by the SPO sending the message.
-    pub kes_signature: Vec<u8>,
 
     /// The KES period at which the KES signature was created.
     pub kes_period: u64,

--- a/pallas-network/src/miniprotocols/localmsgsubmission/protocol.rs
+++ b/pallas-network/src/miniprotocols/localmsgsubmission/protocol.rs
@@ -7,20 +7,20 @@ pub struct DmqMsg {
     /// The message body.
     pub msg_body: Vec<u8>,
 
-    /// The block number at which the message is to be submitted.
-    pub block_number: u32,
-
-    /// The time to live for the message in number of blocks.
-    pub ttl: u16,
-
     /// The KES signature of the message created by the SPO sending the message.
     pub kes_signature: Vec<u8>,
+
+    /// The KES period at which the KES signature was created.
+    pub kes_period: u64,
 
     /// The operational certificate of the SPO that created the message.
     pub operational_certificate: Vec<u8>,
 
-    /// The KES period at which the KES signature was created.
-    pub kes_period: u32,
+    /// The cold verification key of the SPO that created the message.
+    pub cold_verification_key: Vec<u8>,
+
+    /// The expiration timestamp of the message.
+    pub expires_at: u32,
 }
 
 /// Reject reason.

--- a/pallas-network/src/miniprotocols/localmsgsubmission/protocol.rs
+++ b/pallas-network/src/miniprotocols/localmsgsubmission/protocol.rs
@@ -10,6 +10,12 @@ pub struct DmqMsg {
 
     /// The KES signature of the message created by the SPO sending the message.
     pub kes_signature: Vec<u8>,
+
+    /// The operational certificate of the SPO that created the message.
+    pub operational_certificate: Vec<u8>,
+
+    /// The cold verification key of the SPO that created the message.
+    pub cold_verification_key: Vec<u8>,
 }
 
 /// The payload of a message to be submitted to the local message submission protocol.
@@ -25,12 +31,6 @@ pub struct DmqMsgPayload {
 
     /// The KES period at which the KES signature was created.
     pub kes_period: u64,
-
-    /// The operational certificate of the SPO that created the message.
-    pub operational_certificate: Vec<u8>,
-
-    /// The cold verification key of the SPO that created the message.
-    pub cold_verification_key: Vec<u8>,
 
     /// The expiration timestamp of the message.
     pub expires_at: u32,
@@ -63,15 +63,10 @@ mod tests {
             msg_id: vec![1, 2, 3],
             msg_body: vec![4, 5, 6],
             kes_period: 7,
-            operational_certificate: vec![8, 9, 10],
-            cold_verification_key: vec![11, 12, 13],
             expires_at: 14,
         };
 
         let bytes = payload.bytes_to_sign().unwrap();
-        assert_eq!(
-            vec![134, 67, 1, 2, 3, 67, 4, 5, 6, 7, 67, 8, 9, 10, 67, 11, 12, 13, 14,],
-            bytes
-        );
+        assert_eq!(vec![134, 67, 1, 2, 3, 67, 4, 5, 6, 7, 14], bytes);
     }
 }

--- a/pallas-network/tests/protocols.rs
+++ b/pallas-network/tests/protocols.rs
@@ -1858,24 +1858,23 @@ pub async fn local_message_notification_server_and_client_happy_path() {
                 msg_payload: DmqMsgPayload {
                     msg_id: vec![0, 1],
                     msg_body: vec![0, 1, 2],
-
                     kes_period: 10,
-                    operational_certificate: vec![0, 1, 2, 3, 4],
-                    cold_verification_key: vec![0, 1, 2, 3, 4, 5],
                     expires_at: 100,
                 },
                 kes_signature: vec![0, 1, 2, 3],
+                operational_certificate: vec![0, 1, 2, 3, 4],
+                cold_verification_key: vec![0, 1, 2, 3, 4, 5],
             },
             DmqMsg {
                 msg_payload: DmqMsgPayload {
                     msg_id: vec![1, 2],
                     msg_body: vec![1, 2, 3],
                     kes_period: 12,
-                    operational_certificate: vec![1, 2, 3, 4, 5],
-                    cold_verification_key: vec![1, 2, 3, 4, 5, 6],
                     expires_at: 102,
                 },
                 kes_signature: vec![1, 2, 3, 4],
+                operational_certificate: vec![1, 2, 3, 4, 5],
+                cold_verification_key: vec![1, 2, 3, 4, 5, 6],
             },
         ]
     }
@@ -1986,13 +1985,12 @@ pub async fn local_message_submission_server_and_client_happy_path() {
             msg_payload: DmqMsgPayload {
                 msg_id: vec![0, 1],
                 msg_body: vec![0, 1, 2],
-
                 kes_period: 10,
-                operational_certificate: vec![0, 1, 2, 3, 4],
-                cold_verification_key: vec![0, 1, 2, 3, 4, 5],
                 expires_at: 100,
             },
             kes_signature: vec![0, 1, 2, 3],
+            operational_certificate: vec![0, 1, 2, 3, 4],
+            cold_verification_key: vec![0, 1, 2, 3, 4, 5],
         }
     }
 

--- a/pallas-network/tests/protocols.rs
+++ b/pallas-network/tests/protocols.rs
@@ -1855,20 +1855,20 @@ pub async fn local_message_notification_server_and_client_happy_path() {
             DmqMsg {
                 msg_id: vec![0, 1],
                 msg_body: vec![0, 1, 2],
-                block_number: 10,
-                ttl: 100,
                 kes_signature: vec![0, 1, 2, 3],
-                operational_certificate: vec![0, 1, 2, 3, 4],
                 kes_period: 10,
+                operational_certificate: vec![0, 1, 2, 3, 4],
+                cold_verification_key: vec![0, 1, 2, 3, 4, 5],
+                expires_at: 100,
             },
             DmqMsg {
                 msg_id: vec![1, 2],
                 msg_body: vec![1, 2, 3],
-                block_number: 11,
-                ttl: 100,
                 kes_signature: vec![1, 2, 3, 4],
+                kes_period: 12,
                 operational_certificate: vec![1, 2, 3, 4, 5],
-                kes_period: 11,
+                cold_verification_key: vec![1, 2, 3, 4, 5, 6],
+                expires_at: 102,
             },
         ]
     }
@@ -1976,11 +1976,11 @@ pub async fn local_message_submission_server_and_client_happy_path() {
         DmqMsg {
             msg_id: vec![0, 1],
             msg_body: vec![0, 1, 2],
-            block_number: 10,
-            ttl: 100,
             kes_signature: vec![0, 1, 2, 3],
-            operational_certificate: vec![0, 1, 2, 3, 4],
             kes_period: 10,
+            operational_certificate: vec![0, 1, 2, 3, 4],
+            cold_verification_key: vec![0, 1, 2, 3, 4, 5],
+            expires_at: 100,
         }
     }
 

--- a/pallas-network/tests/protocols.rs
+++ b/pallas-network/tests/protocols.rs
@@ -1851,24 +1851,31 @@ pub async fn peer_sharing_server_and_client_happy_path() {
 #[tokio::test]
 pub async fn local_message_notification_server_and_client_happy_path() {
     fn fake_msgs() -> Vec<DmqMsg> {
+        use pallas_network::miniprotocols::localmsgsubmission::DmqMsgPayload;
+
         vec![
             DmqMsg {
-                msg_id: vec![0, 1],
-                msg_body: vec![0, 1, 2],
+                msg_payload: DmqMsgPayload {
+                    msg_id: vec![0, 1],
+                    msg_body: vec![0, 1, 2],
+
+                    kes_period: 10,
+                    operational_certificate: vec![0, 1, 2, 3, 4],
+                    cold_verification_key: vec![0, 1, 2, 3, 4, 5],
+                    expires_at: 100,
+                },
                 kes_signature: vec![0, 1, 2, 3],
-                kes_period: 10,
-                operational_certificate: vec![0, 1, 2, 3, 4],
-                cold_verification_key: vec![0, 1, 2, 3, 4, 5],
-                expires_at: 100,
             },
             DmqMsg {
-                msg_id: vec![1, 2],
-                msg_body: vec![1, 2, 3],
+                msg_payload: DmqMsgPayload {
+                    msg_id: vec![1, 2],
+                    msg_body: vec![1, 2, 3],
+                    kes_period: 12,
+                    operational_certificate: vec![1, 2, 3, 4, 5],
+                    cold_verification_key: vec![1, 2, 3, 4, 5, 6],
+                    expires_at: 102,
+                },
                 kes_signature: vec![1, 2, 3, 4],
-                kes_period: 12,
-                operational_certificate: vec![1, 2, 3, 4, 5],
-                cold_verification_key: vec![1, 2, 3, 4, 5, 6],
-                expires_at: 102,
             },
         ]
     }
@@ -1973,14 +1980,19 @@ pub async fn local_message_submission_server_and_client_happy_path() {
     use pallas_network::miniprotocols::localmsgsubmission::DmqMsgValidationError;
 
     fn fake_msg() -> DmqMsg {
+        use pallas_network::miniprotocols::localmsgsubmission::DmqMsgPayload;
+
         DmqMsg {
-            msg_id: vec![0, 1],
-            msg_body: vec![0, 1, 2],
+            msg_payload: DmqMsgPayload {
+                msg_id: vec![0, 1],
+                msg_body: vec![0, 1, 2],
+
+                kes_period: 10,
+                operational_certificate: vec![0, 1, 2, 3, 4],
+                cold_verification_key: vec![0, 1, 2, 3, 4, 5],
+                expires_at: 100,
+            },
             kes_signature: vec![0, 1, 2, 3],
-            kes_period: 10,
-            operational_certificate: vec![0, 1, 2, 3, 4],
-            cold_verification_key: vec![0, 1, 2, 3, 4, 5],
-            expires_at: 100,
         }
     }
 


### PR DESCRIPTION
This PR includes updates of the [**CIP-0137**](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0137/README.md):
- **The structure of the DMQ messages has evolved**:
  - removed the `blockNumber` field
  - removed the `ttl` 
  - added an `expiresAt` field (`word32`)
  - added a `coldVerificationKey` field (`word32`)
  - split the message payload from the KES signature and verification material
- **The `MsgServerDone` message has been removed from the `n2c local message notification` mini-protocol**

These modifications are being reflected into a [CIP update](https://github.com/cardano-scaling/CIPs/pull/15).