### PR TITLE
fix: multieratx sorted inputs

### DIFF
--- a/pallas-traverse/src/input.rs
+++ b/pallas-traverse/src/input.rs
@@ -63,8 +63,8 @@ impl<'b> MultiEraInput<'b> {
     }
 
     /// Returns the key used for lexicographical ordering of the input
-    pub fn lexicographical_key(&self) -> String {
-        format!("{}#{}", self.hash(), self.index())
+    pub fn lexicographical_key(&self) -> (Hash<32>, u64) {
+        (*self.hash(), self.index())
     }
 
     pub fn hash(&self) -> &Hash<32> {


### PR DESCRIPTION
Using the utxo ref string as the sorting key means that `"15"` < `"7"` for example - change sort key to tuple of hash and index.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated a data retrieval method to return structured values instead of formatted text strings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->