### PR TITLE
fix(validate): treat empty multiasset values as equal to coin values

### DIFF
--- a/pallas-validate/src/utils.rs
+++ b/pallas-validate/src/utils.rs
@@ -596,8 +596,8 @@ fn conway_wrap_multiasset<T>(
 pub fn values_are_equal(first: &Value, second: &Value) -> bool {
     match (first, second) {
         (Value::Coin(f), Value::Coin(s)) => f == s,
-        (Value::Multiasset(..), Value::Coin(..)) => false,
-        (Value::Coin(..), Value::Multiasset(..)) => false,
+        (Value::Multiasset(f, fma), Value::Coin(s)) => f == s && fma.is_empty(),
+        (Value::Coin(f), Value::Multiasset(s, sma)) => f == s && sma.is_empty(),
         (Value::Multiasset(f, fma), Value::Multiasset(s, sma)) => {
             if f != s {
                 false
@@ -610,8 +610,8 @@ pub fn values_are_equal(first: &Value, second: &Value) -> bool {
 pub fn conway_values_are_equal(first: &ConwayValue, second: &ConwayValue) -> bool {
     match (first, second) {
         (ConwayValue::Coin(f), ConwayValue::Coin(s)) => f == s,
-        (ConwayValue::Multiasset(..), ConwayValue::Coin(..)) => false,
-        (ConwayValue::Coin(..), ConwayValue::Multiasset(..)) => false,
+        (ConwayValue::Multiasset(f, fma), ConwayValue::Coin(s)) => f == s && fma.is_empty(),
+        (ConwayValue::Coin(f), ConwayValue::Multiasset(s, sma)) => f == s && sma.is_empty(),
         (ConwayValue::Multiasset(f, fma), ConwayValue::Multiasset(s, sma)) => {
             if f != s {
                 false

--- a/pallas-validate/tests/babbage.rs
+++ b/pallas-validate/tests/babbage.rs
@@ -21,8 +21,8 @@ mod babbage_tests {
     use pallas_validate::{
         phase1::validate_txs,
         utils::{
-            AccountState, BabbageProtParams, CertState, Environment, MultiEraProtocolParameters,
-            PostAlonzoError, UTxOs, ValidationError::*,
+            values_are_equal, AccountState, BabbageProtParams, CertState, Environment,
+            MultiEraProtocolParameters, PostAlonzoError, UTxOs, ValidationError::*,
         },
     };
     use std::borrow::Cow;
@@ -1394,6 +1394,15 @@ mod babbage_tests {
                 _ => panic!("Unexpected error ({err:?})"),
             },
         }
+    }
+
+    #[test]
+    fn preservation_of_value_allows_empty_multiasset_to_equal_coin() {
+        let coin = Value::Coin(10);
+        let empty_multiasset = Value::Multiasset(10, std::collections::BTreeMap::new());
+
+        assert!(values_are_equal(&coin, &empty_multiasset));
+        assert!(values_are_equal(&empty_multiasset, &coin));
     }
 
     #[test]

--- a/pallas-validate/tests/conway.rs
+++ b/pallas-validate/tests/conway.rs
@@ -20,8 +20,8 @@ use pallas_traverse::MultiEraTx;
 use pallas_validate::{
     phase1::validate_txs,
     utils::{
-        AccountState, CertState, ConwayProtParams, Environment, MultiEraProtocolParameters,
-        PostAlonzoError, UTxOs, ValidationError::*,
+        conway_values_are_equal, AccountState, CertState, ConwayProtParams, Environment,
+        MultiEraProtocolParameters, PostAlonzoError, UTxOs, ValidationError::*,
     },
 };
 
@@ -31,7 +31,7 @@ mod conway_tests {
 
     use pallas_addresses::{Address, ShelleyAddress, ShelleyPaymentPart};
     use pallas_primitives::{conway::PostAlonzoTransactionOutput, PositiveCoin};
-    use pallas_traverse::{ComputeHash, MultiEraInput, MultiEraOutput};
+    use pallas_traverse::{MultiEraInput, MultiEraOutput};
 
     use super::*;
 
@@ -532,6 +532,15 @@ mod conway_tests {
                 _ => panic!("Unexpected error ({err:?})"),
             },
         }
+    }
+
+    #[test]
+    fn preservation_of_value_allows_empty_multiasset_to_equal_coin() {
+        let coin = Value::Coin(10);
+        let empty_multiasset = Value::Multiasset(10, std::collections::BTreeMap::new());
+
+        assert!(conway_values_are_equal(&coin, &empty_multiasset));
+        assert!(conway_values_are_equal(&empty_multiasset, &coin));
     }
 
     #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Value comparison logic updated to correctly treat empty multiassets as equivalent to coin values for validation purposes.

* **Tests**
  * Added test coverage confirming proper value equivalence behavior for empty multiassets across different transaction contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->