### PR TITLE
fix(validate): migrate phase2 evaluation to uplc

### DIFF
--- a/pallas-validate/Cargo.toml
+++ b/pallas-validate/Cargo.toml
@@ -24,8 +24,8 @@ itertools = "0.14.0"
 tracing = "0.1.41"
 
 # phase2 dependencies
-pallas-uplc = { version = "0.1.0", optional = true }
-# pallas-uplc = { git = "https://github.com/txpipe/uplc-turbo.git", rev = "bd174b3", optional = true }
+pallas-primitives-uplc = { package = "pallas-primitives", version = "=0.33.0", optional = true }
+uplc = { version = "=1.1.19", optional = true }
 
 [features]
-phase2 = ["pallas-uplc"]
+phase2 = ["uplc", "pallas-primitives-uplc"]

--- a/pallas-validate/src/phase2/error.rs
+++ b/pallas-validate/src/phase2/error.rs
@@ -1,8 +1,6 @@
-use pallas_primitives::{conway::Language, TransactionInput};
-use pallas_uplc::{
-    binder::DeBruijn,
-    flat::FlatDecodeError,
-    machine::{self, ExBudget},
+use pallas_primitives::{
+    conway::{ExUnits, Language},
+    TransactionInput,
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -11,43 +9,27 @@ pub enum Error {
     Address(#[from] pallas_addresses::Error),
     #[error("only shelley reward addresses can be a part of withdrawals")]
     BadWithdrawalAddress,
-    #[error("flat decode error: {0}")]
-    FlatDecode(#[from] FlatDecodeError),
+    #[error("flat decode error: {source}")]
+    FlatDecode {
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
     #[error("fragment decode error: {0}")]
     FragmentDecode(#[from] pallas_primitives::Error),
-    #[error("{}{}", .0, .2.iter()
-        .map(|trace| {
-            format!(
-                "\n{:>13} {}",
-                "Trace",
-                if trace.contains('\n') {
-                    trace.lines()
-                        .enumerate()
-                        .map(|(ix, row)| {
-                            if ix == 0 {
-                                row.to_string()
-                            } else {
-                                format!("{:>13} {}", "",
-                                    row
-                                )
-                            }
-                        })
-                        .collect::<Vec<_>>()
-                        .join("\n")
-                } else {
-                    trace.to_string()
-                }
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("")
-        .as_str()
+    #[error(
+        "{message}\n{:>13} {}\n{:>13} {}{}",
+        "Mem",
+        budget.mem,
+        "CPU",
+        budget.steps,
+        format_machine_traces(logs, labels)
     )]
-    Machine(
-        machine::MachineError<'static, DeBruijn>,
-        ExBudget,
-        Vec<String>,
-    ),
+    Machine {
+        message: String,
+        budget: ExUnits,
+        logs: Vec<String>,
+        labels: Vec<String>,
+    },
 
     #[error("native script can't be executed in phase-two")]
     NativeScriptPhaseTwo,
@@ -110,4 +92,45 @@ pub enum Error {
     SlotTooFarInThePast { oldest_allowed: u64 },
     #[error("could not build script context")]
     ScriptContextBuildError,
+}
+
+impl Error {
+    pub(crate) fn flat_decode(err: impl std::error::Error + Send + Sync + 'static) -> Self {
+        Self::FlatDecode {
+            source: Box::new(err),
+        }
+    }
+}
+
+fn format_machine_traces(logs: &[String], labels: &[String]) -> String {
+    let mut out = String::new();
+
+    for label in labels {
+        out.push_str(&format!("\n{:>13} {}", "Label", indent_trace(label)));
+    }
+
+    for log in logs {
+        out.push_str(&format!("\n{:>13} {}", "Trace", indent_trace(log)));
+    }
+
+    out
+}
+
+fn indent_trace(trace: &str) -> String {
+    if !trace.contains('\n') {
+        return trace.to_string();
+    }
+
+    trace
+        .lines()
+        .enumerate()
+        .map(|(ix, row)| {
+            if ix == 0 {
+                row.to_string()
+            } else {
+                format!("{:>13} {}", "", row)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }

--- a/pallas-validate/src/phase2/evaluator.rs
+++ b/pallas-validate/src/phase2/evaluator.rs
@@ -1,0 +1,347 @@
+use pallas_primitives::{
+    conway::{ExUnits, Language, PlutusData},
+    Fragment,
+};
+use pallas_primitives_uplc::conway::Language as UplcLanguage;
+use uplc::{
+    ast::{Constant, DeBruijn, Program, Term},
+    machine::cost_model::ExBudget,
+};
+
+use super::error::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MachineFailure {
+    pub message: String,
+    pub budget: ExUnits,
+    pub logs: Vec<String>,
+    pub labels: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ScriptEvalResult {
+    pub success: bool,
+    pub units: ExUnits,
+    pub logs: Vec<String>,
+    pub labels: Vec<String>,
+    pub failure: Option<MachineFailure>,
+}
+
+pub(crate) fn eval_script(
+    language: Language,
+    script_bytes: &[u8],
+    datum: Option<&PlutusData>,
+    redeemer: &PlutusData,
+    script_context: &PlutusData,
+) -> Result<ScriptEvalResult, Error> {
+    let flat: pallas_codec::minicbor::bytes::ByteVec =
+        pallas_codec::minicbor::decode(script_bytes)?;
+    let mut program = Program::<DeBruijn>::from_flat(flat.as_ref()).map_err(Error::flat_decode)?;
+
+    if matches!(language, Language::PlutusV1 | Language::PlutusV2) {
+        if let Some(datum) = datum {
+            program = program.apply_data(convert_plutus_data(datum)?);
+        }
+
+        program = program.apply_data(convert_plutus_data(redeemer)?);
+    }
+
+    program = program.apply_data(convert_plutus_data(script_context)?);
+
+    let eval_result = program.eval_version(ExBudget::max(), &map_language(&language));
+    let units = budget_to_ex_units(eval_result.cost());
+    let logs = eval_result.logs();
+    let labels = eval_result.labels();
+
+    let failure = eval_result.result().err().map(|err| MachineFailure {
+        message: err.to_string(),
+        budget: units,
+        logs: logs.clone(),
+        labels: labels.clone(),
+    });
+
+    let success = match eval_result.result() {
+        Ok(term) => match language {
+            Language::PlutusV1 | Language::PlutusV2 => term.is_valid_script_result(),
+            Language::PlutusV3 => matches!(
+                term,
+                Term::Constant(constant) if matches!(constant.as_ref(), Constant::Unit)
+            ),
+        },
+        Err(_) => false,
+    };
+
+    Ok(ScriptEvalResult {
+        success,
+        units,
+        logs,
+        labels,
+        failure,
+    })
+}
+
+fn convert_plutus_data(data: &PlutusData) -> Result<uplc::PlutusData, Error> {
+    let bytes = data.encode_fragment()?;
+
+    uplc::plutus_data(&bytes).map_err(Error::from)
+}
+
+fn budget_to_ex_units(budget: ExBudget) -> ExUnits {
+    ExUnits {
+        mem: budget.mem.max(0) as u64,
+        steps: budget.cpu.max(0) as u64,
+    }
+}
+
+fn map_language(language: &Language) -> UplcLanguage {
+    match language {
+        Language::PlutusV1 => UplcLanguage::PlutusV1,
+        Language::PlutusV2 => UplcLanguage::PlutusV2,
+        Language::PlutusV3 => UplcLanguage::PlutusV3,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pallas_codec::utils::Int;
+    use pallas_primitives::conway::PlutusData;
+    use pallas_primitives::BigInt;
+    use pallas_primitives::PlutusScript;
+    use std::rc::Rc;
+    use uplc::parser;
+    use uplc::{
+        ast::{Constant, Name, Program, Term, Unique},
+        builtins::DefaultFunction,
+    };
+
+    use super::*;
+    use crate::phase2::data::Data as LedgerData;
+
+    fn zero_data() -> PlutusData {
+        LedgerData::integer(BigInt::Int(Int::from(0)))
+    }
+
+    fn script_cbor(program: &str) -> Vec<u8> {
+        parser::program(program)
+            .unwrap()
+            .to_debruijn()
+            .unwrap()
+            .to_cbor()
+            .unwrap()
+    }
+
+    fn term_cbor(term: Term<Name>) -> Vec<u8> {
+        Program {
+            version: (1, 0, 0),
+            term,
+        }
+        .to_debruijn()
+        .unwrap()
+        .to_cbor()
+        .unwrap()
+    }
+
+    fn integer_data(value: i64) -> PlutusData {
+        LedgerData::integer(BigInt::Int(Int::from(value)))
+    }
+
+    fn list_data(values: impl IntoIterator<Item = i64>) -> PlutusData {
+        LedgerData::list(values.into_iter().map(integer_data).collect())
+    }
+
+    fn bytes_data(bytes: &[u8]) -> PlutusData {
+        LedgerData::bytestring(bytes.to_vec())
+    }
+
+    fn name(text: &str, unique: isize) -> Name {
+        Name {
+            text: text.to_string(),
+            unique: Unique::new(unique),
+        }
+    }
+
+    fn var(name: &Name) -> Term<Name> {
+        Term::Var(Rc::new(name.clone()))
+    }
+
+    fn lambda(param: Name, body: Term<Name>) -> Term<Name> {
+        Term::Lambda {
+            parameter_name: Rc::new(param),
+            body: Rc::new(body),
+        }
+    }
+
+    fn apply(function: Term<Name>, argument: Term<Name>) -> Term<Name> {
+        Term::Apply {
+            function: Rc::new(function),
+            argument: Rc::new(argument),
+        }
+    }
+
+    fn builtin(function: DefaultFunction) -> Term<Name> {
+        Term::Builtin(function)
+    }
+
+    fn unit() -> Term<Name> {
+        Term::Constant(Rc::new(Constant::Unit))
+    }
+
+    #[test]
+    fn script_cbor_decode_failure_is_typed() {
+        let err = eval_script(
+            Language::PlutusV3,
+            &[0x01],
+            None,
+            &zero_data(),
+            &zero_data(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, Error::DecodeError(_)));
+    }
+
+    #[test]
+    fn flat_decode_failure_is_typed() {
+        let script = pallas_codec::minicbor::to_vec(PlutusScript::<3>(vec![0xff].into())).unwrap();
+
+        let err = eval_script(
+            Language::PlutusV3,
+            &script,
+            None,
+            &zero_data(),
+            &zero_data(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, Error::FlatDecode { .. }));
+    }
+
+    #[test]
+    fn machine_failure_keeps_logs_and_labels() {
+        let fail_term = Term::add_integer()
+            .apply(Term::integer(1.into()))
+            .apply(Term::unit());
+
+        let traced = fail_term
+            .delayed_trace(Term::string("\0phase2-label"))
+            .delayed_trace(Term::string("phase2-log"));
+
+        let program = Program {
+            version: (1, 0, 0),
+            term: Term::Lambda {
+                parameter_name: Rc::new(Name::text("ctx")),
+                body: Rc::new(traced),
+            },
+        };
+
+        let script = program.to_debruijn().unwrap().to_cbor().unwrap();
+
+        let result = eval_script(
+            Language::PlutusV3,
+            &script,
+            None,
+            &zero_data(),
+            &zero_data(),
+        )
+        .unwrap();
+
+        assert!(!result.success);
+
+        let failure = result.failure.expect("machine failure should be captured");
+        assert!(failure.logs.iter().any(|x| x == "phase2-log"));
+        assert!(failure.labels.iter().any(|x| x == "phase2-label"));
+    }
+
+    #[test]
+    fn serialise_data_v3_script_evaluates_without_panic() {
+        let script = script_cbor(
+            r#"(program 1.0.0
+                (lam ctx
+                  [(lam _ (con unit ()))
+                   [(builtin serialiseData) (con data (I 0))]]))"#,
+        );
+
+        let result = eval_script(
+            Language::PlutusV3,
+            &script,
+            None,
+            &zero_data(),
+            &zero_data(),
+        )
+        .unwrap();
+
+        assert!(result.success, "{result:#?}");
+        assert!(result.failure.is_none(), "{result:#?}");
+    }
+
+    #[test]
+    fn plutus_v2_applies_datum_then_redeemer_then_context() {
+        let datum = name("datum", 1);
+        let redeemer = name("redeemer", 2);
+        let ctx = name("ctx", 3);
+        let datum_checked = name("_datum_checked", 4);
+        let redeemer_checked = name("_redeemer_checked", 5);
+        let ctx_checked = name("_ctx_checked", 6);
+
+        let un_i_data = apply(builtin(DefaultFunction::UnIData), var(&datum));
+        let un_list_data = apply(builtin(DefaultFunction::UnListData), var(&redeemer));
+        let un_b_data = apply(builtin(DefaultFunction::UnBData), var(&ctx));
+        let body = apply(
+            lambda(
+                datum_checked,
+                apply(
+                    lambda(
+                        redeemer_checked,
+                        apply(lambda(ctx_checked, unit()), un_b_data),
+                    ),
+                    un_list_data,
+                ),
+            ),
+            un_i_data,
+        );
+        let script = term_cbor(lambda(datum, lambda(redeemer, lambda(ctx, body))));
+
+        let result = eval_script(
+            Language::PlutusV2,
+            &script,
+            Some(&integer_data(1)),
+            &list_data([2]),
+            &bytes_data(&[3]),
+        )
+        .unwrap();
+
+        assert!(result.success, "{result:#?}");
+        assert!(result.failure.is_none(), "{result:#?}");
+    }
+
+    #[test]
+    fn plutus_v2_skips_missing_datum_and_applies_redeemer_then_context() {
+        let redeemer = name("redeemer", 1);
+        let ctx = name("ctx", 2);
+        let redeemer_checked = name("_redeemer_checked", 3);
+        let ctx_checked = name("_ctx_checked", 4);
+
+        let un_list_data = apply(builtin(DefaultFunction::UnListData), var(&redeemer));
+        let un_b_data = apply(builtin(DefaultFunction::UnBData), var(&ctx));
+        let body = apply(
+            lambda(
+                redeemer_checked,
+                apply(lambda(ctx_checked, unit()), un_b_data),
+            ),
+            un_list_data,
+        );
+        let script = term_cbor(lambda(redeemer, lambda(ctx, body)));
+
+        let result = eval_script(
+            Language::PlutusV2,
+            &script,
+            None,
+            &list_data([2]),
+            &bytes_data(&[3]),
+        )
+        .unwrap();
+
+        assert!(result.success, "{result:#?}");
+        assert!(result.failure.is_none(), "{result:#?}");
+    }
+}

--- a/pallas-validate/src/phase2/mod.rs
+++ b/pallas-validate/src/phase2/mod.rs
@@ -1,5 +1,6 @@
 pub mod data;
 pub mod error;
+mod evaluator;
 pub mod script_context;
 pub mod to_plutus_data;
 pub mod tx;

--- a/pallas-validate/src/phase2/script_context.rs
+++ b/pallas-validate/src/phase2/script_context.rs
@@ -657,7 +657,6 @@ pub fn get_data_info(witness_set: &WitnessSet) -> Vec<(DatumHash, PlutusData)> {
         .as_deref()
         .map(|s| {
             s.iter()
-                .cloned()
                 .map(|d| (d.original_hash(), d.clone().unwrap()))
                 .sorted()
                 .collect()

--- a/pallas-validate/src/phase2/tx.rs
+++ b/pallas-validate/src/phase2/tx.rs
@@ -1,7 +1,8 @@
 use crate::utils::{MultiEraProtocolParameters, UtxoMap};
 
 use super::{
-    script_context::{ScriptContext, TxInfo, TxInfoV1},
+    evaluator,
+    script_context::{TxInfo, TxInfoV1},
     to_plutus_data::ToPlutusData,
 };
 
@@ -10,18 +11,13 @@ use super::{
     script_context::{
         find_script, DataLookupTable, ResolvedInput, ScriptVersion, SlotConfig, TxInfoV2, TxInfoV3,
     },
-    to_plutus_data::convert_tag_to_constr,
 };
 use pallas_primitives::{
-    conway::{Redeemer, RedeemerTag},
+    conway::{Language, Redeemer, RedeemerTag},
     ExUnits, PlutusData,
 };
 use pallas_traverse::{MultiEraRedeemer, MultiEraTx};
 
-use pallas_uplc::{
-    binder::DeBruijn, bumpalo::Bump, constant::Constant, data::PlutusData as PragmaPlutusData,
-    term::Term,
-};
 use tracing::{debug, instrument};
 
 #[derive(Debug)]
@@ -31,81 +27,6 @@ pub struct TxEvalResult {
     pub units: ExUnits,
     pub success: bool,
     pub logs: Vec<String>,
-}
-
-pub fn map_pallas_data_to_pragma_data<'a>(
-    arena: &'a Bump,
-    data: &'a PlutusData,
-) -> &'a PragmaPlutusData<'a> {
-    match data {
-        PlutusData::Constr(constr) => {
-            let fields = constr
-                .fields
-                .iter()
-                .map(|f| map_pallas_data_to_pragma_data(arena, f));
-
-            let fields = arena.alloc_slice_fill_iter(fields);
-
-            PragmaPlutusData::constr(arena, convert_tag_to_constr(constr.tag).unwrap(), fields)
-        }
-        PlutusData::Map(key_value_pairs) => {
-            let key_value_pairs = key_value_pairs.iter().map(|(k, v)| {
-                (
-                    map_pallas_data_to_pragma_data(arena, k),
-                    map_pallas_data_to_pragma_data(arena, v),
-                )
-            });
-
-            let key_value_pairs = arena.alloc_slice_fill_iter(key_value_pairs);
-
-            PragmaPlutusData::map(arena, key_value_pairs)
-        }
-        PlutusData::BigInt(big_int) => match big_int {
-            pallas_primitives::BigInt::Int(int) => {
-                let val = i128::from(*int);
-                PragmaPlutusData::integer_from(arena, val)
-            }
-            pallas_primitives::BigInt::BigNInt(big_num_bytes) => {
-                let val = pallas_uplc::constant::integer_from_bytes_and_sign(
-                    arena,
-                    big_num_bytes.as_slice(),
-                    -1,
-                );
-
-                PragmaPlutusData::integer(arena, val)
-            }
-            // @TODO: recheck this implementations correctness
-            pallas_primitives::BigInt::BigUInt(big_num_bytes) => {
-                let val = pallas_uplc::constant::integer_from_bytes_and_sign(
-                    arena,
-                    big_num_bytes.as_slice(),
-                    1,
-                );
-
-                PragmaPlutusData::integer(arena, val)
-            }
-        },
-        PlutusData::BoundedBytes(bounded_bytes) => {
-            let bounded_bytes = arena.alloc(bounded_bytes.as_slice());
-            PragmaPlutusData::byte_string(arena, bounded_bytes)
-        }
-        PlutusData::Array(maybe_indef_array) => {
-            let items = maybe_indef_array
-                .iter()
-                .map(|x| map_pallas_data_to_pragma_data(arena, x));
-
-            let items = arena.alloc_slice_fill_iter(items);
-
-            PragmaPlutusData::list(arena, items)
-        }
-    }
-}
-
-pub fn plutus_data_to_pragma_term<'a>(
-    arena: &'a Bump,
-    data: &'a PlutusData,
-) -> &'a Term<'a, DeBruijn> {
-    Term::data(arena, map_pallas_data_to_pragma_data(arena, data))
 }
 
 pub fn eval_tx(
@@ -140,6 +61,7 @@ pub fn eval_tx(
 }
 
 fn execute_script(
+    language: Language,
     tx_info: TxInfo,
     script_bytes: &[u8],
     datum: Option<PlutusData>,
@@ -149,64 +71,31 @@ fn execute_script(
         .into_script_context(redeemer, datum.as_ref())
         .ok_or_else(|| Error::ScriptContextBuildError)?;
 
-    let arena = Bump::with_capacity(1_024_000);
-
     let script_context_data = script_context.to_plutus_data();
-    let script_context_term = plutus_data_to_pragma_term(&arena, &script_context_data);
-
     let redeemer_data = redeemer.to_plutus_data();
-    let redeemer_term = plutus_data_to_pragma_term(&arena, &redeemer_data);
+    let result = evaluator::eval_script(
+        language,
+        script_bytes,
+        datum.as_ref(),
+        &redeemer_data,
+        &script_context_data,
+    )?;
 
-    let datum_term = datum
-        .as_ref()
-        .map(|d| plutus_data_to_pragma_term(&arena, d));
-
-    let flat: pallas_codec::minicbor::bytes::ByteVec =
-        pallas_codec::minicbor::decode(&script_bytes)
-            .map_err(pallas_codec::minicbor::decode::Error::from)?;
-
-    let program = pallas_uplc::flat::decode(&arena, &flat)?;
-
-    let program = match script_context {
-        ScriptContext::V1V2 { .. } => if let Some(datum_term) = datum_term {
-            program.apply(&arena, datum_term)
-        } else {
-            program
-        }
-        .apply(&arena, redeemer_term)
-        .apply(&arena, script_context_term),
-
-        ScriptContext::V3 { .. } => program.apply(&arena, script_context_term),
-    };
-
-    let result = program.eval(&arena);
-
-    let success = match script_context {
-        // a non-error result is enough success criteria for v1v2
-        ScriptContext::V1V2 { .. } => result.term.is_ok(),
-        // v3 requires the result to be ok and the term to be a unit
-        ScriptContext::V3 { .. } => match result.term {
-            Ok(term) => match term {
-                Term::Constant(constant) => match constant {
-                    Constant::Unit => true,
-                    _ => false,
-                },
-                _ => false,
-            },
-            Err(_) => false,
-        },
-    };
+    if let Some(failure) = result.failure.as_ref() {
+        debug!(
+            message = %failure.message,
+            logs = ?failure.logs,
+            labels = ?failure.labels,
+            "phase-two script execution failed"
+        );
+    }
 
     Ok(TxEvalResult {
         tag: redeemer.tag,
         index: redeemer.index,
-        success,
-        units: ExUnits {
-            // @TODO hack until we have cost models
-            steps: (result.info.consumed_budget.cpu * 11 / 10) as u64,
-            mem: (result.info.consumed_budget.mem * 11 / 10) as u64,
-        },
-        logs: result.info.logs,
+        success: result.success,
+        units: result.units,
+        logs: result.logs,
     })
 }
 
@@ -230,6 +119,7 @@ pub fn eval_redeemer(
         (ScriptVersion::Native(_), _) => Err(Error::NativeScriptPhaseTwo),
 
         (ScriptVersion::V1(script), datum) => Ok(execute_script(
+            Language::PlutusV1,
             TxInfoV1::from_transaction(tx, utxos, slot_config)?,
             script.as_ref(),
             datum,
@@ -237,6 +127,7 @@ pub fn eval_redeemer(
         )?),
 
         (ScriptVersion::V2(script), datum) => Ok(execute_script(
+            Language::PlutusV2,
             TxInfoV2::from_transaction(tx, utxos, slot_config)?,
             script.as_ref(),
             datum,
@@ -244,6 +135,7 @@ pub fn eval_redeemer(
         )?),
 
         (ScriptVersion::V3(script), datum) => Ok(execute_script(
+            Language::PlutusV3,
             TxInfoV3::from_transaction(tx, utxos, slot_config)?,
             script.as_ref(),
             datum,


### PR DESCRIPTION
Replace the legacy pallas-uplc evaluator with Aiken uplc to avoid incomplete runtime behavior such as serialiseData panics. Keep the phase2 API stable while normalizing errors and reporting direct evaluator budgets and traces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized script evaluation logic into a dedicated evaluator module for improved modularity.
  * Enhanced error reporting with detailed execution information, including CPU/memory budgets, debug logs, and execution traces.

* **Dependencies**
  * Updated UPLC validation dependencies to new compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->