### PR TITLE
fix(utxorpc): forward v1alpha/v1beta service features from utxorpc-spec

### DIFF
--- a/pallas-utxorpc/Cargo.toml
+++ b/pallas-utxorpc/Cargo.toml
@@ -14,7 +14,15 @@ authors = ["Santiago Carmuega <santiago@carmuega.me>"]
 # utxorpc-spec = { path = "../../../utxorpc/spec/gen/rust" }
 utxorpc-spec = { version = "0.19", default-features = false, features = [
     "utxorpc-v1alpha-cardano",
+    "utxorpc-v1alpha-query",
+    "utxorpc-v1alpha-submit",
+    "utxorpc-v1alpha-sync",
+    "utxorpc-v1alpha-watch",
     "utxorpc-v1beta-cardano",
+    "utxorpc-v1beta-query",
+    "utxorpc-v1beta-submit",
+    "utxorpc-v1beta-sync",
+    "utxorpc-v1beta-watch",
 ] }
 
 pallas-traverse = { version = "=1.0.0-alpha.6", path = "../pallas-traverse" }


### PR DESCRIPTION
## Summary
- `utxorpc-spec` 0.19 gated each service module (`query`, `submit`, `sync`, `watch`) behind its own cargo feature. `pallas-utxorpc` was only forwarding the `*-cardano` features, so `spec::query/submit/sync/watch` disappeared from the re-export at `pallas::interop::utxorpc::spec`.
- Downstream consumers that implement u5c gRPC services (e.g. dolos) failed to compile against `main` with errors like `cannot find ``submit`` in ``spec``` (item gated behind `utxorpc-v1alpha-submit`).
- Forwards the four service features for both v1alpha and v1beta so the re-export stays complete. Cardano features are pulled in transitively by each service feature.

## Why explicit features (not `default-features = true`)
`utxorpc-spec`'s default is `proto_full`, which also enables `utxorpc-v1alpha-bitcoin`, `utxorpc-v1beta-bitcoin`, and `utxorpc-v1beta-handshake`. Pallas is a Cardano-focused crate; re-exporting bitcoin protos at `pallas::interop::utxorpc::spec` would be semantic noise. The explicit list also keeps pallas insulated from future changes to `proto_full`.

## Test plan
- [x] `cargo check -p pallas-utxorpc` passes
- [x] Verified locally that dolos (which uses `pallas::interop::utxorpc::spec::{query,submit,sync,watch}`) compiles against this branch — the previous "configured out" errors are gone
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)