### PR TITLE
chore: fix clippy warnings across workspace

### DIFF
--- a/pallas-codec/src/lib.rs
+++ b/pallas-codec/src/lib.rs
@@ -77,9 +77,7 @@ mod tests {
     }
 
     #[cfg(test)]
-    pub fn roundtrip_codec<T: Encode<()> + for<'a> Decode<'a, ()> + std::fmt::Debug>(
-        query: T,
-    ) -> () {
+    pub fn roundtrip_codec<T: Encode<()> + for<'a> Decode<'a, ()> + std::fmt::Debug>(query: T) {
         let mut cbor = Vec::new();
         match encode(query, &mut cbor) {
             Ok(_) => (),

--- a/pallas-math/src/math.rs
+++ b/pallas-math/src/math.rs
@@ -463,22 +463,19 @@ mod tests {
             // println!("res.iterations: {}", res.iterations);
 
             // we compare 1/(1-p) < e^-(1-(1-f)^sigma)
-            if a < (&one - &threshold_b) && res.estimation != ExpOrdering::LT {
-                println!(
+            let threshold = &one - &threshold_b;
+            if a < threshold && res.estimation != ExpOrdering::LT {
+                panic!(
                     "wrong result should be leader {} should be more like {}",
-                    &temp,
-                    &one - &threshold_b
+                    &temp, threshold
                 );
-                assert!(false);
             }
 
-            if !(a < (&one - &threshold_b)) && res.estimation != ExpOrdering::GT {
-                println!(
+            if a >= threshold && res.estimation != ExpOrdering::GT {
+                panic!(
                     "wrong result should not be leader {} should be more like {}",
-                    &temp,
-                    &one - &threshold_b
+                    &temp, threshold
                 );
-                assert!(false);
             }
 
             assert_eq!(res.approx.to_string(), expected_approx_exp);

--- a/pallas-network/src/miniprotocols/handshake/server.rs
+++ b/pallas-network/src/miniprotocols/handshake/server.rs
@@ -129,7 +129,7 @@ where
         // find highest intersect with our version table (TODO: improve)
         let mut versions = versions.values.into_iter().collect::<Vec<(u64, D)>>();
 
-        versions.sort_by(|a, b| b.0.cmp(&a.0));
+        versions.sort_by_key(|v| std::cmp::Reverse(v.0));
 
         for (ver_num, ver_data) in versions.clone() {
             for (client_ver_num, client_ver_data) in client_versions.clone() {

--- a/pallas-network/src/miniprotocols/localstate/queries_v16/codec.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/codec.rs
@@ -878,9 +878,7 @@ pub mod tests {
                         panic!("error decoding cbor from query message: {e:?}")
                     });
                     match request {
-                        Request::GetSystemStart => {
-                            return Message::Query(AnyCbor::from_encode(request))
-                        }
+                        Request::GetSystemStart => Message::Query(AnyCbor::from_encode(request)),
                         _ => panic!("unexpected query type"),
                     }
                 }
@@ -893,7 +891,7 @@ pub mod tests {
                     let result = minicbor::decode::<SystemStart>(&cbor[..]).unwrap_or_else(|e| {
                         panic!("error decoding cbor from query message: {e:?}")
                     });
-                    return Message::Result(AnyCbor::from_encode(result));
+                    Message::Result(AnyCbor::from_encode(result))
                 }
                 _ => panic!("unexpected message type"),
             });

--- a/pallas-primitives/src/conway/script_data.rs
+++ b/pallas-primitives/src/conway/script_data.rs
@@ -108,7 +108,7 @@ mod tests {
 
     use super::*;
 
-    const COST_MODEL_PLUTUS_V1: LazyLock<Vec<i64>> = LazyLock::new(|| {
+    static COST_MODEL_PLUTUS_V1: LazyLock<Vec<i64>> = LazyLock::new(|| {
         vec![
             100788, 420, 1, 1, 1000, 173, 0, 1, 1000, 59957, 4, 1, 11183, 32, 201305, 8356, 4,
             16000, 100, 16000, 100, 16000, 100, 16000, 100, 16000, 100, 16000, 100, 100, 100,
@@ -140,7 +140,7 @@ mod tests {
         ]
     });
 
-    const TEST_VECTORS: LazyLock<Vec<(Vec<u8>, Option<LanguageView>)>> = LazyLock::new(|| {
+    static TEST_VECTORS: LazyLock<Vec<(Vec<u8>, Option<LanguageView>)>> = LazyLock::new(|| {
         vec![
             (
                 hex::decode(include_str!("../../../test_data/conway1.tx")).unwrap(),

--- a/pallas-validate/src/phase1/alonzo.rs
+++ b/pallas-validate/src/phase1/alonzo.rs
@@ -222,28 +222,21 @@ fn check_collaterals_assets(
         Some(collaterals) => {
             for collateral in collaterals {
                 match utxos.get(&MultiEraInput::from_alonzo_compatible(collateral)) {
-                    Some(multi_era_output) => match MultiEraOutput::as_alonzo(multi_era_output) {
-                        Some(TransactionOutput {
-                            amount: Value::Coin(n),
-                            ..
-                        }) => {
+                    Some(multi_era_output) => {
+                        if let Some(TransactionOutput { amount, .. }) =
+                            MultiEraOutput::as_alonzo(multi_era_output)
+                        {
+                            let (Value::Coin(n) | Value::Multiasset(n, _)) = amount;
                             if *n * 100 < fee_percentage {
                                 return Err(Alonzo(CollateralMinLovelace));
                             }
-                        }
-                        Some(TransactionOutput {
-                            amount: Value::Multiasset(n, multi_assets),
-                            ..
-                        }) => {
-                            if *n * 100 < fee_percentage {
-                                return Err(Alonzo(CollateralMinLovelace));
-                            }
-                            if !multi_assets.is_empty() {
-                                return Err(Alonzo(NonLovelaceCollateral));
+                            if let Value::Multiasset(_, multi_assets) = amount {
+                                if !multi_assets.is_empty() {
+                                    return Err(Alonzo(NonLovelaceCollateral));
+                                }
                             }
                         }
-                        None => (),
-                    },
+                    }
                     None => return Err(Alonzo(CollateralNotInUTxO)),
                 }
             }

--- a/pallas-validate/src/phase2/script_context.rs
+++ b/pallas-validate/src/phase2/script_context.rs
@@ -657,7 +657,6 @@ pub fn get_data_info(witness_set: &WitnessSet) -> Vec<(DatumHash, PlutusData)> {
         .as_deref()
         .map(|s| {
             s.iter()
-                .cloned()
                 .map(|d| (d.original_hash(), d.clone().unwrap()))
                 .sorted()
                 .collect()

--- a/pallas-validate/src/phase2/tx.rs
+++ b/pallas-validate/src/phase2/tx.rs
@@ -162,8 +162,7 @@ fn execute_script(
         .map(|d| plutus_data_to_pragma_term(&arena, d));
 
     let flat: pallas_codec::minicbor::bytes::ByteVec =
-        pallas_codec::minicbor::decode(&script_bytes)
-            .map_err(pallas_codec::minicbor::decode::Error::from)?;
+        pallas_codec::minicbor::decode(script_bytes)?;
 
     let program = pallas_uplc::flat::decode(&arena, &flat)?;
 
@@ -185,16 +184,10 @@ fn execute_script(
         // a non-error result is enough success criteria for v1v2
         ScriptContext::V1V2 { .. } => result.term.is_ok(),
         // v3 requires the result to be ok and the term to be a unit
-        ScriptContext::V3 { .. } => match result.term {
-            Ok(term) => match term {
-                Term::Constant(constant) => match constant {
-                    Constant::Unit => true,
-                    _ => false,
-                },
-                _ => false,
-            },
-            Err(_) => false,
-        },
+        ScriptContext::V3 { .. } => matches!(
+            result.term,
+            Ok(Term::Constant(constant)) if matches!(*constant, Constant::Unit)
+        ),
     };
 
     Ok(TxEvalResult {

--- a/pallas-validate/tests/babbage.rs
+++ b/pallas-validate/tests/babbage.rs
@@ -36,12 +36,7 @@ mod babbage_tests {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage3.tx"));
         let mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
         let metx: MultiEraTx = MultiEraTx::from_babbage(&mtx);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[BabbageTxOutInfo] = &[(
             String::from("011be1f490912af2fc39f8e3637a2bade2ecbebefe63e8bfef10989cd6f593309a155b0ebb45ff830747e61f98e5b77feaf7529ce9df351382"),
             Value::Coin(103324335),
             None,
@@ -74,12 +69,7 @@ mod babbage_tests {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage4.tx"));
         let mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
         let metx: MultiEraTx = MultiEraTx::from_babbage(&mtx);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[
+        let tx_outs_info: &[BabbageTxOutInfo] = &[
             (
                 String::from("11a55f409501bf65805bb0dc76f6f9ae90b61e19ed870bc0025681360881728e7ed4cf324e1323135e7e6d931f01e30792d9cdf17129cb806d"),
                 Value::Coin(25000000),
@@ -113,12 +103,7 @@ mod babbage_tests {
             ),
         ];
         let mut utxos: UTxOs = mk_utxo_for_babbage_tx(&mtx.transaction_body, tx_outs_info);
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[BabbageCollateralInfo] = &[(
             String::from("01f1e126304308006938d2e8571842ff87302fff95a037b3fd838451b8b3c9396d0680d912487139cb7fc85aa279ea70e8cdacee4c6cae40fd"),
             Value::Coin(5000000),
             None,
@@ -151,12 +136,7 @@ mod babbage_tests {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage7.tx"));
         let mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
         let metx: MultiEraTx = MultiEraTx::from_babbage(&mtx);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[
+        let tx_outs_info: &[BabbageTxOutInfo] = &[
             (
                 String::from("119068A7A3F008803EDAC87AF1619860F2CDCDE40C26987325ACE138AD81728E7ED4CF324E1323135E7E6D931F01E30792D9CDF17129CB806D"),
                 Value::Multiasset(
@@ -187,24 +167,14 @@ mod babbage_tests {
             ),
         ];
         let mut utxos: UTxOs = mk_utxo_for_babbage_tx(&mtx.transaction_body, tx_outs_info);
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[BabbageCollateralInfo] = &[(
             String::from("01a7d37f1d43d1197a994d95b3ce15d9af3b4697cc7cdf9bcd1f81688d3499ac08066b36bc6c2d86a21243b940e84dbe5cac3fab5f76ab9229"),
             Value::Coin(5000000),
             None,
             None,
         )];
         add_collateral_babbage(&mtx.transaction_body, &mut utxos, collateral_info);
-        let ref_input_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let ref_input_info: &[BabbageRefInputInfo] = &[(
             String::from("119068a7a3f008803edac87af1619860f2cdcde40c26987325ace138ad81728e7ed4cf324e1323135e7e6d931f01e30792d9cdf17129cb806d"),
             Value::Coin(40000000),
             None,
@@ -237,12 +207,7 @@ mod babbage_tests {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage12.tx"));
         let mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
         let metx: MultiEraTx = MultiEraTx::from_babbage(&mtx);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[
+        let tx_outs_info: &[BabbageTxOutInfo] = &[
             (
                 String::from("60b5f82aaebdc942bb0c8774dc712338b82e5133fe69ebbc3b6312098e"),
                 Value::Coin(20000000),
@@ -280,12 +245,7 @@ mod babbage_tests {
             ),
         ];
         let mut utxos: UTxOs = mk_utxo_for_babbage_tx(&mtx.transaction_body, tx_outs_info);
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[BabbageCollateralInfo] = &[(
             String::from("60b5f82aaebdc942bb0c8774dc712338b82e5133fe69ebbc3b6312098e"),
             Value::Coin(20000000),
             None,
@@ -321,12 +281,7 @@ mod babbage_tests {
         let plutus_data_cbor: Vec<u8> = hex::decode(
             "D8799FD8799F1A1DCD650019300BFF1B0000018B2B449D97581C28B3E2B8259FAABB566361635C4F8BBF31FE1388B15565F917C33C85FF"
         ).unwrap();
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[
+        let tx_outs_info: &[BabbageTxOutInfo] = &[
             (
                 String::from("30DAB18165AE50399C5E477E0CFB38D0B35B32C75F7EB150EBC7874A5EDAB18165AE50399C5E477E0CFB38D0B35B32C75F7EB150EBC7874A5E"),
                 Value::Multiasset(
@@ -364,12 +319,7 @@ mod babbage_tests {
             ),
         ];
         let mut utxos: UTxOs = mk_utxo_for_babbage_tx(&mtx.transaction_body, tx_outs_info);
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[BabbageCollateralInfo] = &[(
             String::from("0028B3E2B8259FAABB566361635C4F8BBF31FE1388B15565F917C33C85700D57DE08040F55793195E7ED87E693DBFCF4A62CF3597B1BC93567"),
             Value::Coin(70884589),
             None,
@@ -402,12 +352,7 @@ mod babbage_tests {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage5.tx"));
         let mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
         let metx: MultiEraTx = MultiEraTx::from_babbage(&mtx);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[
+        let tx_outs_info: &[BabbageTxOutInfo] = &[
             (
                 String::from("719b85d5e8611945505f078aeededcbed1d6ca11053f61e3f9d999fe44"),
                 Value::Multiasset(
@@ -469,12 +414,7 @@ mod babbage_tests {
             ),
         ];
         let mut utxos: UTxOs = mk_utxo_for_babbage_tx(&mtx.transaction_body, tx_outs_info);
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[BabbageCollateralInfo] = &[(
             String::from("0121316dbc84420a5ee7461438483564c41fae876029319b3ee641fe4422339411d2df4c9c7c50b3d8f88db98d475e9d1bccd4244b412fbe5e"),
             Value::Coin(5000000),
             None,
@@ -507,12 +447,7 @@ mod babbage_tests {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage6.tx"));
         let mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
         let metx: MultiEraTx = MultiEraTx::from_babbage(&mtx);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[
+        let tx_outs_info: &[BabbageTxOutInfo] = &[
             (
                 String::from("11A55F409501BF65805BB0DC76F6F9AE90B61E19ED870BC0025681360881728E7ED4CF324E1323135E7E6D931F01E30792D9CDF17129CB806D"),
                 Value::Multiasset(
@@ -543,12 +478,7 @@ mod babbage_tests {
             ),
         ];
         let mut utxos: UTxOs = mk_utxo_for_babbage_tx(&mtx.transaction_body, tx_outs_info);
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[BabbageCollateralInfo] = &[(
             String::from("01eda33318624ade03d53b7e954713d9e69440891f0d02e823267b610d6018dc6c7989a46ec26822425a3d2bac60eec2682a022740361ed957"),
             Value::Coin(5000000),
             None,
@@ -579,12 +509,7 @@ mod babbage_tests {
     fn empty_ins() {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage3.tx"));
         let mut mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[BabbageTxOutInfo] = &[(
             String::from("011be1f490912af2fc39f8e3637a2bade2ecbebefe63e8bfef10989cd6f593309a155b0ebb45ff830747e61f98e5b77feaf7529ce9df351382"),
             Value::Coin(103324335),
             None,
@@ -612,7 +537,7 @@ mod babbage_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "Inputs set should not be empty"),
+            Ok(()) => panic!("Inputs set should not be empty"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::TxInsEmpty) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -642,7 +567,7 @@ mod babbage_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "All inputs should be within the UTxO set"),
+            Ok(()) => panic!("All inputs should be within the UTxO set"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::InputNotInUTxO) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -656,12 +581,7 @@ mod babbage_tests {
     fn validity_interval_lower_bound_unreached() {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage3.tx"));
         let mut mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[BabbageTxOutInfo] = &[(
             String::from("011be1f490912af2fc39f8e3637a2bade2ecbebefe63e8bfef10989cd6f593309a155b0ebb45ff830747e61f98e5b77feaf7529ce9df351382"),
             Value::Coin(103324335),
             None,
@@ -689,10 +609,7 @@ mod babbage_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(
-                false,
-                "Validity interval lower bound should have been reached"
-            ),
+            Ok(()) => panic!("Validity interval lower bound should have been reached"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::BlockPrecedesValInt) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -706,12 +623,7 @@ mod babbage_tests {
     fn validity_interval_upper_bound_surpassed() {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage3.tx"));
         let mut mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[BabbageTxOutInfo] = &[(
             String::from("011be1f490912af2fc39f8e3637a2bade2ecbebefe63e8bfef10989cd6f593309a155b0ebb45ff830747e61f98e5b77feaf7529ce9df351382"),
             Value::Coin(103324335),
             None,
@@ -739,10 +651,7 @@ mod babbage_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(
-                false,
-                "Validity interval upper bound should not have been surpassed"
-            ),
+            Ok(()) => panic!("Validity interval upper bound should not have been surpassed"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::BlockExceedsValInt) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -757,12 +666,7 @@ mod babbage_tests {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage3.tx"));
         let mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
         let metx: MultiEraTx = MultiEraTx::from_babbage(&mtx);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[BabbageTxOutInfo] = &[(
             String::from("011be1f490912af2fc39f8e3637a2bade2ecbebefe63e8bfef10989cd6f593309a155b0ebb45ff830747e61f98e5b77feaf7529ce9df351382"),
             Value::Coin(103324335),
             None,
@@ -785,7 +689,7 @@ mod babbage_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "Fee should not be below minimum"),
+            Ok(()) => panic!("Fee should not be below minimum"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::FeeBelowMin) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -799,12 +703,7 @@ mod babbage_tests {
     fn no_collateral_inputs() {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage4.tx"));
         let mut mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[
+        let tx_outs_info: &[BabbageTxOutInfo] = &[
             (
                 String::from("11a55f409501bf65805bb0dc76f6f9ae90b61e19ed870bc0025681360881728e7ed4cf324e1323135e7e6d931f01e30792d9cdf17129cb806d"),
                 Value::Coin(25000000),
@@ -838,12 +737,7 @@ mod babbage_tests {
             ),
         ];
         let mut utxos: UTxOs = mk_utxo_for_babbage_tx(&mtx.transaction_body, tx_outs_info);
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[BabbageCollateralInfo] = &[(
             String::from("01f1e126304308006938d2e8571842ff87302fff95a037b3fd838451b8b3c9396d0680d912487139cb7fc85aa279ea70e8cdacee4c6cae40fd"),
             Value::Coin(5000000),
             None,
@@ -871,7 +765,7 @@ mod babbage_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "No collateral inputs"),
+            Ok(()) => panic!("No collateral inputs"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::CollateralMissing) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -887,12 +781,7 @@ mod babbage_tests {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage4.tx"));
         let mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
         let metx: MultiEraTx = MultiEraTx::from_babbage(&mtx);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[
+        let tx_outs_info: &[BabbageTxOutInfo] = &[
             (
                 String::from("11a55f409501bf65805bb0dc76f6f9ae90b61e19ed870bc0025681360881728e7ed4cf324e1323135e7e6d931f01e30792d9cdf17129cb806d"),
                 Value::Coin(25000000),
@@ -926,12 +815,7 @@ mod babbage_tests {
             ),
         ];
         let mut utxos: UTxOs = mk_utxo_for_babbage_tx(&mtx.transaction_body, tx_outs_info);
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[BabbageCollateralInfo] = &[(
             String::from("01f1e126304308006938d2e8571842ff87302fff95a037b3fd838451b8b3c9396d0680d912487139cb7fc85aa279ea70e8cdacee4c6cae40fd"),
             Value::Coin(5000000),
             None,
@@ -954,7 +838,7 @@ mod babbage_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "Number of collateral inputs should be within limits"),
+            Ok(()) => panic!("Number of collateral inputs should be within limits"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::TooManyCollaterals) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -968,12 +852,7 @@ mod babbage_tests {
     fn collateral_is_not_verification_key_locked() {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage4.tx"));
         let mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[
+        let tx_outs_info: &[BabbageTxOutInfo] = &[
             (
                 String::from("11a55f409501bf65805bb0dc76f6f9ae90b61e19ed870bc0025681360881728e7ed4cf324e1323135e7e6d931f01e30792d9cdf17129cb806d"),
                 Value::Coin(25000000),
@@ -1055,7 +934,7 @@ mod babbage_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "Collateral inputs should be verification-key locked"),
+            Ok(()) => panic!("Collateral inputs should be verification-key locked"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::CollateralNotVKeyLocked) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -1071,12 +950,7 @@ mod babbage_tests {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage4.tx"));
         let mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
         let metx: MultiEraTx = MultiEraTx::from_babbage(&mtx);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[
+        let tx_outs_info: &[BabbageTxOutInfo] = &[
             (
                 String::from("11a55f409501bf65805bb0dc76f6f9ae90b61e19ed870bc0025681360881728e7ed4cf324e1323135e7e6d931f01e30792d9cdf17129cb806d"),
                 Value::Coin(25000000),
@@ -1132,12 +1006,7 @@ mod babbage_tests {
             ),
         ];
         let mut utxos: UTxOs = mk_utxo_for_babbage_tx(&mtx.transaction_body, tx_outs_info);
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[BabbageCollateralInfo] = &[(
             String::from("01f1e126304308006938d2e8571842ff87302fff95a037b3fd838451b8b3c9396d0680d912487139cb7fc85aa279ea70e8cdacee4c6cae40fd"),
             Value::Multiasset(
                 5000000,
@@ -1169,7 +1038,7 @@ mod babbage_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "Collateral balance should contained only lovelace"),
+            Ok(()) => panic!("Collateral balance should contained only lovelace"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::NonLovelaceCollateral) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -1184,12 +1053,7 @@ mod babbage_tests {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage4.tx"));
         let mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
         let metx: MultiEraTx = MultiEraTx::from_babbage(&mtx);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[
+        let tx_outs_info: &[BabbageTxOutInfo] = &[
             (
                 String::from("11a55f409501bf65805bb0dc76f6f9ae90b61e19ed870bc0025681360881728e7ed4cf324e1323135e7e6d931f01e30792d9cdf17129cb806d"),
                 Value::Coin(25000000),
@@ -1223,12 +1087,7 @@ mod babbage_tests {
             ),
         ];
         let mut utxos: UTxOs = mk_utxo_for_babbage_tx(&mtx.transaction_body, tx_outs_info);
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[BabbageCollateralInfo] = &[(
             String::from("01f1e126304308006938d2e8571842ff87302fff95a037b3fd838451b8b3c9396d0680d912487139cb7fc85aa279ea70e8cdacee4c6cae40fd"),
             Value::Coin(5000000),
             None,
@@ -1252,10 +1111,7 @@ mod babbage_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(
-                false,
-                "Collateral balance should contained the minimum lovelace"
-            ),
+            Ok(()) => panic!("Collateral balance should contained the minimum lovelace"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::CollateralMinLovelace) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -1269,12 +1125,7 @@ mod babbage_tests {
     fn collateral_annotation() {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage4.tx"));
         let mut mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[
+        let tx_outs_info: &[BabbageTxOutInfo] = &[
             (
                 String::from("11a55f409501bf65805bb0dc76f6f9ae90b61e19ed870bc0025681360881728e7ed4cf324e1323135e7e6d931f01e30792d9cdf17129cb806d"),
                 Value::Coin(25000000),
@@ -1308,12 +1159,7 @@ mod babbage_tests {
             ),
         ];
         let mut utxos: UTxOs = mk_utxo_for_babbage_tx(&mtx.transaction_body, tx_outs_info);
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[BabbageCollateralInfo] = &[(
             String::from("01f1e126304308006938d2e8571842ff87302fff95a037b3fd838451b8b3c9396d0680d912487139cb7fc85aa279ea70e8cdacee4c6cae40fd"),
             Value::Coin(5000000),
             None,
@@ -1341,7 +1187,7 @@ mod babbage_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "Collateral annotation"),
+            Ok(()) => panic!("Collateral annotation"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::CollateralAnnotation) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -1355,12 +1201,7 @@ mod babbage_tests {
     fn preservation_of_value() {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage3.tx"));
         let mut mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[BabbageTxOutInfo] = &[(
             String::from("011be1f490912af2fc39f8e3637a2bade2ecbebefe63e8bfef10989cd6f593309a155b0ebb45ff830747e61f98e5b77feaf7529ce9df351382"),
             Value::Coin(103324335),
             None,
@@ -1388,7 +1229,7 @@ mod babbage_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "Preservation of value does not hold"),
+            Ok(()) => panic!("Preservation of value does not hold"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::PreservationOfValue) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -1412,12 +1253,7 @@ mod babbage_tests {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage3.tx"));
         let mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
         let metx: MultiEraTx = MultiEraTx::from_babbage(&mtx);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[BabbageTxOutInfo] = &[(
             String::from("011be1f490912af2fc39f8e3637a2bade2ecbebefe63e8bfef10989cd6f593309a155b0ebb45ff830747e61f98e5b77feaf7529ce9df351382"),
             Value::Coin(103324335),
             None,
@@ -1440,7 +1276,7 @@ mod babbage_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "Output minimum lovelace is unreached"),
+            Ok(()) => panic!("Output minimum lovelace is unreached"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::MinLovelaceUnreached) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -1455,12 +1291,7 @@ mod babbage_tests {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage3.tx"));
         let mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
         let metx: MultiEraTx = MultiEraTx::from_babbage(&mtx);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[BabbageTxOutInfo] = &[(
             String::from("011be1f490912af2fc39f8e3637a2bade2ecbebefe63e8bfef10989cd6f593309a155b0ebb45ff830747e61f98e5b77feaf7529ce9df351382"),
             Value::Coin(103324335),
             None,
@@ -1483,7 +1314,7 @@ mod babbage_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "Max value size exceeded"),
+            Ok(()) => panic!("Max value size exceeded"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::MaxValSizeExceeded) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -1497,12 +1328,7 @@ mod babbage_tests {
     fn output_network_id() {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage3.tx"));
         let mut mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[BabbageTxOutInfo] = &[(
             String::from("011be1f490912af2fc39f8e3637a2bade2ecbebefe63e8bfef10989cd6f593309a155b0ebb45ff830747e61f98e5b77feaf7529ce9df351382"),
             Value::Coin(103324335),
             None,
@@ -1572,10 +1398,7 @@ mod babbage_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(
-                false,
-                "Output network ID should match environment network ID"
-            ),
+            Ok(()) => panic!("Output network ID should match environment network ID"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::OutputWrongNetworkID) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -1589,12 +1412,7 @@ mod babbage_tests {
     fn tx_network_id() {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage3.tx"));
         let mut mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[BabbageTxOutInfo] = &[(
             String::from("011be1f490912af2fc39f8e3637a2bade2ecbebefe63e8bfef10989cd6f593309a155b0ebb45ff830747e61f98e5b77feaf7529ce9df351382"),
             Value::Coin(103324335),
             None,
@@ -1622,10 +1440,7 @@ mod babbage_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(
-                false,
-                "Transaction network ID should match environment network ID"
-            ),
+            Ok(()) => panic!("Transaction network ID should match environment network ID"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::TxWrongNetworkID) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -1641,12 +1456,7 @@ mod babbage_tests {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage4.tx"));
         let mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
         let metx: MultiEraTx = MultiEraTx::from_babbage(&mtx);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[
+        let tx_outs_info: &[BabbageTxOutInfo] = &[
             (
                 String::from("11a55f409501bf65805bb0dc76f6f9ae90b61e19ed870bc0025681360881728e7ed4cf324e1323135e7e6d931f01e30792d9cdf17129cb806d"),
                 Value::Coin(25000000),
@@ -1680,12 +1490,7 @@ mod babbage_tests {
             ),
         ];
         let mut utxos: UTxOs = mk_utxo_for_babbage_tx(&mtx.transaction_body, tx_outs_info);
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[BabbageCollateralInfo] = &[(
             String::from("01f1e126304308006938d2e8571842ff87302fff95a037b3fd838451b8b3c9396d0680d912487139cb7fc85aa279ea70e8cdacee4c6cae40fd"),
             Value::Coin(5000000),
             None,
@@ -1709,7 +1514,7 @@ mod babbage_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "Transaction ex units should be below maximum"),
+            Ok(()) => panic!("Transaction ex units should be below maximum"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::TxExUnitsExceeded) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -1725,12 +1530,7 @@ mod babbage_tests {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage3.tx"));
         let mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
         let metx: MultiEraTx = MultiEraTx::from_babbage(&mtx);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[BabbageTxOutInfo] = &[(
             String::from("011be1f490912af2fc39f8e3637a2bade2ecbebefe63e8bfef10989cd6f593309a155b0ebb45ff830747e61f98e5b77feaf7529ce9df351382"),
             Value::Coin(103324335),
             None,
@@ -1753,10 +1553,7 @@ mod babbage_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(
-                false,
-                "Transaction size should not exceed the maximum allowed"
-            ),
+            Ok(()) => panic!("Transaction size should not exceed the maximum allowed"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::MaxTxSizeExceeded) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -1770,12 +1567,7 @@ mod babbage_tests {
     fn minting_lacks_policy() {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage5.tx"));
         let mut mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[
+        let tx_outs_info: &[BabbageTxOutInfo] = &[
             (
                 String::from("719b85d5e8611945505f078aeededcbed1d6ca11053f61e3f9d999fe44"),
                 Value::Multiasset(
@@ -1837,12 +1629,7 @@ mod babbage_tests {
             ),
         ];
         let mut utxos: UTxOs = mk_utxo_for_babbage_tx(&mtx.transaction_body, tx_outs_info);
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[BabbageCollateralInfo] = &[(
             String::from("0121316dbc84420a5ee7461438483564c41fae876029319b3ee641fe4422339411d2df4c9c7c50b3d8f88db98d475e9d1bccd4244b412fbe5e"),
             Value::Coin(5000000),
             None,
@@ -1870,10 +1657,7 @@ mod babbage_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(
-                false,
-                "Minting policy is not supported by the corresponding native script"
-            ),
+            Ok(()) => panic!("Minting policy is not supported by the corresponding native script"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::MintingLacksPolicy(_)) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -1889,12 +1673,7 @@ mod babbage_tests {
         let mut mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
         mtx.auxiliary_data = None.into();
         let metx: MultiEraTx = MultiEraTx::from_babbage(&mtx);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[
+        let tx_outs_info: &[BabbageTxOutInfo] = &[
             (
                 String::from("11A55F409501BF65805BB0DC76F6F9AE90B61E19ED870BC0025681360881728E7ED4CF324E1323135E7E6D931F01E30792D9CDF17129CB806D"),
                 Value::Multiasset(
@@ -1925,12 +1704,7 @@ mod babbage_tests {
             ),
         ];
         let mut utxos: UTxOs = mk_utxo_for_babbage_tx(&mtx.transaction_body, tx_outs_info);
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[BabbageCollateralInfo] = &[(
             String::from("01eda33318624ade03d53b7e954713d9e69440891f0d02e823267b610d6018dc6c7989a46ec26822425a3d2bac60eec2682a022740361ed957"),
             Value::Coin(5000000),
             None,
@@ -1951,7 +1725,7 @@ mod babbage_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "Transaction auxiliary data removed"),
+            Ok(()) => panic!("Transaction auxiliary data removed"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::MetadataHash) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -1966,12 +1740,7 @@ mod babbage_tests {
     fn script_input_lacks_script() {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage4.tx"));
         let mut mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[
+        let tx_outs_info: &[BabbageTxOutInfo] = &[
             (
                 String::from("11a55f409501bf65805bb0dc76f6f9ae90b61e19ed870bc0025681360881728e7ed4cf324e1323135e7e6d931f01e30792d9cdf17129cb806d"),
                 Value::Coin(25000000),
@@ -2005,12 +1774,7 @@ mod babbage_tests {
             ),
         ];
         let mut utxos: UTxOs = mk_utxo_for_babbage_tx(&mtx.transaction_body, tx_outs_info);
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[BabbageCollateralInfo] = &[(
             String::from("01f1e126304308006938d2e8571842ff87302fff95a037b3fd838451b8b3c9396d0680d912487139cb7fc85aa279ea70e8cdacee4c6cae40fd"),
             Value::Coin(5000000),
             None,
@@ -2038,10 +1802,7 @@ mod babbage_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(
-                false,
-                "Script hash in input is not matched to a script in the witness set"
-            ),
+            Ok(()) => panic!("Script hash in input is not matched to a script in the witness set"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::ScriptWitnessMissing) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -2055,12 +1816,7 @@ mod babbage_tests {
     fn missing_input_datum() {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage4.tx"));
         let mut mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[
+        let tx_outs_info: &[BabbageTxOutInfo] = &[
             (
                 String::from("11a55f409501bf65805bb0dc76f6f9ae90b61e19ed870bc0025681360881728e7ed4cf324e1323135e7e6d931f01e30792d9cdf17129cb806d"),
                 Value::Coin(25000000),
@@ -2094,12 +1850,7 @@ mod babbage_tests {
             ),
         ];
         let mut utxos: UTxOs = mk_utxo_for_babbage_tx(&mtx.transaction_body, tx_outs_info);
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[BabbageCollateralInfo] = &[(
             String::from("01f1e126304308006938d2e8571842ff87302fff95a037b3fd838451b8b3c9396d0680d912487139cb7fc85aa279ea70e8cdacee4c6cae40fd"),
             Value::Coin(5000000),
             None,
@@ -2141,12 +1892,7 @@ mod babbage_tests {
     fn extra_input_datum() {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage4.tx"));
         let mut mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[
+        let tx_outs_info: &[BabbageTxOutInfo] = &[
             (
                 String::from("11a55f409501bf65805bb0dc76f6f9ae90b61e19ed870bc0025681360881728e7ed4cf324e1323135e7e6d931f01e30792d9cdf17129cb806d"),
                 Value::Coin(25000000),
@@ -2180,12 +1926,7 @@ mod babbage_tests {
             ),
         ];
         let mut utxos: UTxOs = mk_utxo_for_babbage_tx(&mtx.transaction_body, tx_outs_info);
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[BabbageCollateralInfo] = &[(
             String::from("01f1e126304308006938d2e8571842ff87302fff95a037b3fd838451b8b3c9396d0680d912487139cb7fc85aa279ea70e8cdacee4c6cae40fd"),
             Value::Coin(5000000),
             None,
@@ -2233,12 +1974,7 @@ mod babbage_tests {
     fn extra_redeemer() {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage4.tx"));
         let mut mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[
+        let tx_outs_info: &[BabbageTxOutInfo] = &[
             (
                 String::from("11a55f409501bf65805bb0dc76f6f9ae90b61e19ed870bc0025681360881728e7ed4cf324e1323135e7e6d931f01e30792d9cdf17129cb806d"),
                 Value::Coin(25000000),
@@ -2272,12 +2008,7 @@ mod babbage_tests {
             ),
         ];
         let mut utxos: UTxOs = mk_utxo_for_babbage_tx(&mtx.transaction_body, tx_outs_info);
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[BabbageCollateralInfo] = &[(
             String::from("01f1e126304308006938d2e8571842ff87302fff95a037b3fd838451b8b3c9396d0680d912487139cb7fc85aa279ea70e8cdacee4c6cae40fd"),
             Value::Coin(5000000),
             None,
@@ -2328,12 +2059,7 @@ mod babbage_tests {
     fn script_integrity_hash() {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/babbage4.tx"));
         let mut mtx: Tx = babbage_minted_tx_from_cbor(&cbor_bytes);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[
+        let tx_outs_info: &[BabbageTxOutInfo] = &[
             (
                 String::from("11a55f409501bf65805bb0dc76f6f9ae90b61e19ed870bc0025681360881728e7ed4cf324e1323135e7e6d931f01e30792d9cdf17129cb806d"),
                 Value::Coin(25000000),
@@ -2367,12 +2093,7 @@ mod babbage_tests {
             ),
         ];
         let mut utxos: UTxOs = mk_utxo_for_babbage_tx(&mtx.transaction_body, tx_outs_info);
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[BabbageCollateralInfo] = &[(
             String::from("01f1e126304308006938d2e8571842ff87302fff95a037b3fd838451b8b3c9396d0680d912487139cb7fc85aa279ea70e8cdacee4c6cae40fd"),
             Value::Coin(5000000),
             None,

--- a/pallas-validate/tests/common.rs
+++ b/pallas-validate/tests/common.rs
@@ -17,21 +17,21 @@ use pallas_codec::utils::{Bytes, CborWrap};
 use pallas_crypto::hash::Hash;
 
 // Type aliases to reduce complexity
-type BabbageTxOutInfo<'a> = (
+pub type BabbageTxOutInfo<'a> = (
     String, // address in string format
     Value,
     Option<pallas_primitives::babbage::DatumOption<'a>>,
     Option<CborWrap<pallas_primitives::babbage::ScriptRef<'a>>>,
 );
 
-type ConwayTxOutInfo<'a> = (
+pub type ConwayTxOutInfo<'a> = (
     String, // address in string format
     pallas_primitives::conway::Value,
     Option<pallas_primitives::conway::DatumOption<'a>>,
     Option<CborWrap<pallas_primitives::conway::ScriptRef<'a>>>,
 );
 
-type ConwayTxOutInfoMut<'a> = (
+pub type ConwayTxOutInfoMut<'a> = (
     String, // address in string format
     pallas_primitives::conway::Value,
     Option<pallas_codec::utils::KeepRaw<'a, pallas_primitives::conway::DatumOption<'a>>>,
@@ -39,27 +39,27 @@ type ConwayTxOutInfoMut<'a> = (
     Vec<u8>, // Placeholder for CBOR data.
 );
 
-type AlonzoCollateralInfo = (
+pub type AlonzoCollateralInfo = (
     String, // address in string format
     Value,
     Option<Hash<32>>,
 );
 
-type BabbageCollateralInfo<'a> = (
+pub type BabbageCollateralInfo<'a> = (
     String, // address in string format
     Value,
     Option<pallas_primitives::babbage::DatumOption<'a>>,
     Option<CborWrap<pallas_primitives::babbage::ScriptRef<'a>>>,
 );
 
-type ConwayCollateralInfo<'a> = (
+pub type ConwayCollateralInfo<'a> = (
     String, // address in string format
     pallas_primitives::conway::Value,
     Option<pallas_primitives::conway::DatumOption<'a>>,
     Option<CborWrap<pallas_primitives::conway::ScriptRef<'a>>>,
 );
 
-type ConwayCollateralInfoMut<'a> = (
+pub type ConwayCollateralInfoMut<'a> = (
     String, // address in string format
     pallas_primitives::conway::Value,
     Option<pallas_codec::utils::KeepRaw<'a, pallas_primitives::conway::DatumOption<'a>>>,
@@ -67,21 +67,21 @@ type ConwayCollateralInfoMut<'a> = (
     Vec<u8>, // Placeholder for CBOR data.
 );
 
-type BabbageRefInputInfo<'a> = (
+pub type BabbageRefInputInfo<'a> = (
     String, // address in string format
     Value,
     Option<pallas_primitives::babbage::DatumOption<'a>>,
     Option<CborWrap<pallas_primitives::babbage::ScriptRef<'a>>>,
 );
 
-type ConwayRefInputInfo<'a> = (
+pub type ConwayRefInputInfo<'a> = (
     String, // address in string format
     pallas_primitives::conway::Value,
     Option<pallas_primitives::conway::DatumOption<'a>>,
     Option<CborWrap<pallas_primitives::conway::ScriptRef<'a>>>,
 );
 
-type ConwayRefInputInfoMut<'a> = (
+pub type ConwayRefInputInfoMut<'a> = (
     String, // address in string format
     pallas_primitives::conway::Value,
     Option<pallas_codec::utils::KeepRaw<'a, pallas_primitives::conway::DatumOption<'a>>>,

--- a/pallas-validate/tests/conway.rs
+++ b/pallas-validate/tests/conway.rs
@@ -42,12 +42,7 @@ mod conway_tests {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/conway3.tx"));
         let mtx: Tx = conway_minted_tx_from_cbor(&cbor_bytes);
         let metx: MultiEraTx = MultiEraTx::from_conway(&mtx);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[ConwayTxOutInfo] = &[(
             String::from("015c5c318d01f729e205c95eb1b02d623dd10e78ea58f72d0c13f892b2e8904edc699e2f0ce7b72be7cec991df651a222e2ae9244eb5975cba"),
             Value::Coin(20000000),
             None,
@@ -86,13 +81,7 @@ mod conway_tests {
         let datum_option = minicbor::to_vec(datum_option).unwrap();
         let datum_option: KeepRaw<'_, DatumOption> = minicbor::decode(&datum_option).unwrap();
 
-        let mut tx_outs_info: Vec<(
-            String,
-            Value,
-            Option<KeepRaw<'_, DatumOption>>,
-            Option<CborWrap<ScriptRef>>,
-            Vec<u8>,
-        )> = vec![
+        let mut tx_outs_info: Vec<ConwayTxOutInfoMut> = vec![
             (
                 String::from("005c5c318d01f729e205c95eb1b02d623dd10e78ea58f72d0c13f892b2e8904edc699e2f0ce7b72be7cec991df651a222e2ae9244eb5975cba"),
                 Value::Coin(2554710123),
@@ -112,13 +101,7 @@ mod conway_tests {
         let mut utxos: UTxOs =
             mk_codec_safe_utxo_for_conway_tx(&mtx.transaction_body, &mut tx_outs_info);
 
-        let mut ref_info: Vec<(
-            String,
-            Value,
-            Option<KeepRaw<'_, DatumOption>>,
-            Option<CborWrap<ScriptRef>>,
-            Vec<u8>,
-        )> = vec![
+        let mut ref_info: Vec<ConwayRefInputInfoMut> = vec![
             (
                 String::from("70faae60072c45d121b6e58ae35c624693ee3dad9ea8ed765eb6f76f9f"),
                 Value::Coin(1624870),
@@ -130,13 +113,7 @@ mod conway_tests {
 
         add_codec_safe_ref_input_conway(&mtx.transaction_body, &mut utxos, &mut ref_info);
 
-        let mut collateral_info: Vec<(
-            String,
-            Value,
-            Option<KeepRaw<'_, DatumOption>>,
-            Option<CborWrap<ScriptRef>>,
-          Vec<u8>,
-        )> = vec![(
+        let mut collateral_info: Vec<ConwayCollateralInfoMut> = vec![(
             String::from("005c5c318d01f729e205c95eb1b02d623dd10e78ea58f72d0c13f892b2e8904edc699e2f0ce7b72be7cec991df651a222e2ae9244eb5975cba"),
             Value::Coin(2554439518),
             None,
@@ -158,7 +135,7 @@ mod conway_tests {
         };
         let mut cert_state: CertState = CertState::default();
 
-        match validate_txs(&[metx.clone()], &env, &utxos, &mut cert_state) {
+        match validate_txs(std::slice::from_ref(&metx), &env, &utxos, &mut cert_state) {
             Ok(()) => (),
             Err(err) => panic!("Unexpected error ({err:?})"),
         };
@@ -187,13 +164,7 @@ mod conway_tests {
         let datum_option = minicbor::to_vec(datum_option).unwrap();
         let datum_option: KeepRaw<'_, DatumOption> = minicbor::decode(&datum_option).unwrap();
 
-        let mut tx_outs_info: Vec<(
-            String,
-            Value,
-            Option<KeepRaw<'_, DatumOption>>,
-            Option<CborWrap<ScriptRef>>,
-            Vec<u8>,
-        )> = vec![(
+        let mut tx_outs_info: Vec<ConwayTxOutInfoMut> = vec![(
             String::from("71faae60072c45d121b6e58ae35c624693ee3dad9ea8ed765eb6f76f9f"),
             Value::Coin(2000000),
             Some(datum_option),
@@ -204,13 +175,7 @@ mod conway_tests {
         let mut utxos: UTxOs =
             mk_codec_safe_utxo_for_conway_tx(&mtx.transaction_body, &mut tx_outs_info);
 
-        let mut ref_info: Vec<(
-            String,
-            Value,
-            Option<KeepRaw<'_, DatumOption>>,
-            Option<CborWrap<ScriptRef>>,
-            Vec<u8>,
-        )> = vec![
+        let mut ref_info: Vec<ConwayRefInputInfoMut> = vec![
             (
                 String::from("71faae60072c45d121b6e58ae35c624693ee3dad9ea8ed765eb6f76f9f"),
                 Value::Coin(1624870),
@@ -222,13 +187,7 @@ mod conway_tests {
 
         add_codec_safe_ref_input_conway(&mtx.transaction_body, &mut utxos, &mut ref_info);
 
-        let mut collateral_info: Vec<(
-            String,
-            Value,
-            Option<KeepRaw<'_, DatumOption>>,
-            Option<CborWrap<ScriptRef>>,
-            Vec<u8>,
-        )> = vec![(
+        let mut collateral_info: Vec<ConwayCollateralInfoMut> = vec![(
             String::from("015c5c318d01f729e205c95eb1b02d623dd10e78ea58f72d0c13f892b2e8904edc699e2f0ce7b72be7cec991df651a222e2ae9244eb5975cba"),
             Value::Coin(49731771),
             None,
@@ -251,7 +210,7 @@ mod conway_tests {
         };
         let mut cert_state: CertState = CertState::default();
 
-        match validate_txs(&[metx.clone()], &env, &utxos, &mut cert_state) {
+        match validate_txs(std::slice::from_ref(&metx), &env, &utxos, &mut cert_state) {
             Ok(()) => (),
             Err(err) => panic!("Unexpected error ({err:?})"),
         };
@@ -273,12 +232,7 @@ mod conway_tests {
     fn empty_ins() {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/conway3.tx"));
         let mut mtx: Tx = conway_minted_tx_from_cbor(&cbor_bytes);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[ConwayTxOutInfo] = &[(
             String::from("015c5c318d01f729e205c95eb1b02d623dd10e78ea58f72d0c13f892b2e8904edc699e2f0ce7b72be7cec991df651a222e2ae9244eb5975cba"),
             Value::Coin(20000000),
             None,
@@ -306,7 +260,7 @@ mod conway_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "Inputs set should not be empty"),
+            Ok(()) => panic!("Inputs set should not be empty"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::TxInsEmpty) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -336,7 +290,7 @@ mod conway_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "All inputs should be within the UTxO set"),
+            Ok(()) => panic!("All inputs should be within the UTxO set"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::InputNotInUTxO) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -350,12 +304,7 @@ mod conway_tests {
     fn validity_interval_lower_bound_unreached() {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/conway3.tx"));
         let mut mtx: Tx = conway_minted_tx_from_cbor(&cbor_bytes);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[ConwayTxOutInfo] = &[(
             String::from("015c5c318d01f729e205c95eb1b02d623dd10e78ea58f72d0c13f892b2e8904edc699e2f0ce7b72be7cec991df651a222e2ae9244eb5975cba"),
             Value::Coin(20000000),
             None,
@@ -383,10 +332,7 @@ mod conway_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(
-                false,
-                "Validity interval lower bound should have been reached"
-            ),
+            Ok(()) => panic!("Validity interval lower bound should have been reached"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::BlockPrecedesValInt) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -400,12 +346,7 @@ mod conway_tests {
     fn validity_interval_upper_bound_surpassed() {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/conway3.tx"));
         let mut mtx: Tx = conway_minted_tx_from_cbor(&cbor_bytes);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[ConwayTxOutInfo] = &[(
             String::from("015c5c318d01f729e205c95eb1b02d623dd10e78ea58f72d0c13f892b2e8904edc699e2f0ce7b72be7cec991df651a222e2ae9244eb5975cba"),
             Value::Coin(20000000),
             None,
@@ -433,10 +374,7 @@ mod conway_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(
-                false,
-                "Validity interval upper bound should not have been surpassed"
-            ),
+            Ok(()) => panic!("Validity interval upper bound should not have been surpassed"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::BlockExceedsValInt) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -451,12 +389,7 @@ mod conway_tests {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/conway3.tx"));
         let mtx: Tx = conway_minted_tx_from_cbor(&cbor_bytes);
         let metx: MultiEraTx = MultiEraTx::from_conway(&mtx);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[ConwayTxOutInfo] = &[(
             String::from("015c5c318d01f729e205c95eb1b02d623dd10e78ea58f72d0c13f892b2e8904edc699e2f0ce7b72be7cec991df651a222e2ae9244eb5975cba"),
             Value::Coin(20000000),
             None,
@@ -479,7 +412,7 @@ mod conway_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "Fee should not be below minimum"),
+            Ok(()) => panic!("Fee should not be below minimum"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::FeeBelowMin) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -493,12 +426,7 @@ mod conway_tests {
     fn preservation_of_value() {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/conway3.tx"));
         let mut mtx: Tx = conway_minted_tx_from_cbor(&cbor_bytes);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[ConwayTxOutInfo] = &[(
             String::from("015c5c318d01f729e205c95eb1b02d623dd10e78ea58f72d0c13f892b2e8904edc699e2f0ce7b72be7cec991df651a222e2ae9244eb5975cba"),
             Value::Coin(20000000),
             None,
@@ -526,7 +454,7 @@ mod conway_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "Preservation of value does not hold"),
+            Ok(()) => panic!("Preservation of value does not hold"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::PreservationOfValue) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -550,12 +478,7 @@ mod conway_tests {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/conway3.tx"));
         let mtx: Tx = conway_minted_tx_from_cbor(&cbor_bytes);
         let metx: MultiEraTx = MultiEraTx::from_conway(&mtx);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[ConwayTxOutInfo] = &[(
             String::from("015c5c318d01f729e205c95eb1b02d623dd10e78ea58f72d0c13f892b2e8904edc699e2f0ce7b72be7cec991df651a222e2ae9244eb5975cba"),
             Value::Coin(20000000),
             None,
@@ -578,7 +501,7 @@ mod conway_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "Output minimum lovelace is unreached"),
+            Ok(()) => panic!("Output minimum lovelace is unreached"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::MinLovelaceUnreached) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -593,12 +516,7 @@ mod conway_tests {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/conway3.tx"));
         let mtx: Tx = conway_minted_tx_from_cbor(&cbor_bytes);
         let metx: MultiEraTx = MultiEraTx::from_conway(&mtx);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[ConwayTxOutInfo] = &[(
             String::from("015c5c318d01f729e205c95eb1b02d623dd10e78ea58f72d0c13f892b2e8904edc699e2f0ce7b72be7cec991df651a222e2ae9244eb5975cba"),
             Value::Coin(20000000),
             None,
@@ -621,7 +539,7 @@ mod conway_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "Max value size exceeded"),
+            Ok(()) => panic!("Max value size exceeded"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::MaxValSizeExceeded) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -635,12 +553,7 @@ mod conway_tests {
     fn tx_network_id() {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/conway3.tx"));
         let mut mtx: Tx = conway_minted_tx_from_cbor(&cbor_bytes);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[ConwayTxOutInfo] = &[(
             String::from("015c5c318d01f729e205c95eb1b02d623dd10e78ea58f72d0c13f892b2e8904edc699e2f0ce7b72be7cec991df651a222e2ae9244eb5975cba"),
             Value::Coin(20000000),
             None,
@@ -668,10 +581,7 @@ mod conway_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(
-                false,
-                "Transaction network ID should match environment network ID"
-            ),
+            Ok(()) => panic!("Transaction network ID should match environment network ID"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::TxWrongNetworkID) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -687,12 +597,7 @@ mod conway_tests {
         let mut mtx: Tx = conway_minted_tx_from_cbor(&cbor_bytes);
         let datum_bytes = cbor_to_bytes("d8799f4568656c6c6fff");
 
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[ConwayTxOutInfo] = &[(
             String::from("71faae60072c45d121b6e58ae35c624693ee3dad9ea8ed765eb6f76f9f"),
             Value::Coin(2000000),
             Some(DatumOption::Data(CborWrap(
@@ -703,12 +608,7 @@ mod conway_tests {
 
         let mut utxos: UTxOs = mk_utxo_for_conway_tx(&mtx.transaction_body, tx_outs_info);
 
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[ConwayCollateralInfo] = &[(
             String::from("015c5c318d01f729e205c95eb1b02d623dd10e78ea58f72d0c13f892b2e8904edc699e2f0ce7b72be7cec991df651a222e2ae9244eb5975cba"),
             Value::Coin(49731771),
             None,
@@ -738,7 +638,7 @@ mod conway_tests {
 
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "No collateral inputs"),
+            Ok(()) => panic!("No collateral inputs"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::CollateralMissing) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -756,12 +656,7 @@ mod conway_tests {
         let metx: MultiEraTx = MultiEraTx::from_conway(&mtx);
         let datum_bytes = cbor_to_bytes("d8799f4568656c6c6fff");
 
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[ConwayTxOutInfo] = &[(
             String::from("71faae60072c45d121b6e58ae35c624693ee3dad9ea8ed765eb6f76f9f"),
             Value::Coin(2000000),
             Some(DatumOption::Data(CborWrap(
@@ -772,12 +667,7 @@ mod conway_tests {
 
         let mut utxos: UTxOs = mk_utxo_for_conway_tx(&mtx.transaction_body, tx_outs_info);
 
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[ConwayCollateralInfo] = &[(
             String::from("015c5c318d01f729e205c95eb1b02d623dd10e78ea58f72d0c13f892b2e8904edc699e2f0ce7b72be7cec991df651a222e2ae9244eb5975cba"),
             Value::Coin(49731771),
             None,
@@ -803,7 +693,7 @@ mod conway_tests {
 
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "Number of collateral inputs should be within limits"),
+            Ok(()) => panic!("Number of collateral inputs should be within limits"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::TooManyCollaterals) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -819,12 +709,7 @@ mod conway_tests {
         let mtx: Tx = conway_minted_tx_from_cbor(&cbor_bytes);
         let datum_bytes = cbor_to_bytes("d8799f4568656c6c6fff");
 
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[ConwayTxOutInfo] = &[(
             String::from("71faae60072c45d121b6e58ae35c624693ee3dad9ea8ed765eb6f76f9f"),
             Value::Coin(2000000),
             Some(DatumOption::Data(CborWrap(
@@ -885,7 +770,7 @@ mod conway_tests {
 
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "Collateral inputs should be verification-key locked"),
+            Ok(()) => panic!("Collateral inputs should be verification-key locked"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::CollateralNotVKeyLocked) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -903,12 +788,7 @@ mod conway_tests {
         let metx: MultiEraTx = MultiEraTx::from_conway(&mtx);
         let datum_bytes = cbor_to_bytes("d8799f4568656c6c6fff");
 
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[ConwayTxOutInfo] = &[(
             String::from("71faae60072c45d121b6e58ae35c624693ee3dad9ea8ed765eb6f76f9f"),
             Value::Coin(2000000),
             Some(DatumOption::Data(CborWrap(
@@ -931,12 +811,7 @@ mod conway_tests {
             network_id: 1,
             acnt: Some(acnt),
         };
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[ConwayCollateralInfo] = &[(
             String::from("01f1e126304308006938d2e8571842ff87302fff95a037b3fd838451b8b3c9396d0680d912487139cb7fc85aa279ea70e8cdacee4c6cae40fd"),
             Value::Multiasset(
                 5000000,
@@ -960,7 +835,7 @@ mod conway_tests {
 
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "Collateral balance should contained only lovelace"),
+            Ok(()) => panic!("Collateral balance should contained only lovelace"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::NonLovelaceCollateral) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -977,12 +852,7 @@ mod conway_tests {
         let metx: MultiEraTx = MultiEraTx::from_conway(&mtx);
         let datum_bytes = cbor_to_bytes("d8799f4568656c6c6fff");
 
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[ConwayTxOutInfo] = &[(
             String::from("71faae60072c45d121b6e58ae35c624693ee3dad9ea8ed765eb6f76f9f"),
             Value::Coin(2000000),
             Some(DatumOption::Data(CborWrap(
@@ -993,12 +863,7 @@ mod conway_tests {
 
         let mut utxos: UTxOs = mk_utxo_for_conway_tx(&mtx.transaction_body, tx_outs_info);
 
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[ConwayCollateralInfo] = &[(
             String::from("015c5c318d01f729e205c95eb1b02d623dd10e78ea58f72d0c13f892b2e8904edc699e2f0ce7b72be7cec991df651a222e2ae9244eb5975cba"),
             Value::Coin(88118796),
             None,
@@ -1023,10 +888,7 @@ mod conway_tests {
 
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(
-                false,
-                "Collateral balance should contained the minimum lovelace"
-            ),
+            Ok(()) => panic!("Collateral balance should contained the minimum lovelace"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::CollateralMinLovelace) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -1042,12 +904,7 @@ mod conway_tests {
         let mut mtx: Tx = conway_minted_tx_from_cbor(&cbor_bytes);
         let datum_bytes = cbor_to_bytes("d8799f4568656c6c6fff");
 
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[ConwayTxOutInfo] = &[(
             String::from("71faae60072c45d121b6e58ae35c624693ee3dad9ea8ed765eb6f76f9f"),
             Value::Coin(2000000),
             Some(DatumOption::Data(CborWrap(
@@ -1058,12 +915,7 @@ mod conway_tests {
 
         let mut utxos: UTxOs = mk_utxo_for_conway_tx(&mtx.transaction_body, tx_outs_info);
 
-        let collateral_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let collateral_info: &[ConwayCollateralInfo] = &[(
             String::from("015c5c318d01f729e205c95eb1b02d623dd10e78ea58f72d0c13f892b2e8904edc699e2f0ce7b72be7cec991df651a222e2ae9244eb5975cba"),
             Value::Coin(100118796),
             None,
@@ -1094,7 +946,7 @@ mod conway_tests {
 
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(false, "Collateral annotation"),
+            Ok(()) => panic!("Collateral annotation"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::CollateralAnnotation) => (),
                 _ => panic!("Unexpected error ({err:?})"),
@@ -1110,12 +962,7 @@ mod conway_tests {
         let cbor_bytes: Vec<u8> = cbor_to_bytes(include_str!("../../test_data/conway3.tx"));
         let mtx: Tx = conway_minted_tx_from_cbor(&cbor_bytes);
         let metx: MultiEraTx = MultiEraTx::from_conway(&mtx);
-        let tx_outs_info: &[(
-            String,
-            Value,
-            Option<DatumOption>,
-            Option<CborWrap<ScriptRef>>,
-        )] = &[(
+        let tx_outs_info: &[ConwayTxOutInfo] = &[(
             String::from("015c5c318d01f729e205c95eb1b02d623dd10e78ea58f72d0c13f892b2e8904edc699e2f0ce7b72be7cec991df651a222e2ae9244eb5975cba"),
             Value::Coin(20000000),
             None,
@@ -1138,10 +985,7 @@ mod conway_tests {
         };
         let mut cert_state: CertState = CertState::default();
         match validate_txs(&[metx], &env, &utxos, &mut cert_state) {
-            Ok(()) => assert!(
-                false,
-                "Transaction size should not exceed the maximum allowed"
-            ),
+            Ok(()) => panic!("Transaction size should not exceed the maximum allowed"),
             Err(err) => match err {
                 PostAlonzo(PostAlonzoError::MaxTxSizeExceeded) => (),
                 _ => panic!("Unexpected error ({err:?})"),


### PR DESCRIPTION
## Summary
- Resolves all clippy warnings under `cargo clippy --all-targets --all-features` (only an external `chumsky v1.0.0-alpha.7` future-incompat note remains, untouchable from this repo).
- Lib clippy as CI runs it (`cargo clippy -- -D warnings`) is green.
- Notable refactors:
  - `pallas-validate/src/phase1/alonzo.rs`: collateral check now extracts the shared lovelace comparison across `Coin` and `Multiasset` arms (eliminates `collapsible_match`).
  - `pallas-primitives/src/conway/script_data.rs`: `const LazyLock<…>` → `static LazyLock<…>` (interior mutability lint).
  - `pallas-validate/tests/common.rs`: existing tuple type aliases (`BabbageTxOutInfo`, `ConwayCollateralInfoMut`, …) exposed as `pub`; `babbage.rs` / `conway.rs` now use them instead of duplicating 4–5-field tuple types inline.
  - `assert!(false, msg)` → `panic!(msg)` in `pallas-math` and validate tests.
  - Misc small fixes: `sort_by` → `sort_by_key` w/ `Reverse`, removed needless `return`s, removed redundant `.cloned()`, useless `Error::from` conversion, redundant `&`-then-deref, collapsed nested matches into `matches!`, dropped a `-> ()` return.

## Test plan
- [x] `cargo clippy --all-targets --all-features` — clean (modulo external chumsky note)
- [x] `cargo clippy -- -D warnings` (CI invocation) — passes
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p pallas-math --lib` — 19 passed
- [x] `cargo test -p pallas-network --lib` — 240 passed
- [x] `cargo test -p pallas-validate --test babbage --test conway` — all pass
- [x] `cargo check --all-targets --all-features` — builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified code structure across validation, encoding, and networking modules for improved maintainability
  * Optimized version handling and data processing in network communications
  * Improved type organization and error handling patterns

* **Tests**
  * Enhanced test assertions and error reporting
  * Updated test data initialization and structure for better performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->