### PR TITLE
refactor(validate): extract phase2 evaluator and surface failure context

### DIFF
--- a/pallas-validate/src/phase2/error.rs
+++ b/pallas-validate/src/phase2/error.rs
@@ -1,9 +1,8 @@
-use amaru_uplc::{
-    binder::DeBruijn,
-    flat::FlatDecodeError,
-    machine::{self, ExBudget},
+use amaru_uplc::flat::FlatDecodeError;
+use pallas_primitives::{
+    conway::{ExUnits, Language},
+    TransactionInput,
 };
-use pallas_primitives::{conway::Language, TransactionInput};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -15,39 +14,19 @@ pub enum Error {
     FlatDecode(#[from] FlatDecodeError),
     #[error("fragment decode error: {0}")]
     FragmentDecode(#[from] pallas_primitives::Error),
-    #[error("{}{}", .0, .2.iter()
-        .map(|trace| {
-            format!(
-                "\n{:>13} {}",
-                "Trace",
-                if trace.contains('\n') {
-                    trace.lines()
-                        .enumerate()
-                        .map(|(ix, row)| {
-                            if ix == 0 {
-                                row.to_string()
-                            } else {
-                                format!("{:>13} {}", "",
-                                    row
-                                )
-                            }
-                        })
-                        .collect::<Vec<_>>()
-                        .join("\n")
-                } else {
-                    trace.to_string()
-                }
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("")
-        .as_str()
+    #[error(
+        "{message}\n{:>13} {}\n{:>13} {}{}",
+        "Mem",
+        budget.mem,
+        "CPU",
+        budget.steps,
+        format_machine_traces(logs),
     )]
-    Machine(
-        machine::MachineError<'static, DeBruijn>,
-        ExBudget,
-        Vec<String>,
-    ),
+    Machine {
+        message: String,
+        budget: ExUnits,
+        logs: Vec<String>,
+    },
 
     #[error("native script can't be executed in phase-two")]
     NativeScriptPhaseTwo,
@@ -110,4 +89,30 @@ pub enum Error {
     SlotTooFarInThePast { oldest_allowed: u64 },
     #[error("could not build script context")]
     ScriptContextBuildError,
+}
+
+fn format_machine_traces(logs: &[String]) -> String {
+    logs.iter()
+        .map(|trace| format!("\n{:>13} {}", "Trace", indent_trace(trace)))
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+fn indent_trace(trace: &str) -> String {
+    if !trace.contains('\n') {
+        return trace.to_string();
+    }
+
+    trace
+        .lines()
+        .enumerate()
+        .map(|(ix, row)| {
+            if ix == 0 {
+                row.to_string()
+            } else {
+                format!("{:>13} {}", "", row)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }

--- a/pallas-validate/src/phase2/evaluator.rs
+++ b/pallas-validate/src/phase2/evaluator.rs
@@ -1,0 +1,293 @@
+use amaru_uplc::{
+    arena::Arena,
+    binder::DeBruijn,
+    bumpalo::Bump,
+    constant::Constant,
+    data::PlutusData as PragmaPlutusData,
+    flat,
+    machine::{ExBudget, PlutusVersion},
+    program::Program,
+    term::Term,
+};
+use pallas_codec::minicbor;
+use pallas_primitives::conway::{ExUnits, Language, PlutusData};
+
+use super::error::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MachineFailure {
+    pub message: String,
+    pub budget: ExUnits,
+    pub logs: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ScriptEvalResult {
+    pub success: bool,
+    pub units: ExUnits,
+    pub logs: Vec<String>,
+    pub failure: Option<MachineFailure>,
+}
+
+pub(crate) fn eval_script(
+    language: Language,
+    script_bytes: &[u8],
+    datum: Option<&PlutusData>,
+    redeemer: &PlutusData,
+    script_context: &PlutusData,
+    protocol_version_major: u32,
+) -> Result<ScriptEvalResult, Error> {
+    let arena = Arena::from_bump(Bump::with_capacity(1_024_000));
+    let plutus_version = map_language(&language);
+
+    let flat_bytes: minicbor::bytes::ByteVec = minicbor::decode(script_bytes)?;
+
+    let program: &Program<DeBruijn> =
+        flat::decode(&arena, &flat_bytes, plutus_version, protocol_version_major)?;
+
+    let datum_term = datum.map(|d| plutus_data_to_term(&arena, d));
+    let redeemer_term = plutus_data_to_term(&arena, redeemer);
+    let script_context_term = plutus_data_to_term(&arena, script_context);
+
+    let program = match &language {
+        Language::PlutusV1 | Language::PlutusV2 => {
+            let program = if let Some(datum_term) = datum_term {
+                program.apply(&arena, datum_term)
+            } else {
+                program
+            };
+            program
+                .apply(&arena, redeemer_term)
+                .apply(&arena, script_context_term)
+        }
+        Language::PlutusV3 => program.apply(&arena, script_context_term),
+    };
+
+    let result = program.eval_version(&arena, plutus_version);
+
+    let units = budget_to_ex_units(result.info.consumed_budget);
+    let logs = result.info.logs;
+
+    let failure = result.term.as_ref().err().map(|err| MachineFailure {
+        message: err.to_string(),
+        budget: units,
+        logs: logs.clone(),
+    });
+
+    let success = match (&result.term, &language) {
+        (Ok(_), Language::PlutusV1 | Language::PlutusV2) => true,
+        (Ok(term), Language::PlutusV3) => matches!(
+            term,
+            Term::Constant(constant) if matches!(**constant, Constant::Unit)
+        ),
+        (Err(_), _) => false,
+    };
+
+    Ok(ScriptEvalResult {
+        success,
+        units,
+        logs,
+        failure,
+    })
+}
+
+fn plutus_data_to_term<'a>(arena: &'a Arena, data: &PlutusData) -> &'a Term<'a, DeBruijn> {
+    // Bridge pallas PlutusData -> amaru-uplc PlutusData through CBOR. Both
+    // sides implement the same Plutus data encoding; the upstream amaru node
+    // uses this exact pattern. Vec writer is Infallible and the bytes are
+    // fresh, so neither side can fail in practice.
+    let bytes = minicbor::to_vec(data).expect("PlutusData encode");
+    let pragma_data = PragmaPlutusData::from_cbor(arena, &bytes).expect("PlutusData decode");
+    Term::data(arena, pragma_data)
+}
+
+fn budget_to_ex_units(budget: ExBudget) -> ExUnits {
+    ExUnits {
+        mem: budget.mem.max(0) as u64,
+        steps: budget.cpu.max(0) as u64,
+    }
+}
+
+fn map_language(language: &Language) -> PlutusVersion {
+    match language {
+        Language::PlutusV1 => PlutusVersion::V1,
+        Language::PlutusV2 => PlutusVersion::V2,
+        Language::PlutusV3 => PlutusVersion::V3,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use amaru_uplc::{arena::Arena, flat, syn::parse_program};
+    use pallas_codec::{minicbor, utils::Int};
+    use pallas_primitives::{BigInt, PlutusScript};
+
+    use crate::phase2::data::Data as LedgerData;
+
+    use super::*;
+
+    const PROTOCOL_VERSION_MAJOR: u32 = 9;
+
+    fn zero_data() -> PlutusData {
+        LedgerData::integer(BigInt::Int(Int::from(0i64)))
+    }
+
+    fn integer_data(value: i64) -> PlutusData {
+        LedgerData::integer(BigInt::Int(Int::from(value)))
+    }
+
+    fn list_data(values: impl IntoIterator<Item = i64>) -> PlutusData {
+        LedgerData::list(values.into_iter().map(integer_data).collect())
+    }
+
+    fn bytes_data(bytes: &[u8]) -> PlutusData {
+        LedgerData::bytestring(bytes.to_vec())
+    }
+
+    fn script_cbor(source: &str) -> Vec<u8> {
+        let arena = Arena::new();
+        let program = parse_program(&arena, source)
+            .into_result()
+            .expect("parse program");
+        let flat_bytes = flat::encode(program).expect("flat encode");
+        minicbor::to_vec(PlutusScript::<3>(flat_bytes.into())).expect("cbor encode script")
+    }
+
+    #[test]
+    fn script_cbor_decode_failure_is_typed() {
+        let err = eval_script(
+            Language::PlutusV3,
+            &[0x01],
+            None,
+            &zero_data(),
+            &zero_data(),
+            PROTOCOL_VERSION_MAJOR,
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, Error::DecodeError(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn flat_decode_failure_is_typed() {
+        let script = minicbor::to_vec(PlutusScript::<3>(vec![0xff].into())).unwrap();
+
+        let err = eval_script(
+            Language::PlutusV3,
+            &script,
+            None,
+            &zero_data(),
+            &zero_data(),
+            PROTOCOL_VERSION_MAJOR,
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, Error::FlatDecode(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn machine_failure_keeps_logs() {
+        // Body: addInteger 1 (trace "phase2-log" ()).
+        // Argument is evaluated first: trace fires, returns (). Then
+        // addInteger 1 () fails with a type mismatch.
+        let script = script_cbor(
+            r#"(program 1.1.0
+                (lam ctx
+                  [[(builtin addInteger) (con integer 1)]
+                   [[(force (builtin trace)) (con string "phase2-log")] (con unit ())]]))"#,
+        );
+
+        let result = eval_script(
+            Language::PlutusV3,
+            &script,
+            None,
+            &zero_data(),
+            &zero_data(),
+            PROTOCOL_VERSION_MAJOR,
+        )
+        .unwrap();
+
+        assert!(!result.success, "{result:#?}");
+        let failure = result.failure.expect("machine failure should be captured");
+        assert!(
+            failure.logs.iter().any(|x| x == "phase2-log"),
+            "logs were {:?}",
+            failure.logs
+        );
+        assert!(!failure.message.is_empty());
+    }
+
+    #[test]
+    fn serialise_data_v3_script_evaluates_without_panic() {
+        // Regression test: previous evaluator (txpipe uplc-turbo fork) panicked
+        // on serialiseData for V3 scripts. This must complete without panicking
+        // and yield a successful unit result.
+        let script = script_cbor(
+            r#"(program 1.1.0
+                (lam ctx
+                  [(lam discard (con unit ()))
+                   [(builtin serialiseData) (con data (I 0))]]))"#,
+        );
+
+        let result = eval_script(
+            Language::PlutusV3,
+            &script,
+            None,
+            &zero_data(),
+            &zero_data(),
+            PROTOCOL_VERSION_MAJOR,
+        )
+        .unwrap();
+
+        assert!(result.success, "{result:#?}");
+        assert!(result.failure.is_none(), "{result:#?}");
+    }
+
+    #[test]
+    fn plutus_v2_applies_datum_then_redeemer_then_context() {
+        // 3-arg lambda: succeeds only when called with all three args, in
+        // order datum -> redeemer -> context. The body unwraps each via
+        // type-specific builtins so a wrong type for any slot fails.
+        let script = script_cbor(
+            r#"(program 1.0.0
+                (lam d (lam r (lam c
+                  [(lam di [(lam lr [(lam bc (con unit ())) [(builtin unBData) c]]) [(builtin unListData) r]]) [(builtin unIData) d]]))))"#,
+        );
+
+        let result = eval_script(
+            Language::PlutusV2,
+            &script,
+            Some(&integer_data(1)),
+            &list_data([2]),
+            &bytes_data(&[3]),
+            PROTOCOL_VERSION_MAJOR,
+        )
+        .unwrap();
+
+        assert!(result.success, "{result:#?}");
+        assert!(result.failure.is_none(), "{result:#?}");
+    }
+
+    #[test]
+    fn plutus_v2_skips_missing_datum_and_applies_redeemer_then_context() {
+        // 2-arg lambda: when datum is None, only redeemer + context are applied.
+        let script = script_cbor(
+            r#"(program 1.0.0
+                (lam r (lam c
+                  [(lam lr [(lam bc (con unit ())) [(builtin unBData) c]]) [(builtin unListData) r]])))"#,
+        );
+
+        let result = eval_script(
+            Language::PlutusV2,
+            &script,
+            None,
+            &list_data([2]),
+            &bytes_data(&[3]),
+            PROTOCOL_VERSION_MAJOR,
+        )
+        .unwrap();
+
+        assert!(result.success, "{result:#?}");
+        assert!(result.failure.is_none(), "{result:#?}");
+    }
+}

--- a/pallas-validate/src/phase2/mod.rs
+++ b/pallas-validate/src/phase2/mod.rs
@@ -1,5 +1,6 @@
 pub mod data;
 pub mod error;
+mod evaluator;
 pub mod script_context;
 pub mod to_plutus_data;
 pub mod tx;

--- a/pallas-validate/src/phase2/tx.rs
+++ b/pallas-validate/src/phase2/tx.rs
@@ -2,22 +2,19 @@ use crate::utils::{MultiEraProtocolParameters, UtxoMap};
 
 use super::{
     error::Error,
+    evaluator,
     script_context::{
-        find_script, DataLookupTable, ResolvedInput, ScriptContext, ScriptVersion, SlotConfig,
-        TxInfo, TxInfoV1, TxInfoV2, TxInfoV3,
+        find_script, DataLookupTable, ResolvedInput, ScriptVersion, SlotConfig, TxInfo, TxInfoV1,
+        TxInfoV2, TxInfoV3,
     },
     to_plutus_data::ToPlutusData,
 };
 use pallas_primitives::{
-    conway::{Redeemer, RedeemerTag},
+    conway::{Language, Redeemer, RedeemerTag},
     ExUnits, PlutusData,
 };
 use pallas_traverse::{MultiEraRedeemer, MultiEraTx};
 
-use amaru_uplc::{
-    arena::Arena, binder::DeBruijn, bumpalo::Bump, constant::Constant,
-    data::PlutusData as PragmaPlutusData, machine::PlutusVersion, term::Term,
-};
 use tracing::{debug, instrument};
 
 #[derive(Debug)]
@@ -27,24 +24,12 @@ pub struct TxEvalResult {
     pub units: ExUnits,
     pub success: bool,
     pub logs: Vec<String>,
-}
-
-pub fn plutus_data_to_pragma_term<'a>(
-    arena: &'a Arena,
-    data: &PlutusData,
-) -> &'a Term<'a, DeBruijn> {
-    // Bridge pallas PlutusData -> amaru-uplc PlutusData through CBOR. Both
-    // sides implement the same Plutus data encoding, and the upstream amaru
-    // node uses this exact pattern. Vec writer is Infallible and the bytes
-    // are fresh, so neither side can fail in practice.
-    let bytes = pallas_codec::minicbor::to_vec(data).expect("PlutusData encode");
-    let pragma_data = PragmaPlutusData::from_cbor(arena, &bytes).expect("PlutusData decode");
-    Term::data(arena, pragma_data)
+    pub failure_message: Option<String>,
 }
 
 pub fn eval_tx(
     tx: &MultiEraTx,
-    pparams: &MultiEraProtocolParameters, // For Cost Models
+    pparams: &MultiEraProtocolParameters,
     utxos: &UtxoMap,
     slot_config: &SlotConfig,
 ) -> Result<Vec<TxEvalResult>, Error> {
@@ -85,68 +70,45 @@ pub fn eval_tx(
 }
 
 fn execute_script(
+    language: Language,
     tx_info: TxInfo,
     script_bytes: &[u8],
     datum: Option<PlutusData>,
     redeemer: &Redeemer,
-    plutus_version: PlutusVersion,
     protocol_version_major: u32,
 ) -> Result<TxEvalResult, Error> {
     let script_context = tx_info
         .into_script_context(redeemer, datum.as_ref())
         .ok_or_else(|| Error::ScriptContextBuildError)?;
 
-    let arena = Arena::from_bump(Bump::with_capacity(1_024_000));
-
     let script_context_data = script_context.to_plutus_data();
-    let script_context_term = plutus_data_to_pragma_term(&arena, &script_context_data);
-
     let redeemer_data = redeemer.to_plutus_data();
-    let redeemer_term = plutus_data_to_pragma_term(&arena, &redeemer_data);
 
-    let datum_term = datum
-        .as_ref()
-        .map(|d| plutus_data_to_pragma_term(&arena, d));
+    let result = evaluator::eval_script(
+        language,
+        script_bytes,
+        datum.as_ref(),
+        &redeemer_data,
+        &script_context_data,
+        protocol_version_major,
+    )?;
 
-    let flat: pallas_codec::minicbor::bytes::ByteVec =
-        pallas_codec::minicbor::decode(script_bytes)?;
-
-    let program = amaru_uplc::flat::decode(&arena, &flat, plutus_version, protocol_version_major)?;
-
-    let program = match script_context {
-        ScriptContext::V1V2 { .. } => if let Some(datum_term) = datum_term {
-            program.apply(&arena, datum_term)
-        } else {
-            program
-        }
-        .apply(&arena, redeemer_term)
-        .apply(&arena, script_context_term),
-
-        ScriptContext::V3 { .. } => program.apply(&arena, script_context_term),
-    };
-
-    let result = program.eval_version(&arena, plutus_version);
-
-    let success = match script_context {
-        // a non-error result is enough success criteria for v1v2
-        ScriptContext::V1V2 { .. } => result.term.is_ok(),
-        // v3 requires the result to be ok and the term to be a unit
-        ScriptContext::V3 { .. } => matches!(
-            result.term,
-            Ok(Term::Constant(constant)) if matches!(*constant, Constant::Unit)
-        ),
-    };
+    let failure_message = result.failure.map(|f| {
+        debug!(
+            message = %f.message,
+            logs = ?f.logs,
+            "phase-two script execution failed"
+        );
+        f.message
+    });
 
     Ok(TxEvalResult {
         tag: redeemer.tag,
         index: redeemer.index,
-        success,
-        units: ExUnits {
-            // @TODO hack until we have cost models
-            steps: (result.info.consumed_budget.cpu * 11 / 10) as u64,
-            mem: (result.info.consumed_budget.mem * 11 / 10) as u64,
-        },
-        logs: result.info.logs,
+        success: result.success,
+        units: result.units,
+        logs: result.logs,
+        failure_message,
     })
 }
 
@@ -171,29 +133,29 @@ pub fn eval_redeemer(
         (ScriptVersion::Native(_), _) => Err(Error::NativeScriptPhaseTwo),
 
         (ScriptVersion::V1(script), datum) => Ok(execute_script(
+            Language::PlutusV1,
             TxInfoV1::from_transaction(tx, utxos, slot_config)?,
             script.as_ref(),
             datum,
             &redeemer,
-            PlutusVersion::V1,
             protocol_version_major,
         )?),
 
         (ScriptVersion::V2(script), datum) => Ok(execute_script(
+            Language::PlutusV2,
             TxInfoV2::from_transaction(tx, utxos, slot_config)?,
             script.as_ref(),
             datum,
             &redeemer,
-            PlutusVersion::V2,
             protocol_version_major,
         )?),
 
         (ScriptVersion::V3(script), datum) => Ok(execute_script(
+            Language::PlutusV3,
             TxInfoV3::from_transaction(tx, utxos, slot_config)?,
             script.as_ref(),
             datum,
             &redeemer,
-            PlutusVersion::V3,
             protocol_version_major,
         )?),
     }


### PR DESCRIPTION
## Summary

- Extracts the amaru-uplc invocation out of `phase2/tx.rs` into a dedicated `phase2::evaluator` module returning a structured `ScriptEvalResult`.
- Surfaces machine-failure diagnostics that were previously discarded: `TxEvalResult` gains `failure_message: Option<String>`, and the same context is emitted at debug level via `tracing`.
- Restructures `Error::Machine` into `{ message, budget, logs }` with a clean `Display` impl. The previous opaque tuple variant was dead code (its arena lifetime made it un-constructible).
- Drops the legacy `* 11 / 10` budget inflation hack in `tx.rs` — the evaluator's reported `consumed_budget` is now passed through verbatim. **Behavior change**: callers will see slightly lower `units` values than before.

## Context

These are the architectural improvements proposed in #739, ported on top of the recently merged amaru-uplc switch (#749). #739 itself is now obsolete — the dependency change it introduced is superseded — but the error-handling refactor, the dedicated evaluator module, and the test coverage were still missing from main.

## Test plan

- [x] `cargo test -p pallas-validate --features phase2` — 6 new evaluator unit tests + 121 existing tests all pass
- [x] `cargo clippy -p pallas-validate --features phase2 --all-targets -- -D warnings` clean
- [x] New regression test (`serialise_data_v3_script_evaluates_without_panic`) confirms the original motivation behind #739 — that `serialiseData` no longer panics — holds under amaru-uplc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Plutus script evaluation functionality with support for multiple Plutus versions and comprehensive error tracking.
  * Enhanced failure reporting to include detailed error messages and execution logs.

* **Bug Fixes**
  * Improved error handling and logging capture during script execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->