### PR TITLE
fix(network): include n2c handshake versions 17-23 for van Rossem

### DIFF
--- a/pallas-miniprotocols/src/handshake/n2c.rs
+++ b/pallas-miniprotocols/src/handshake/n2c.rs
@@ -22,6 +22,13 @@ const PROTOCOL_V13: u64 = 32781;
 const PROTOCOL_V14: u64 = 32782;
 const PROTOCOL_V15: u64 = 32783;
 const PROTOCOL_V16: u64 = 32784;
+const PROTOCOL_V17: u64 = 32785;
+const PROTOCOL_V18: u64 = 32786;
+const PROTOCOL_V19: u64 = 32787;
+const PROTOCOL_V20: u64 = 32788;
+const PROTOCOL_V21: u64 = 32789;
+const PROTOCOL_V22: u64 = 32790;
+const PROTOCOL_V23: u64 = 32791;
 
 impl VersionTable {
     pub fn v1_and_above(network_magic: u64) -> VersionTable {
@@ -42,6 +49,13 @@ impl VersionTable {
             (PROTOCOL_V14, VersionData(network_magic, None)),
             (PROTOCOL_V15, VersionData(network_magic, Some(false))),
             (PROTOCOL_V16, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V17, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V18, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V19, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V20, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V21, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V22, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V23, VersionData(network_magic, Some(false))),
         ]
         .into_iter()
         .collect::<HashMap<u64, VersionData>>();
@@ -66,6 +80,13 @@ impl VersionTable {
             (PROTOCOL_V14, VersionData(network_magic, None)),
             (PROTOCOL_V15, VersionData(network_magic, Some(false))),
             (PROTOCOL_V16, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V17, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V18, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V19, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V20, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V21, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V22, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V23, VersionData(network_magic, Some(false))),
         ]
         .into_iter()
         .collect::<HashMap<u64, VersionData>>();


### PR DESCRIPTION
## Summary

- Backports the handshake half of #747 to the `0.18.x` line.
- Adds NodeToClient protocol versions V17–V23 to `pallas-miniprotocols/src/handshake/n2c.rs`, mirroring the entries on `main`. This unblocks 0.18.x consumers from negotiating NodeToClient sessions with cardano-node 10.x peers, including the 10.7.x release that targets the van Rossem hard fork (protocol version 11).
- The other changes in #747 (`queries_v16` additions, the new `ConwayLedgerFailure` tags, and the `pallas-network2` / `pallas-hardano` counterparts) depend on modules that were introduced **after** this branch diverged from `main`, so they are intentionally out of scope.
- No `Cargo.toml` version bump in this PR — release will be cut separately.

## Test plan

- [x] `cargo build -p pallas-miniprotocols` — clean.
- [x] `cargo test -p pallas-miniprotocols` — existing tests pass.
- [ ] Optional: run `examples/n2c-miniprotocols` against a 10.7.x node and confirm v23 is negotiated instead of falling back to v16.