### PR TITLE
backport(network): include n2c handshake versions 17-23 for van Rossem

### DIFF
--- a/pallas-network/src/miniprotocols/handshake/n2c.rs
+++ b/pallas-network/src/miniprotocols/handshake/n2c.rs
@@ -23,6 +23,13 @@ const PROTOCOL_V13: u64 = 32781;
 const PROTOCOL_V14: u64 = 32782;
 const PROTOCOL_V15: u64 = 32783;
 const PROTOCOL_V16: u64 = 32784;
+const PROTOCOL_V17: u64 = 32785;
+const PROTOCOL_V18: u64 = 32786;
+const PROTOCOL_V19: u64 = 32787;
+const PROTOCOL_V20: u64 = 32788;
+const PROTOCOL_V21: u64 = 32789;
+const PROTOCOL_V22: u64 = 32790;
+const PROTOCOL_V23: u64 = 32791;
 
 const PROTOCOL_DMQ_V1: u64 = 4097;
 
@@ -45,6 +52,13 @@ impl VersionTable {
             (PROTOCOL_V14, VersionData(network_magic, None)),
             (PROTOCOL_V15, VersionData(network_magic, Some(false))),
             (PROTOCOL_V16, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V17, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V18, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V19, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V20, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V21, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V22, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V23, VersionData(network_magic, Some(false))),
         ]
         .into_iter()
         .collect::<HashMap<u64, VersionData>>();
@@ -69,6 +83,13 @@ impl VersionTable {
             (PROTOCOL_V14, VersionData(network_magic, None)),
             (PROTOCOL_V15, VersionData(network_magic, Some(false))),
             (PROTOCOL_V16, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V17, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V18, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V19, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V20, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V21, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V22, VersionData(network_magic, Some(false))),
+            (PROTOCOL_V23, VersionData(network_magic, Some(false))),
         ]
         .into_iter()
         .collect::<HashMap<u64, VersionData>>();


### PR DESCRIPTION
## Summary

- Backports the n2c handshake portion of #747 ("feat: prep for van Rossem hard fork") to the `lts/v0` line.
- Adds protocol versions 17-23 to the NodeToClient `VersionTable`, including v23 used by the cardano-node 10.7.x release that targets the van Rossem hard fork. Without this, downstream consumers pinned on `lts/v0` will be unable to negotiate NodeToClient sessions with van-Rossem-era nodes.

## Scope

PR #747 also touched `pallas-network2`, `pallas-hardano/display`, `queries_v16` (new BlockQuery variants for `GetLedgerPeerSnapshot`, `GetPoolDistr2`, `GetStakeDistribution2`, `GetDRepsDelegations`), and the `ConwayLedgerFailure` enum in `localtxsubmission`. None of those have their prerequisites on `lts/v0`:

- `pallas-network2` and `pallas-validate` are empty stubs / not in the workspace.
- `pallas-hardano` has no `display/` module on this branch.
- `queries_v16/mod.rs` predates the post-Conway BlockQuery variants (tags 24+); the helper macros (`block_query_with_args!` / `block_query_no_args!`) and the `TaggedSet` / `SMaybe` / `DRep` types do not exist on `lts/v0`.
- `localtxsubmission/protocol.rs` on `lts/v0` is a 45-line stub with `RejectReason(Vec<u8>)` — the structured `ConwayLedgerFailure` enum being amended in #747 does not exist on this branch.

This backport therefore reduces to the same surgical n2c version-table change that was applied to `hotfix/v0.18` in #757.

## Test plan
- [x] `cargo build -p pallas-network`
- [x] `cargo test -p pallas-network`
- [x] `cargo clippy -p pallas-network --all-targets` (no new warnings)
- [ ] (optional, integration) Negotiate a session against a cardano-node 10.7.x peer and confirm v23 is selected