### PR TITLE
docs: tidy per-crate READMEs onto a common structure

### DIFF
--- a/pallas-addresses/README.md
+++ b/pallas-addresses/README.md
@@ -1,1 +1,36 @@
 # Pallas Addresses
+
+Encode and decode Cardano addresses of every kind — Byron, Shelley payment,
+and stake. The crate is the canonical entry point for parsing a bech32 /
+base58 / hex string into a typed value, inspecting its parts (network,
+payment credential, delegation), and re-serialising it. Address shape
+follows [CIP-19](https://cips.cardano.org/cips/cip19/).
+
+## Usage
+
+```rust
+use pallas_addresses::Address;
+
+let addr = Address::from_bech32(
+    "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8\
+     ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp",
+)?;
+
+match addr {
+    Address::Byron(b)   => println!("byron:   {}", b.to_base58()),
+    Address::Shelley(s) => println!("shelley: {} on {:?}", s.to_bech32()?, s.network()),
+    Address::Stake(s)   => println!("stake:   {}", s.to_bech32()?),
+}
+```
+
+## Overview
+
+- `Address` enum — top-level decoded form, dispatching to the three variants.
+- `ByronAddress`, `ShelleyAddress`, `StakeAddress` — per-kind decoded
+  representations.
+- `ShelleyPaymentPart`, `ShelleyDelegationPart`, `StakePayload`, `Pointer` —
+  the structural pieces that make up a Shelley / stake address.
+- `Network` — Mainnet / Testnet / `Other(u8)` discriminator parsed from the
+  address header.
+- `byron` submodule — Byron-specific structures and CBOR helpers.
+- `varuint` submodule — variable-length integer codec used by stake pointers.

--- a/pallas-bech32/README.md
+++ b/pallas-bech32/README.md
@@ -1,1 +1,27 @@
 # Pallas Bech32
+
+Bech32 conventions for Cardano: the [CIP-5] human-readable prefix table for
+keys, hashes, and addresses; and the [CIP-14] asset fingerprint computation.
+
+[CIP-5]: https://cips.cardano.org/cips/cip5/
+[CIP-14]: https://cips.cardano.org/cips/cip14/
+
+## Usage
+
+```rust
+use pallas_bech32::cip14::AssetFingerprint;
+
+let fp = AssetFingerprint::from_parts(
+    "7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373",
+    "",
+)?;
+
+assert_eq!(fp.finger_print()?, "asset1rjklcrnsdzqp65wjgrg55sy9723kw09mlgvlc3");
+```
+
+## Overview
+
+- `cip5` — `KEYS`, `HASHES`, and `MISCELLANEOUS` constants holding the bech32
+  HRPs assigned by CIP-5 (e.g. `addr`, `stake`, `pool`, `vrf_vk`).
+- `cip14` — `AssetFingerprint` builds and prints the `asset1…` fingerprint
+  for a (policy id, asset name) pair.

--- a/pallas-codec/README.md
+++ b/pallas-codec/README.md
@@ -1,5 +1,37 @@
 # Pallas Codec
 
-## Flat
+The encoding foundation that the rest of the workspace builds on:
+[minicbor](https://docs.rs/minicbor) for CBOR (re-exported) and a Rust port
+of the Plutus Core [flat] format. Most users won't depend on this crate
+directly — they'll get its types transitively through `pallas-primitives`,
+`pallas-traverse`, `pallas-txbuilder`, etc.
 
-A Rust port of the [Haskell reference implementation](https://github.com/Quid2/flat).
+[flat]: https://github.com/Quid2/flat
+
+## Usage
+
+```rust
+use pallas_codec::minicbor;
+
+#[derive(minicbor::Encode, minicbor::Decode)]
+struct Pair(#[n(0)] u64, #[n(1)] String);
+
+let bytes = minicbor::to_vec(Pair(1, "hi".into()))?;
+let back: Pair = minicbor::decode(&bytes)?;
+```
+
+## Overview
+
+- `minicbor` — re-exported as-is; this is the workspace's single source of
+  truth for CBOR.
+- `flat` — Rust port of the Haskell [flat] reference implementation, used
+  for Plutus Core scripts.
+- `utils` — round-trip-friendly helper types (`KeepRaw`, `KeyValuePairs`,
+  `MaybeIndefArray`, `NonEmptySet`, `Nullable`, `PositiveCoin`, …) reused
+  by the higher-level era types.
+- `Fragment` trait — blanket-implemented for any type that is both
+  `minicbor::Encode` and `minicbor::Decode`; used as a bound where the
+  workspace wants "any CBOR-roundtrippable type".
+- `codec_by_datatype!` macro — derives a tag-free CBOR codec for enums
+  whose variants are distinguished by their data-type rather than a
+  discriminant.

--- a/pallas-configs/README.md
+++ b/pallas-configs/README.md
@@ -1,8 +1,11 @@
 # Pallas Configs
 
-This crate provides strongly typed helpers for working with Cardano configuration
-files, including the stake pool registrations bundled inside the legacy
-`staking` section of Shelley genesis files.
+Strongly typed parsers for Cardano genesis files and protocol parameters
+across every era. Useful for tools that need to reason about staking
+metadata, cost models, or other configuration data without hand-rolling
+JSON shapes.
+
+## Usage
 
 ```rust
 use pallas_configs::shelley;
@@ -12,9 +15,15 @@ let config = shelley::from_file(std::path::Path::new("genesis.json"))?;
 if let Some(staking) = config.staking {
     if let Some(pools) = staking.pools {
         for (pool_id, pool) in pools {
-            println!("pool {} has pledge {}", pool_id, pool.pledge);
+            println!("pool {pool_id} has pledge {}", pool.pledge);
         }
     }
 }
 ```
 
+## Overview
+
+- `byron`, `shelley`, `alonzo`, `conway` — one module per era, each exposing
+  a `GenesisFile` (or equivalent) struct and a `from_file` helper.
+- `cost_models` — typed views over Plutus cost-model tables, shared across
+  eras.

--- a/pallas-crypto/README.md
+++ b/pallas-crypto/README.md
@@ -1,14 +1,45 @@
 # Pallas Crypto
 
-Crate with all the cryptographic material to support Cardano protocol:
+Cryptographic primitives required to participate in the Cardano protocol:
+Blake2b hashing, Ed25519 signing (regular and BIP32-extended), VRF, KES
+forward-secure signatures, and nonce evolution.
+
+## Usage
+
+```rust
+use pallas_crypto::hash::Hasher;
+
+let mut h = Hasher::<256>::new();
+h.input(b"hello");
+let digest = h.finalize();
+println!("blake2b-256 = {}", digest);
+```
+
+## Overview
+
+- `hash` — `Hash<N>` and `Hasher<N>` over Blake2b. The const generic is in
+  bits, so `Hasher::<224>` and `Hasher::<256>` cover the common Cardano
+  digest sizes.
+- `key::ed25519` — regular and extended Ed25519 key pairs, signing and
+  verification.
+- `kes` — KES (Key Evolving Signature) primitives used by block producers.
+- `nonce` — epoch / chain-nonce evolution helpers.
+- `memsec` — secure-memory utilities used to wipe key material.
+
+## Status
 
 - [x] Blake2b 256
 - [x] Blake2b 224
 - [x] Ed25519 asymmetric key pair and EdDSA
 - [x] Ed25519 Extended asymmetric key pair
-- [ ] Bip32-Ed25519 key derivation
+- [ ] BIP32-Ed25519 key derivation
 - [ ] BIP39 mnemonics
 - [x] VRF
-- [x] [KES](src/kes/README.md)
+- [x] KES
 - [ ] SECP256k1
 - [x] Nonce calculations
+
+## Further reading
+
+- [`src/kes/README.md`](src/kes/README.md) — KES design notes and
+  interoperability considerations.

--- a/pallas-hardano/README.md
+++ b/pallas-hardano/README.md
@@ -1,1 +1,25 @@
 # Pallas Hardano
+
+Interoperability with implementation-specific artifacts of the Haskell
+Cardano node. Today the main job is reading the node's immutable on-disk
+chunks (the `immutable/` directory of a synced node), so a Rust process
+can iterate the chain without re-syncing.
+
+## Usage
+
+```rust
+use std::path::Path;
+use pallas_hardano::storage::immutable;
+
+for block in immutable::read_blocks(Path::new("/var/cardano/data/immutable"))? {
+    let bytes = block?;
+    // hand `bytes` to pallas-traverse / pallas-primitives for typed access
+}
+```
+
+## Overview
+
+- `storage::immutable` — readers over the node's chunk / primary / secondary
+  index files. Top-level entry points: `read_blocks`,
+  `read_blocks_from_point`, `get_tip`.
+- `display` — pretty-printing helpers for the structures above.

--- a/pallas-math/README.md
+++ b/pallas-math/README.md
@@ -1,14 +1,27 @@
 # Pallas Math
 
-Crate with all the mathematics functions to support Cardano protocol:
+Fixed-precision arithmetic for the parts of the Cardano protocol that need
+to compute `ln`, `exp`, and `pow` to high precision — most notably the
+reward and pool-saturation calculations. Backed by [`dashu`] for the
+underlying big-integer representation.
 
-- [] lncf - Approximate `ln(1+x)` for `x in 0..infinty`.
-- [] cf - Compute continued fraction using max steps or bounded list of a/b factors.
-- [] bound - Simple way to find integer powers that bound x.
-- [] contract - Bisect bounds to find the smallest integer power such that `factor^n<=x<factor^(n+1)`.
-- [] find_e - find n with `e^n<=x<e^(n+1)`.
-- [] ln - Compute natural logarithm via continued fraction, first splitting integral part and then using continued fractions approximation for `ln(1+x)`.
-- [] taylor_exp - Compute `exp(x)` using Taylor expansion.
-- [] taylor_exp_cmp - Efficient way to compare the result of the Taylor expansion of the exponential function to a threshold value.
-- ...
-- ...
+[`dashu`]: https://docs.rs/dashu
+
+## Usage
+
+```rust
+use pallas_math::math::{FixedDecimal, FixedPrecision};
+
+let x = FixedDecimal::from_str("2", 34)?;   // 2.0 with 34 fractional digits
+let y = x.ln();                             // ≈ 0.6931471805599453…
+println!("ln(2) ≈ {y}");
+```
+
+## Overview
+
+- `math` — the public surface: `FixedDecimal` (the fixed-precision number
+  type) and the `FixedPrecision` trait it implements (`new`, `from_str`,
+  `precision`, `exp`, `ln`, `pow`, `exp_cmp`, `round`/`floor`/`ceil`/`trunc`).
+- `math_dashu` — `dashu`-backed implementation that `FixedDecimal` aliases.
+- `DEFAULT_PRECISION` (34), and the lazy `ZERO` / `ONE` / `MINUS_ONE`
+  constants for convenience.

--- a/pallas-network/README.md
+++ b/pallas-network/README.md
@@ -1,3 +1,40 @@
 # Pallas Network
 
-An implementation of the Ouroboros networking stack. It provides a generic multiplexer and state-machines for the different mini-protocols. It uses async and tokio under the hood.
+Implementation of the Ouroboros networking stack — a multiplexer plus
+state-machines for each Cardano mini-protocol (handshake, chainsync,
+blockfetch, txsubmission, local-state-query, …) — exposed through
+ergonomic per-role facades. Async, tokio-backed.
+
+This is the original, single-connection / client-server-shaped stack. A
+peer-to-peer rewrite is in progress in `pallas-network2`; once that is
+mature it is intended to replace this crate.
+
+## Usage
+
+```rust
+use pallas_network::facades::PeerClient;
+use pallas_network::miniprotocols::MAINNET_MAGIC;
+
+let mut peer = PeerClient::connect(
+    "relays-new.cardano-mainnet.iohk.io:3001",
+    MAINNET_MAGIC,
+).await?;
+
+let _chainsync  = peer.chainsync();   // &mut chainsync::N2NClient
+let _blockfetch = peer.blockfetch();  // &mut blockfetch::Client
+```
+
+## Overview
+
+- `facades` — opinionated client / server bundles per role:
+  `PeerClient` / `PeerServer` (N2N), `NodeClient` / `NodeServer` (N2C),
+  `DmqClient` / `DmqServer`. Each owns a multiplexer and exposes the
+  relevant mini-protocols through accessor methods.
+- `multiplexer` — the segment-level transport: `RunningPlexer`, `Bearer`,
+  `VersionTable`, `VersionNumber`.
+- `miniprotocols` — every Ouroboros mini-protocol: `handshake`, `chainsync`,
+  `blockfetch`, `txsubmission`, `localstate`, `localtxsubmission`,
+  `txmonitor`, `keepalive`, `peersharing`, `localmsgnotification`,
+  `localmsgsubmission`. Network-magic constants (`MAINNET_MAGIC`,
+  `TESTNET_MAGIC`, `PREVIEW_MAGIC`, `PREPROD_MAGIC`, `SANCHONET_MAGIC`) are
+  re-exported from this module.

--- a/pallas-network2/README.md
+++ b/pallas-network2/README.md
@@ -11,17 +11,20 @@ Once this crate is thoroughly tested and adopted by downstream clients,
 
 ## Usage
 
-```rust
+The control flow is the same regardless of which `Interface` /
+`Behavior` you plug in. Sketch (substitute your own values for
+`interface`, `behavior`, and any commands):
+
+```text
 use pallas_network2::Manager;
 
 let mut manager = Manager::new(interface, behavior);
 
 while let Some(event) = manager.poll_next().await {
-    // event is `<B as Behavior>::Event`
-    handle(event);
+    // event has type `<B as Behavior>::Event`
 }
 
-manager.execute(my_external_command);
+manager.execute(command);
 ```
 
 ## Overview

--- a/pallas-network2/README.md
+++ b/pallas-network2/README.md
@@ -1,5 +1,55 @@
 # Pallas Network 2
 
-An implementation of the Ouroboros networking stack. The `pallas-network2` crate is a new take on the whole networking approach that prioritizes P2P operations over the _client-server_ approach used in the prior version.
+A new take on the Ouroboros networking stack that prioritises P2P
+operation over the *client / server* shape used by `pallas-network`. The
+public API is split between an `Interface` (where IO happens) and a
+`Behavior` (the business logic), reconciled by a `Manager` — a layout
+inspired by libp2p's swarm.
 
-At some point, once this new version is thoroughly tested and adopted by downstream clients, `network2` will replace the original one. 
+Once this crate is thoroughly tested and adopted by downstream clients,
+`network2` is intended to replace the original `pallas-network`.
+
+## Usage
+
+```rust
+use pallas_network2::Manager;
+
+let mut manager = Manager::new(interface, behavior);
+
+while let Some(event) = manager.poll_next().await {
+    // event is `<B as Behavior>::Event`
+    handle(event);
+}
+
+manager.execute(my_external_command);
+```
+
+## Overview
+
+- `Manager` — drives a paired `Interface` + `Behavior`. `poll_next` advances
+  IO and the behavior; `execute` forwards an external command to the
+  behavior.
+- `Interface` trait — the IO side. Receives `InterfaceCommand` (Connect /
+  Send / Disconnect) and yields `InterfaceEvent` (Connected / Disconnected /
+  Sent / Recv / Error / Idle).
+- `Behavior` trait — the protocol logic. Defines its own `Event`,
+  `Command`, `PeerState`, and `Message`, and emits `BehaviorOutput`s.
+- `Message` trait — describes a mini-protocol message (channel id +
+  payload encoding).
+- `OutboundQueue` — convenience queue of pending `BehaviorOutput`s ready
+  to be polled by the manager.
+- `PeerId`, `Channel`, `Payload`, `MAX_SEGMENT_PAYLOAD_LENGTH` — the
+  primitive vocabulary.
+
+### Modules
+
+- `bearer` — low-level transport for reading and writing multiplexed segments.
+- `interface` — `Interface` implementations for TCP connections.
+- `behavior` — opinionated `Behavior` implementations for Cardano stacks.
+- `protocol` — the Ouroboros mini-protocol definitions (handshake,
+  chainsync, blockfetch, …).
+
+## Feature flags
+
+- `emulation` — enables the `emulation` module, an in-memory test harness
+  for exercising behaviors without real network IO.

--- a/pallas-network2/README.md
+++ b/pallas-network2/README.md
@@ -11,20 +11,40 @@ Once this crate is thoroughly tested and adopted by downstream clients,
 
 ## Usage
 
-The control flow is the same regardless of which `Interface` /
-`Behavior` you plug in. Sketch (substitute your own values for
-`interface`, `behavior`, and any commands):
+A typical setup pairs a transport (an `Interface` impl, e.g. the
+TCP-backed `TcpInterface`) with a protocol (a `Behavior` impl, e.g. the
+node-to-node `InitiatorBehavior`) and drives both through a `Manager`.
+The `Manager` polls the interface for IO events, hands them to the
+behavior, and pushes any commands the behavior emits back at the
+interface — leaving you to consume the behavior's external events. The
+example below is illustrative (error handling and the `await` runtime
+are elided):
 
-```text
-use pallas_network2::Manager;
+```rust,ignore
+use pallas_network2::{
+    behavior::{AnyMessage, InitiatorBehavior, InitiatorCommand, InitiatorEvent},
+    interface::TcpInterface,
+    Manager, PeerId,
+};
+
+let interface = TcpInterface::<AnyMessage>::new();
+let behavior  = InitiatorBehavior::default();
 
 let mut manager = Manager::new(interface, behavior);
 
-while let Some(event) = manager.poll_next().await {
-    // event has type `<B as Behavior>::Event`
-}
+manager.execute(InitiatorCommand::IncludePeer(
+    "relays-new.cardano-mainnet.iohk.io:3001".parse::<PeerId>().unwrap(),
+));
 
-manager.execute(command);
+while let Some(event) = manager.poll_next().await {
+    match event {
+        InitiatorEvent::PeerInitialized(pid, _) => println!("up: {pid}"),
+        InitiatorEvent::BlockHeaderReceived(pid, header, _) => {
+            println!("hdr from {pid}: {} bytes", header.cbor.len());
+        }
+        _ => {}
+    }
+}
 ```
 
 ## Overview

--- a/pallas-primitives/README.md
+++ b/pallas-primitives/README.md
@@ -1,2 +1,36 @@
 # Pallas Primitives
 
+Era-aware Cardano ledger types with their CBOR codecs. This is the data
+layer that the rest of the Pallas ledger crates sit on: `pallas-traverse`
+gives you a multi-era read API over these types, `pallas-validate`
+applies ledger rules to them, and `pallas-txbuilder` builds new ones.
+
+If you need raw, era-specific access to a `Tx`, `Block`, or `PlutusData`,
+you want this crate. If you'd rather work over many eras through one
+interface, reach for `pallas-traverse`.
+
+## Usage
+
+```rust
+use pallas_codec::minicbor;
+use pallas_primitives::conway;
+
+let tx: conway::Tx = minicbor::decode(&cbor_bytes)?;
+
+for input in tx.transaction_body.inputs.iter() {
+    println!("{:?}#{}", input.transaction_id, input.index);
+}
+```
+
+## Overview
+
+- `byron`, `alonzo`, `babbage`, `conway` — one module per era, each
+  exposing the era's `Block`, `Tx`, `TransactionInput`, `TransactionOutput`,
+  `Value`, `Certificate`, `Metadata`, witness sets, and so on.
+- `plutus_data` — re-exported `PlutusData`, `BigInt`, and helpers shared
+  across eras.
+- `framework` — common type aliases and codec primitives (`AddrKeyhash`,
+  `Coin`, `PolicyId`, `RationalNumber`, `StakeCredential`,
+  `TransactionInput`, `ExUnits`, `PlutusScript<V>`, …).
+- Re-exports from `pallas-codec` (`Bytes`, `KeepRaw`, `KeyValuePairs`,
+  `NonEmptySet`, `Set`, `Nullable`, …) and `pallas-crypto` (`Hash`).

--- a/pallas-traverse/README.md
+++ b/pallas-traverse/README.md
@@ -1,1 +1,43 @@
 # Pallas Traverse
+
+A read-only, era-agnostic view over Cardano blocks and transactions. Where
+`pallas-primitives` exposes the raw typed CBOR per era, this crate hides
+the era split behind `MultiEra*` enums so a single piece of indexing or
+analysis code can run against everything from Byron to Conway.
+
+This is the read side of the ledger. For tx construction see
+`pallas-txbuilder`; for ledger-rule validation see `pallas-validate`.
+
+## Usage
+
+```rust
+use pallas_traverse::MultiEraBlock;
+
+let block = MultiEraBlock::decode(&cbor_bytes)?;
+
+println!("era={:?} slot={} hash={}", block.era(), block.slot(), block.hash());
+
+for tx in block.txs() {
+    for output in tx.outputs() {
+        println!("  → {} lovelace", output.lovelace_amount());
+    }
+}
+```
+
+## Overview
+
+- `MultiEraBlock`, `MultiEraTx`, `MultiEraHeader` — top-level entry points
+  with `decode` / `decode_for_era` constructors.
+- `MultiEraInput`, `MultiEraOutput`, `MultiEraValue`, `MultiEraAsset`,
+  `MultiEraPolicyAssets` — per-piece views.
+- `MultiEraCert`, `MultiEraRedeemer`, `MultiEraWithdrawals`,
+  `MultiEraSigners`, `MultiEraMeta`, `MultiEraUpdate`, `MultiEraProposal`,
+  `MultiEraGovAction` — the rest of the tx surface, normalised across eras.
+- `Era` and `Feature` — discriminators for "which era is this" and "does
+  this era support X" (multi-assets, smart contracts, CIP-1694, …).
+- Trait-driven hashing: `ComputeHash<N>` and `OriginalHash<N>` give you a
+  uniform way to take Blake2b digests of typed structures.
+- Per-aspect submodules for deeper helpers: `block`, `tx`, `input`,
+  `output`, `assets`, `value`, `cert`, `redeemers`, `witnesses`,
+  `signers`, `hashes`, `fees`, `governance`, `time`, `header`, `meta`,
+  `auxiliary`, `probe`, `size`, `withdrawals`, `wellknown`.

--- a/pallas-txbuilder/README.md
+++ b/pallas-txbuilder/README.md
@@ -1,1 +1,38 @@
 # Pallas TxBuilder
+
+Ergonomic builder for constructing and signing Cardano transactions. The
+crate is organised around `StagingTransaction`, a fluent builder that
+collects inputs, outputs, mint, scripts, datums, and redeemers, and
+finalises into a `BuiltTransaction` ready to be signed and submitted.
+
+Currently the only era supported for building is **Conway** (via the
+`BuildConway` trait). Earlier-era builders are intentionally not
+maintained.
+
+## Usage
+
+```rust
+use pallas_txbuilder::{BuildConway, Input, Output, StagingTransaction};
+
+let tx = StagingTransaction::new()
+    .input(Input::new(prev_tx_hash, 0))
+    .output(Output::new(recipient_address, 2_000_000))
+    .fee(170_000)
+    .build_conway_raw()?;
+
+let signed = tx.sign(&signing_key)?;
+let cbor = signed.tx_bytes;
+```
+
+## Overview
+
+- `StagingTransaction` — the in-progress, mutable transaction; the entry
+  point for everything (`new`, `input`, `output`, `mint`, `fee`,
+  `network_id`, `valid_after`, …).
+- `BuiltTransaction` — the finalised, encoded body produced by `BuildConway`;
+  exposes `sign(&signer)` and the raw CBOR bytes.
+- `Input`, `Output`, `ExUnits`, `ScriptKind`, `Bytes`, `Bytes32` — the value
+  types that go into the builder.
+- `BuildConway` trait — implemented for `StagingTransaction`; turns staging
+  state into a Conway-encoded transaction.
+- `TxBuilderError` — the unified error returned from build / sign.

--- a/pallas-utxorpc/README.md
+++ b/pallas-utxorpc/README.md
@@ -1,44 +1,43 @@
-# Pallas UTxO RPC
+# Pallas UTxORPC
 
-Maps Pallas types to the [UTxORPC](https://utxorpc.org) Cardano protobuf
-schema. The crate exposes both spec versions side by side, always compiled
-in:
+Maps Pallas ledger types onto the [UTxORPC](https://utxorpc.org) Cardano
+protobuf schema. Both spec versions are always compiled in side by side, so a
+caller can choose `v1alpha` or `v1beta` per call site without juggling
+features.
 
-- `pallas_utxorpc::v1alpha` — `Mapper` returning `utxorpc_spec::utxorpc::v1alpha::cardano::*`
-- `pallas_utxorpc::v1beta` — `Mapper` returning `utxorpc_spec::utxorpc::v1beta::cardano::*`,
-  including the v1beta-only types (`BootstrapWitness`, `VoterVotes`,
-  `VotingProcedure`, `Vote`).
-
-For back-compat with pre-v1beta releases, the default `u5c-v1alpha-compat`
-feature re-exports v1alpha at the crate root, so `pallas_utxorpc::Mapper`
-and `pallas_utxorpc::spec` keep resolving to v1alpha:
+## Usage
 
 ```rust
-use pallas_utxorpc::Mapper;          // default-features on: same as v1alpha::Mapper
-use pallas_utxorpc::v1alpha::Mapper; // always available, regardless of features
-use pallas_utxorpc::v1beta::Mapper;  // always available, regardless of features
+use pallas_utxorpc::Mapper;          // default features: alias for v1alpha::Mapper
+use pallas_utxorpc::v1alpha::Mapper as V1Alpha;
+use pallas_utxorpc::v1beta::Mapper as V1Beta;
 ```
 
-Disable the compat shim to force callers onto explicit version paths:
+For back-compat with pre-v1beta releases, the default `u5c-v1alpha-compat`
+feature re-exports `v1alpha` at the crate root, so `pallas_utxorpc::Mapper`
+and `pallas_utxorpc::spec` keep resolving to v1alpha. Disable the compat shim
+to force callers onto explicit version paths:
 
 ```toml
 pallas-utxorpc = { version = "...", default-features = false }
 ```
 
-Shared infrastructure (`LedgerContext`, `TxHash`, `TxoIndex`, `TxoRef`,
-`Cbor`, `EraCbor`, `UtxoMap`, `DatumMap`) stays at the crate root and is
-unaffected by the feature flag.
+## Overview
 
-## Snapshot tests
+- `v1alpha` — `Mapper` returning `utxorpc_spec::utxorpc::v1alpha::cardano::*`.
+- `v1beta` — `Mapper` returning `utxorpc_spec::utxorpc::v1beta::cardano::*`,
+  including the v1beta-only types (`BootstrapWitness`, `VoterVotes`,
+  `VotingProcedure`, `Vote`).
+- Crate-root infrastructure (`LedgerContext`, `TxHash`, `TxoIndex`, `TxoRef`,
+  `Cbor`, `EraCbor`, `UtxoMap`, `DatumMap`) is shared across versions and
+  unaffected by the feature flag.
+
+## Testing
 
 Each version has a snapshot test that decodes a fixed Babbage block and
-compares the mapper output to a JSON file under `test_data/`:
-
-- `test_data/u5c_v1alpha.json`
-- `test_data/u5c_v1beta.json`
-
-To overwrite both snapshots with the current mapper output, set
-`REGENERATE_SNAPSHOTS=1`:
+compares the mapper output against a JSON file under `test_data/`
+(`u5c_v1alpha.json`, `u5c_v1beta.json`). To overwrite both snapshots with
+the current mapper output:
 
 ```sh
 REGENERATE_SNAPSHOTS=1 cargo test -p pallas-utxorpc

--- a/pallas-validate/README.md
+++ b/pallas-validate/README.md
@@ -1,7 +1,45 @@
 # Pallas Validate
 
-Crate for performing transaction validation according to the Cardano protocol. Generally speaking, this crate is structured in multiple modules, each one handling a specific Cardano era. These eras are: Byron, ShelleyMA, Alonzo and Babbage.
+Phase-1 (and optionally phase-2) Cardano transaction validation against
+the live ledger rules. Useful for clients that want to reject
+ill-formed or unenforceable transactions locally before submitting them,
+or to replay historical chains and confirm conformance with the protocol
+specification.
 
-Refer to *docs/<era>.md* to see the mathematical specifications regarding *<era>*.
+## Usage
 
-Refer to *tests/README.md* for explanations regarding the test suite in any era.
+```rust
+use pallas_validate::phase1::validate_tx;
+
+validate_tx(&tx, tx_index, &env, &utxos, &mut cert_state)?;
+```
+
+`validate_tx` dispatches on the era encoded in `Environment.prot_params`
+and routes to the matching era-specific validator (`validate_byron_tx`,
+`validate_shelley_ma_tx`, `validate_alonzo_tx`, `validate_babbage_tx`,
+`validate_conway_tx`).
+
+## Overview
+
+- `phase1` — phase-1 (structural / rule-based) validation, with one module
+  per era: `byron`, `shelley_ma`, `alonzo`, `babbage`, `conway`. Top-level
+  entry points are `validate_tx` (single tx) and `validate_txs`
+  (LEDGERS sequence rule).
+- `phase2` — phase-2 (Plutus script execution) validation. Behind the
+  `phase2` cargo feature.
+- `utils` — the shared input types every validator takes:
+  `Environment`, `UTxOs`, `CertState`, `MultiEraProtocolParameters`, and
+  the unified `ValidationError` / `ValidationResult` types.
+
+## Feature flags
+
+- `phase2` — pulls in Plutus script execution and exposes the `phase2`
+  module.
+
+## Further reading
+
+- [`docs/byron.md`](docs/byron.md), [`docs/shelleyMA.md`](docs/shelleyMA.md),
+  [`docs/alonzo.md`](docs/alonzo.md), [`docs/babbage.md`](docs/babbage.md)
+  — mathematical specifications, one per era.
+- [`tests/README.md`](tests/README.md) — test-suite layout and how to
+  reproduce the per-era fixtures.


### PR DESCRIPTION
## Summary

- Brings every per-crate README onto a shared **Scope → Usage → Overview → (optional Status / Feature flags / Testing / Further reading)** skeleton.
- Replaces six stub READMEs (`pallas-addresses`, `pallas-bech32`, `pallas-hardano`, `pallas-primitives`, `pallas-traverse`, `pallas-txbuilder`) with real content.
- Rewrites the partially-populated ones (`pallas-codec`, `pallas-crypto`, `pallas-math`, `pallas-network`, `pallas-network2`, `pallas-validate`); fixes the malformed `[]` checklist in `pallas-math`.
- Reshapes the two reference READMEs (`pallas-utxorpc`, `pallas-configs`) onto the same skeleton with minimal content change.
- Each Usage snippet was grounded against the crate's current public API (verified accessor names like `ShelleyAddress::network()`, `MultiEraOutput::lovelace_amount()`, `Input::new`, `BuiltTransaction::tx_bytes`, etc.).

## Out of scope

- Root `README.md` — deferred follow-up.
- Umbrella `pallas/` crate — its `Cargo.toml` sets `readme = "../README.md"`, so it ships the root README; touching it belongs with the root-README pass.
- Nested READMEs (`pallas-crypto/src/kes/README.md`, `pallas-validate/tests/README.md`) — referenced from the new crate READMEs, not rewritten.

## Test plan

- [ ] `cargo doc --workspace --no-deps` succeeds.
- [ ] Eyeball each README rendered on GitHub — pay attention to lists / tables in `pallas-network2` and `pallas-validate`, which carry the most varied sections.
- [ ] Optional hardening: paste the Usage snippets into a scratch crate and `cargo check` (they aren't committed as doctests in this pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added and updated README files across 14+ Pallas crates with clear descriptions of their purposes, Rust usage examples, module overviews, and feature flag documentation. Covered areas include address parsing, encoding, codecs, configuration, cryptography, storage, mathematics, networking, transaction building, validation, and utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->