### PR TITLE
docs: expand root readme with quickstart and missing crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Foundational primitives with no Cardano-specific semantics. Every higher layer i
 
 ### Network
 
-Wire-level implementation of the Ouroboros mini-protocols used to communicate with other Cardano nodes. `pallas-network2` is a P2P-focused rewrite intended to eventually replace `pallas-network`; new projects should evaluate both.
+Wire-level implementation of the Ouroboros mini-protocols used to communicate with other Cardano nodes.
 
 | Crates                              | Description                                                           |
 | ----------------------------------- | --------------------------------------------------------------------- |
@@ -105,7 +105,7 @@ Cardano's on-chain data model: how transactions, blocks, addresses, and ledger s
 
 ### Interop
 
-Adapters for systems built outside Pallas — file formats, RPC schemas, and other implementations that Pallas-based code needs to consume or produce.
+Adapters for systems built outside Pallas — file formats, RPC schemas, etc.
 
 | Crates                            | Description                                                                         |
 | --------------------------------- | ----------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -77,10 +77,9 @@ The crates are grouped below by domain.
 
 | Crates                          | Description                                                          |
 | ------------------------------- | -------------------------------------------------------------------- |
-| [pallas-codec](/pallas-codec)   | Shared CBOR encoding / decoding using minicbor lib                   |
-| [pallas-crypto](/pallas-crypto) | Shared Cryptographic primitives                                      |
-| [pallas-math](/pallas-math)     | Shared mathematics functions                                         |
-| [pallas-bech32](/pallas-bech32) | Bech32 conventions for Cardano (CIP-5 prefixes, CIP-14 fingerprints) |
+| [pallas-codec](/pallas-codec)   | Shared CBOR encoding / decoding using minicbor lib |
+| [pallas-crypto](/pallas-crypto) | Shared Cryptographic primitives                    |
+| [pallas-math](/pallas-math)     | Shared mathematics functions                       |
 
 ### Network
 
@@ -113,6 +112,12 @@ The crates are grouped below by domain.
 | [pallas-hardano](/pallas-hardano) | Interoperability with implementation-specific artifacts of the Haskell Cardano node |
 | [pallas-configs](/pallas-configs) | Genesis config structs matching the Haskell node (Byron / Shelley / Alonzo / Conway) |
 | [pallas-utxorpc](/pallas-utxorpc) | Interoperability with the [UTxO RPC](https://utxorpc.org) specification             |
+
+### Utils
+
+| Crates                          | Description                                                          |
+| ------------------------------- | -------------------------------------------------------------------- |
+| [pallas-bech32](/pallas-bech32) | Bech32 conventions for Cardano (CIP-5 prefixes, CIP-14 fingerprints) |
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
     <picture>
-        <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/txpipe/pallas/master/assets/logo-dark.svg">
-        <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/txpipe/pallas/master/assets/logo-light.svg">
-        <img src="https://raw.githubusercontent.com/txpipe/pallas/master/assets/logo-light.svg" alt="Pallas Logo" width="500">
+        <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/txpipe/pallas/main/assets/logo-dark.svg">
+        <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/txpipe/pallas/main/assets/logo-light.svg">
+        <img src="https://raw.githubusercontent.com/txpipe/pallas/main/assets/logo-light.svg" alt="Pallas Logo" width="500">
     </picture>
     <hr />
         <h3 align="center" style="border-bottom: none">Rust-native building blocks for the Cardano blockchain ecosystem</h3>
@@ -20,31 +20,56 @@ application, it is meant to be used as a base layer to facilitate the
 development of higher-level use-cases, such as explorers, wallets, etc (who
 knows, maybe even a full node in a far away future).
 
+## Getting Started
+
+Add the umbrella crate to your project:
+
+```bash
+cargo add pallas
+```
+
+Or pick a single building block:
+
+```bash
+cargo add pallas-network pallas-traverse
+```
+
+The umbrella `pallas` crate re-exports all modules behind Cargo features (see
+[Features](#features) below). End-to-end usage patterns live in the
+[`examples/`](/examples) directory — chain crawler, wallet key derivation, P2P
+initiator/responder, and node-to-node / node-to-client mini-protocols.
+
 ## Unboxing
 
 The repository is organized as a Cargo workspace. Each _Pallas_ "building block" lives in its own crate. The root `pallas` crate serves as an all-in-one dependency that re-exports all of the other modules in an hierarchically organized fashion, using Cargo `features` to tailor the setup for each use-case.
 
 ### Core
 
-| Crates                          | Description                                        |
-| ------------------------------- | -------------------------------------------------- |
-| [pallas-codec](/pallas-codec)   | Shared CBOR encoding / decoding using minicbor lib |
-| [pallas-crypto](/pallas-crypto) | Shared Cryptographic primitives                    |
-| [pallas-math](/pallas-math)     | Shared mathematics functions                       |
+| Crates                          | Description                                                          |
+| ------------------------------- | -------------------------------------------------------------------- |
+| [pallas-codec](/pallas-codec)   | Shared CBOR encoding / decoding using minicbor lib                   |
+| [pallas-crypto](/pallas-crypto) | Shared Cryptographic primitives                                      |
+| [pallas-math](/pallas-math)     | Shared mathematics functions                                         |
+| [pallas-bech32](/pallas-bech32) | Bech32 conventions for Cardano (CIP-5 prefixes, CIP-14 fingerprints) |
 
 ### Network
 
-| Crates                            | Description                                                           |
-| --------------------------------- | --------------------------------------------------------------------- |
-| [pallas-network](/pallas-network) | Network stack providing multiplexer and mini-protocol implementations |
+`pallas-network2` is a P2P-focused rewrite intended to eventually replace `pallas-network`. New projects should evaluate both.
+
+| Crates                              | Description                                                           |
+| ----------------------------------- | --------------------------------------------------------------------- |
+| [pallas-network](/pallas-network)   | Network stack providing multiplexer and mini-protocol implementations |
+| [pallas-network2](/pallas-network2) | P2P-first rewrite of the Ouroboros networking stack                   |
 
 ### Ledger
 
-| Crates                                  | Description                                                     |
-| --------------------------------------- | --------------------------------------------------------------- |
-| [pallas-primitives](/pallas-primitives) | Ledger primitives and cbor codec for the different Cardano eras |
-| [pallas-traverse](/pallas-traverse)     | Utilities to traverse over multi-era block data                 |
-| [pallas-addresses](/pallas-addresses)   | Encode / decode Cardano addresses of any type                   |
+| Crates                                  | Description                                                          |
+| --------------------------------------- | -------------------------------------------------------------------- |
+| [pallas-primitives](/pallas-primitives) | Ledger primitives and cbor codec for the different Cardano eras      |
+| [pallas-traverse](/pallas-traverse)     | Utilities to traverse over multi-era block data                      |
+| [pallas-addresses](/pallas-addresses)   | Encode / decode Cardano addresses of any type                        |
+| [pallas-configs](/pallas-configs)       | Genesis config structs (Byron / Shelley / Alonzo / Conway)           |
+| [pallas-validate](/pallas-validate)     | Phase-1 and optional phase-2 (Plutus) transaction validation         |
 
 ### Tx Builder
 
@@ -58,6 +83,18 @@ The repository is organized as a Cargo workspace. Each _Pallas_ "building block"
 | --------------------------------- | ----------------------------------------------------------------------------------- |
 | [pallas-hardano](/pallas-hardano) | Interoperability with implementation-specific artifacts of the Haskell Cardano node |
 | [pallas-utxorpc](/pallas-utxorpc) | Interoperability with the [UTxO RPC](https://utxorpc.org) specification             |
+
+## Features
+
+The umbrella `pallas` crate exposes the following Cargo features:
+
+| Feature    | Enables                                                       |
+| ---------- | ------------------------------------------------------------- |
+| `hardano`  | Haskell-node interop via `pallas-hardano`                     |
+| `phase2`   | Plutus script validation in `pallas-validate`                 |
+| `network2` | Opt in to the new P2P networking stack (`pallas-network2`)    |
+| `relaxed`  | Relaxed validation modes across primitives and crypto         |
+| `unstable` | Aggregates feature gates that are not yet stable              |
 
 ## Etymology
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ The crates are grouped below by domain.
 
 ### Core
 
+Low-level primitives shared across the workspace — CBOR codec, cryptography, and the math routines that ledger and consensus rely on.
+
 | Crates                          | Description                                                          |
 | ------------------------------- | -------------------------------------------------------------------- |
 | [pallas-codec](/pallas-codec)   | Shared CBOR encoding / decoding using minicbor lib |
@@ -83,7 +85,7 @@ The crates are grouped below by domain.
 
 ### Network
 
-`pallas-network2` is a P2P-focused rewrite intended to eventually replace `pallas-network`. New projects should evaluate both.
+The Ouroboros networking stack — multiplexer and mini-protocols for node-to-node and node-to-client communication. `pallas-network2` is a P2P-focused rewrite intended to eventually replace `pallas-network`; new projects should evaluate both.
 
 | Crates                              | Description                                                           |
 | ----------------------------------- | --------------------------------------------------------------------- |
@@ -91,6 +93,8 @@ The crates are grouped below by domain.
 | [pallas-network2](/pallas-network2) | P2P-first rewrite of the Ouroboros networking stack                   |
 
 ### Ledger
+
+Era-aware ledger types and operations — primitives for each Cardano era, multi-era traversal helpers, address encoding, and transaction validation.
 
 | Crates                                  | Description                                                          |
 | --------------------------------------- | -------------------------------------------------------------------- |
@@ -101,6 +105,8 @@ The crates are grouped below by domain.
 
 ### Interop
 
+Bridges between Pallas and external Cardano artifacts — Haskell-node files (genesis, immutable storage) and the UTxO RPC specification.
+
 | Crates                            | Description                                                                         |
 | --------------------------------- | ----------------------------------------------------------------------------------- |
 | [pallas-hardano](/pallas-hardano) | Interoperability with implementation-specific artifacts of the Haskell Cardano node |
@@ -108,6 +114,8 @@ The crates are grouped below by domain.
 | [pallas-utxorpc](/pallas-utxorpc) | Interoperability with the [UTxO RPC](https://utxorpc.org) specification             |
 
 ### Utils
+
+Standalone helpers — encoding conventions and higher-level builders that compose the rest of the stack.
 
 | Crates                                | Description                                                          |
 | ------------------------------------- | -------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The crates are grouped below by domain.
 
 ### Core
 
-Low-level primitives shared across the workspace — CBOR codec, cryptography, and the math routines that ledger and consensus rely on.
+Foundational primitives with no Cardano-specific semantics. Every higher layer in the workspace depends on them.
 
 | Crates                          | Description                                                          |
 | ------------------------------- | -------------------------------------------------------------------- |
@@ -85,7 +85,7 @@ Low-level primitives shared across the workspace — CBOR codec, cryptography, a
 
 ### Network
 
-The Ouroboros networking stack — multiplexer and mini-protocols for node-to-node and node-to-client communication. `pallas-network2` is a P2P-focused rewrite intended to eventually replace `pallas-network`; new projects should evaluate both.
+Wire-level implementation of the Ouroboros mini-protocols used to communicate with other Cardano nodes. `pallas-network2` is a P2P-focused rewrite intended to eventually replace `pallas-network`; new projects should evaluate both.
 
 | Crates                              | Description                                                           |
 | ----------------------------------- | --------------------------------------------------------------------- |
@@ -94,7 +94,7 @@ The Ouroboros networking stack — multiplexer and mini-protocols for node-to-no
 
 ### Ledger
 
-Era-aware ledger types and operations — primitives for each Cardano era, multi-era traversal helpers, address encoding, and transaction validation.
+Cardano's on-chain data model: how transactions, blocks, addresses, and ledger state are represented, traversed, and validated across eras.
 
 | Crates                                  | Description                                                          |
 | --------------------------------------- | -------------------------------------------------------------------- |
@@ -105,7 +105,7 @@ Era-aware ledger types and operations — primitives for each Cardano era, multi
 
 ### Interop
 
-Bridges between Pallas and external Cardano artifacts — Haskell-node files (genesis, immutable storage) and the UTxO RPC specification.
+Adapters for systems built outside Pallas — file formats, RPC schemas, and other implementations that Pallas-based code needs to consume or produce.
 
 | Crates                            | Description                                                                         |
 | --------------------------------- | ----------------------------------------------------------------------------------- |
@@ -115,7 +115,7 @@ Bridges between Pallas and external Cardano artifacts — Haskell-node files (ge
 
 ### Utils
 
-Standalone helpers — encoding conventions and higher-level builders that compose the rest of the stack.
+Optional, self-contained conveniences. Each crate stands alone; pull one in only when you need that specific affordance.
 
 | Crates                                | Description                                                          |
 | ------------------------------------- | -------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -99,12 +99,6 @@ The crates are grouped below by domain.
 | [pallas-addresses](/pallas-addresses)   | Encode / decode Cardano addresses of any type                        |
 | [pallas-validate](/pallas-validate)     | Phase-1 and optional phase-2 (Plutus) transaction validation         |
 
-### Tx Builder
-
-| Crates                                | Description                   |
-| ------------------------------------- | ----------------------------- |
-| [pallas-txbuilder](/pallas-txbuilder) | Ergonomic transaction builder |
-
 ### Interop
 
 | Crates                            | Description                                                                         |
@@ -115,9 +109,10 @@ The crates are grouped below by domain.
 
 ### Utils
 
-| Crates                          | Description                                                          |
-| ------------------------------- | -------------------------------------------------------------------- |
-| [pallas-bech32](/pallas-bech32) | Bech32 conventions for Cardano (CIP-5 prefixes, CIP-14 fingerprints) |
+| Crates                                | Description                                                          |
+| ------------------------------------- | -------------------------------------------------------------------- |
+| [pallas-bech32](/pallas-bech32)       | Bech32 conventions for Cardano (CIP-5 prefixes, CIP-14 fingerprints) |
+| [pallas-txbuilder](/pallas-txbuilder) | Ergonomic transaction builder                                        |
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ The crates are grouped below by domain.
 | [pallas-primitives](/pallas-primitives) | Ledger primitives and cbor codec for the different Cardano eras      |
 | [pallas-traverse](/pallas-traverse)     | Utilities to traverse over multi-era block data                      |
 | [pallas-addresses](/pallas-addresses)   | Encode / decode Cardano addresses of any type                        |
-| [pallas-configs](/pallas-configs)       | Genesis config structs (Byron / Shelley / Alonzo / Conway)           |
 | [pallas-validate](/pallas-validate)     | Phase-1 and optional phase-2 (Plutus) transaction validation         |
 
 ### Tx Builder
@@ -112,6 +111,7 @@ The crates are grouped below by domain.
 | Crates                            | Description                                                                         |
 | --------------------------------- | ----------------------------------------------------------------------------------- |
 | [pallas-hardano](/pallas-hardano) | Interoperability with implementation-specific artifacts of the Haskell Cardano node |
+| [pallas-configs](/pallas-configs) | Genesis config structs matching the Haskell node (Byron / Shelley / Alonzo / Conway) |
 | [pallas-utxorpc](/pallas-utxorpc) | Interoperability with the [UTxO RPC](https://utxorpc.org) specification             |
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -22,26 +22,56 @@ knows, maybe even a full node in a far away future).
 
 ## Getting Started
 
-Add the umbrella crate to your project:
+For most use-cases, depend on the umbrella `pallas` crate — it re-exports every
+building block under a single, organized module tree:
 
 ```bash
 cargo add pallas
 ```
 
-Or pick a single building block:
+The hierarchy mirrors the project's domains (network, ledger, crypto, etc.) so
+you can pull in a single dependency and reach for what you need:
+
+```text
+pallas
+├── network          — Ouroboros networking stack
+├── network2         — P2P-first networking stack (feature `network2`)
+├── ledger
+│   ├── primitives   — multi-era CBOR primitives
+│   ├── traverse     — multi-era traversal helpers
+│   ├── addresses    — Cardano address codec
+│   └── validate     — phase-1 / phase-2 transaction validation
+├── crypto           — cryptographic primitives
+├── codec            — CBOR codec (minicbor)
+├── interop
+│   ├── utxorpc      — UTxO RPC interop
+│   └── hardano      — Haskell-node interop (feature `hardano`)
+└── wallet
+    └── txbuilder    — ergonomic transaction builder
+```
+
+### Features
+
+The umbrella crate exposes the following Cargo features:
+
+| Feature    | Enables                                                     |
+| ---------- | ----------------------------------------------------------- |
+| `hardano`  | Haskell-node interop (`pallas::interop::hardano`)           |
+| `phase2`   | Plutus script validation in `pallas::ledger::validate`      |
+| `network2` | Opt in to the new P2P networking stack (`pallas::network2`) |
+| `relaxed`  | Relaxed validation modes across primitives and crypto       |
+| `unstable` | Aggregates feature gates that are not yet stable            |
+
+## Unboxing
+
+If you'd rather depend on a subset, every building block is published as its
+own crate on crates.io. Pick only what you need:
 
 ```bash
 cargo add pallas-network pallas-traverse
 ```
 
-The umbrella `pallas` crate re-exports all modules behind Cargo features (see
-[Features](#features) below). End-to-end usage patterns live in the
-[`examples/`](/examples) directory — chain crawler, wallet key derivation, P2P
-initiator/responder, and node-to-node / node-to-client mini-protocols.
-
-## Unboxing
-
-The repository is organized as a Cargo workspace. Each _Pallas_ "building block" lives in its own crate. The root `pallas` crate serves as an all-in-one dependency that re-exports all of the other modules in an hierarchically organized fashion, using Cargo `features` to tailor the setup for each use-case.
+The crates are grouped below by domain.
 
 ### Core
 
@@ -73,28 +103,50 @@ The repository is organized as a Cargo workspace. Each _Pallas_ "building block"
 
 ### Tx Builder
 
-| Crates                                | Description                                |
-| ------------------------------------- | ------------------------------------------ |
-| [pallas-txbuilder](/pallas-txbuilder) | Ergonomic transaction builder              |
+| Crates                                | Description                   |
+| ------------------------------------- | ----------------------------- |
+| [pallas-txbuilder](/pallas-txbuilder) | Ergonomic transaction builder |
 
-## Interop
+### Interop
 
 | Crates                            | Description                                                                         |
 | --------------------------------- | ----------------------------------------------------------------------------------- |
 | [pallas-hardano](/pallas-hardano) | Interoperability with implementation-specific artifacts of the Haskell Cardano node |
 | [pallas-utxorpc](/pallas-utxorpc) | Interoperability with the [UTxO RPC](https://utxorpc.org) specification             |
 
-## Features
+## Examples
 
-The umbrella `pallas` crate exposes the following Cargo features:
+The [`examples/`](/examples) directory contains runnable demonstrations of
+common integration patterns:
 
-| Feature    | Enables                                                       |
-| ---------- | ------------------------------------------------------------- |
-| `hardano`  | Haskell-node interop via `pallas-hardano`                     |
-| `phase2`   | Plutus script validation in `pallas-validate`                 |
-| `network2` | Opt in to the new P2P networking stack (`pallas-network2`)    |
-| `relaxed`  | Relaxed validation modes across primitives and crypto         |
-| `unstable` | Aggregates feature gates that are not yet stable              |
+| Example                                          | Description                                                          |
+| ------------------------------------------------ | -------------------------------------------------------------------- |
+| [block-decode](/examples/block-decode)           | Decode a Byron-era block from CBOR                                   |
+| [block-download](/examples/block-download)       | Download a single block from a remote node by chain point            |
+| [crawler](/examples/crawler)                     | Consume the chain-sync mini-protocol with pluggable block/tx filters |
+| [n2n-miniprotocols](/examples/n2n-miniprotocols) | Node-to-node mini-protocols over TCP                                 |
+| [n2c-miniprotocols](/examples/n2c-miniprotocols) | Node-to-client mini-protocols over a local Unix socket               |
+| [p2p-initiator](/examples/p2p-initiator)         | Initiate a P2P connection using `pallas-network2`                    |
+| [p2p-responder](/examples/p2p-responder)         | Accept incoming P2P connections using `pallas-network2`              |
+| [p2p-discovery](/examples/p2p-discovery)         | Peer discovery using `pallas-network2`                               |
+| [wallet](/examples/wallet)                       | Wallet key generation, BIP-39 mnemonics, address derivation          |
+| [otel](/examples/otel)                           | OpenTelemetry collector configuration for tracing the examples above |
+
+## Cardano Era Compatibility
+
+Pallas tracks every Cardano era released to date. `pallas-primitives` provides
+era-specific CBOR types, and `pallas-traverse` exposes a unified `Era` enum
+together with multi-era views over blocks, transactions, and values.
+
+| Era     | Notes                                                   |
+| ------- | ------------------------------------------------------- |
+| Byron   | Original UTxO model                                     |
+| Shelley | Native staking and delegation                           |
+| Allegra | Time-locked transactions                                |
+| Mary    | Native multi-asset support                              |
+| Alonzo  | Plutus smart contracts                                  |
+| Babbage | Reference inputs, inline datums, scripts (CIP-31/32/33) |
+| Conway  | On-chain governance (CIP-1694)                          |
 
 ## Etymology
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ pallas
     └── txbuilder    — ergonomic transaction builder
 ```
 
-### Features
+### Feature Flags
 
 The umbrella crate exposes the following Cargo features:
 
@@ -140,22 +140,14 @@ common integration patterns:
 | [wallet](/examples/wallet)                       | Wallet key generation, BIP-39 mnemonics, address derivation          |
 | [otel](/examples/otel)                           | OpenTelemetry collector configuration for tracing the examples above |
 
-## Cardano Era Compatibility
-
-Pallas tracks every Cardano era released to date. `pallas-primitives` provides
-era-specific CBOR types, and `pallas-traverse` exposes a unified `Era` enum
-together with multi-era views over blocks, transactions, and values.
-
-| Era     | Notes                                                   |
-| ------- | ------------------------------------------------------- |
-| Byron   | Original UTxO model                                     |
-| Shelley | Native staking and delegation                           |
-| Allegra | Time-locked transactions                                |
-| Mary    | Native multi-asset support                              |
-| Alonzo  | Plutus smart contracts                                  |
-| Babbage | Reference inputs, inline datums, scripts (CIP-31/32/33) |
-| Conway  | On-chain governance (CIP-1694)                          |
-
 ## Etymology
 
 > Pallas: (Greek mythology) goddess of wisdom and useful arts and prudent warfare;
+
+## License
+
+Pallas is distributed under the terms of the [Apache License 2.0](LICENSE).
+
+## Security
+
+If you discover a security vulnerability, please follow the disclosure process described in [SECURITY.md](SECURITY.md). Do not open a public GitHub issue.


### PR DESCRIPTION
## Summary

Refreshes the root `README.md` with content the workspace had outgrown:

- Fix logo image URLs (`master` → `main`).
- Add the four published crates that were missing from the Unboxing tables: `pallas-bech32`, `pallas-configs`, `pallas-network2`, `pallas-validate`.
- Add a one-line note in the Network section explaining `pallas-network2` is a P2P-focused rewrite of `pallas-network`.
- Add a **Getting Started** section with `cargo add` snippets and a pointer to `examples/`.
- Add a **Features** section documenting the umbrella crate's Cargo features (`hardano`, `phase2`, `network2`, `relaxed`, `unstable`).

No changes to per-crate READMEs (those are tracked separately on `docs/tidy-per-crate-readmes`).

## Test plan

- [ ] GitHub renders the README correctly (logo loads from `main`, tables align).
- [ ] All relative crate links (`/pallas-bech32`, `/pallas-network2`, etc.) resolve.
- [ ] The `cargo add` snippets are copy-pasteable.
- [ ] The feature table matches `pallas/Cargo.toml` `[features]`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Reorganized README with a new "Getting Started" section providing clearer guidance on using the umbrella crate and understanding the dependency structure.
  * Added a comprehensive feature table and crate catalog organized by domain for easier navigation.
  * Introduced an "Examples" section showcasing available runnable example projects.
  * Added "Cardano Era Compatibility" section detailing supported eras and coverage.
  * Updated asset references for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->