### PR TITLE
fix(validate): include withdrawals in conway redeemer pointer check

### DIFF
--- a/pallas-validate/src/phase1/conway.rs
+++ b/pallas-validate/src/phase1/conway.rs
@@ -1193,9 +1193,7 @@ fn mk_plutus_script_redeemer_pointers(
     }
     if let Some(withdrawals) = &tx_body.withdrawals {
         for (index, (stake_key_hash_bytes, _amount)) in withdrawals.iter().enumerate() {
-            let addr = Address::from_bytes(stake_key_hash_bytes)
-                .ok_or(PostAlonzo(InputDecoding))?;
-            if let Address::Stake(stake_addr) = addr {
+            if let Some(Address::Stake(stake_addr)) = Address::from_bytes(stake_key_hash_bytes) {
                 if stake_addr.is_script() {
                     let script_hash = stake_addr.payload().as_hash();
                     if is_phase_2_script(

--- a/pallas-validate/src/phase1/conway.rs
+++ b/pallas-validate/src/phase1/conway.rs
@@ -1193,7 +1193,8 @@ fn mk_plutus_script_redeemer_pointers(
     }
     if let Some(withdrawals) = &tx_body.withdrawals {
         for (index, (stake_key_hash_bytes, _amount)) in withdrawals.iter().enumerate() {
-            let addr = Address::from_bytes(stake_key_hash_bytes).expect("Invalid stake address bytes");
+            let addr = Address::from_bytes(stake_key_hash_bytes)
+                .ok_or(PostAlonzo(InputDecoding))?;
             if let Address::Stake(stake_addr) = addr {
                 if stake_addr.is_script() {
                     let script_hash = stake_addr.payload().as_hash();

--- a/pallas-validate/src/phase1/conway.rs
+++ b/pallas-validate/src/phase1/conway.rs
@@ -12,7 +12,8 @@ use crate::utils::{
     ValidationError::{self, *},
     ValidationResult,
 };
-use pallas_addresses::{Address, ScriptHash, ShelleyAddress, ShelleyPaymentPart};
+use itertools::Itertools;
+use pallas_addresses::{Address, Network, ScriptHash, ShelleyAddress, ShelleyPaymentPart, StakePayload};
 use pallas_codec::utils::{Bytes, KeepRaw, NonEmptySet};
 use pallas_primitives::{
     babbage,
@@ -23,6 +24,7 @@ use pallas_primitives::{
     AddrKeyhash, Hash, PlutusData, PlutusScript, PolicyId, PositiveCoin, TransactionInput,
 };
 use pallas_traverse::{MultiEraInput, MultiEraOutput, OriginalHash};
+use std::cmp::Ordering;
 use std::ops::Deref;
 
 pub fn validate_conway_tx(
@@ -1148,6 +1150,35 @@ fn sort_inputs(unsorted_inputs: &[TransactionInput]) -> Vec<TransactionInput> {
     res
 }
 
+// Sorting function for reward accounts (withdrawals).
+fn sort_reward_accounts(a: &Bytes, b: &Bytes) -> Ordering {
+    let addr_a = Address::from_bytes(a).expect("invalid reward address in withdrawals.");
+    let addr_b = Address::from_bytes(b).expect("invalid reward address in withdrawals.");
+
+    fn network_tag(network: Network) -> u8 {
+        match network {
+            Network::Testnet => 0,
+            Network::Mainnet => 1,
+            Network::Other(tag) => tag,
+        }
+    }
+
+    if let (Address::Stake(accnt_a), Address::Stake(accnt_b)) = (addr_a, addr_b) {
+        if accnt_a.network() != accnt_b.network() {
+            return network_tag(accnt_a.network()).cmp(&network_tag(accnt_b.network()));
+        }
+
+        match (accnt_a.payload(), accnt_b.payload()) {
+            (StakePayload::Script(..), StakePayload::Stake(..)) => Ordering::Less,
+            (StakePayload::Stake(..), StakePayload::Script(..)) => Ordering::Greater,
+            (StakePayload::Script(hash_a), StakePayload::Script(hash_b)) => hash_a.cmp(hash_b),
+            (StakePayload::Stake(hash_a), StakePayload::Stake(hash_b)) => hash_a.cmp(hash_b),
+        }
+    } else {
+        unreachable!("invalid reward address in withdrawals.");
+    }
+}
+
 fn mk_plutus_script_redeemer_pointers(
     plutus_v1_scripts: &[PolicyId],
     plutus_v2_scripts: &[PolicyId],
@@ -1192,8 +1223,12 @@ fn mk_plutus_script_redeemer_pointers(
         }
     }
     if let Some(withdrawals) = &tx_body.withdrawals {
-        for (index, (stake_key_hash_bytes, _amount)) in withdrawals.iter().enumerate() {
-            if let Some(Address::Stake(stake_addr)) = Address::from_bytes(stake_key_hash_bytes) {
+        for (index, (stake_key_hash_bytes, _amount)) in withdrawals
+            .iter()
+            .sorted_by(|(accnt_a, _), (accnt_b, _)| sort_reward_accounts(accnt_a, accnt_b))
+            .enumerate()
+        {
+            if let Ok(Address::Stake(stake_addr)) = Address::from_bytes(stake_key_hash_bytes) {
                 if stake_addr.is_script() {
                     let script_hash = stake_addr.payload().as_hash();
                     if is_phase_2_script(

--- a/pallas-validate/src/phase1/conway.rs
+++ b/pallas-validate/src/phase1/conway.rs
@@ -12,7 +12,7 @@ use crate::utils::{
     ValidationError::{self, *},
     ValidationResult,
 };
-use pallas_addresses::{ScriptHash, ShelleyAddress, ShelleyPaymentPart};
+use pallas_addresses::{Address, ScriptHash, ShelleyAddress, ShelleyPaymentPart};
 use pallas_codec::utils::{Bytes, KeepRaw, NonEmptySet};
 use pallas_primitives::{
     babbage,
@@ -1129,6 +1129,7 @@ fn check_redeemers(
 
         None => Vec::new(),
     };
+
     let plutus_scripts: Vec<RedeemersKey> = mk_plutus_script_redeemer_pointers(
         plutus_v1_scripts,
         plutus_v2_scripts,
@@ -1187,6 +1188,28 @@ fn mk_plutus_script_redeemer_pointers(
                     tag: pallas_primitives::conway::RedeemerTag::Mint,
                     index: index as u32,
                 })
+            }
+        }
+    }
+    if let Some(withdrawals) = &tx_body.withdrawals {
+        for (index, (stake_key_hash_bytes, _amount)) in withdrawals.iter().enumerate() {
+            let addr = Address::from_bytes(stake_key_hash_bytes).expect("Invalid stake address bytes");
+            if let Address::Stake(stake_addr) = addr {
+                if stake_addr.is_script() {
+                    let script_hash = stake_addr.payload().as_hash();
+                    if is_phase_2_script(
+                        &script_hash,
+                        plutus_v1_scripts,
+                        plutus_v2_scripts,
+                        plutus_v3_scripts,
+                        reference_scripts,
+                    ) {
+                        res.push(RedeemersKey {
+                            tag: pallas_primitives::conway::RedeemerTag::Reward,
+                            index: index as u32,
+                        })
+                    }
+                }
             }
         }
     }

--- a/pallas-validate/src/phase1/conway.rs
+++ b/pallas-validate/src/phase1/conway.rs
@@ -13,7 +13,9 @@ use crate::utils::{
     ValidationResult,
 };
 use itertools::Itertools;
-use pallas_addresses::{Address, Network, ScriptHash, ShelleyAddress, ShelleyPaymentPart, StakePayload};
+use pallas_addresses::{
+    Address, Network, ScriptHash, ShelleyAddress, ShelleyPaymentPart, StakePayload,
+};
 use pallas_codec::utils::{Bytes, KeepRaw, NonEmptySet};
 use pallas_primitives::{
     babbage,

--- a/pallas-validate/src/phase1/conway.rs
+++ b/pallas-validate/src/phase1/conway.rs
@@ -12,9 +12,8 @@ use crate::utils::{
     ValidationError::{self, *},
     ValidationResult,
 };
-use itertools::Itertools;
 use pallas_addresses::{
-    Address, Network, ScriptHash, ShelleyAddress, ShelleyPaymentPart, StakePayload,
+    Address, Network, ScriptHash, ShelleyAddress, ShelleyPaymentPart, StakeAddress, StakePayload,
 };
 use pallas_codec::utils::{Bytes, KeepRaw, NonEmptySet};
 use pallas_primitives::{
@@ -1141,7 +1140,7 @@ fn check_redeemers(
         reference_scripts,
         tx_body,
         utxos,
-    );
+    )?;
     redeemer_key_coincide(&redeemer_key, &plutus_scripts)
 }
 
@@ -1153,10 +1152,7 @@ fn sort_inputs(unsorted_inputs: &[TransactionInput]) -> Vec<TransactionInput> {
 }
 
 // Sorting function for reward accounts (withdrawals).
-fn sort_reward_accounts(a: &Bytes, b: &Bytes) -> Ordering {
-    let addr_a = Address::from_bytes(a).expect("invalid reward address in withdrawals.");
-    let addr_b = Address::from_bytes(b).expect("invalid reward address in withdrawals.");
-
+fn sort_reward_accounts(a: &StakeAddress, b: &StakeAddress) -> Ordering {
     fn network_tag(network: Network) -> u8 {
         match network {
             Network::Testnet => 0,
@@ -1165,19 +1161,15 @@ fn sort_reward_accounts(a: &Bytes, b: &Bytes) -> Ordering {
         }
     }
 
-    if let (Address::Stake(accnt_a), Address::Stake(accnt_b)) = (addr_a, addr_b) {
-        if accnt_a.network() != accnt_b.network() {
-            return network_tag(accnt_a.network()).cmp(&network_tag(accnt_b.network()));
-        }
+    if a.network() != b.network() {
+        return network_tag(a.network()).cmp(&network_tag(b.network()));
+    }
 
-        match (accnt_a.payload(), accnt_b.payload()) {
-            (StakePayload::Script(..), StakePayload::Stake(..)) => Ordering::Less,
-            (StakePayload::Stake(..), StakePayload::Script(..)) => Ordering::Greater,
-            (StakePayload::Script(hash_a), StakePayload::Script(hash_b)) => hash_a.cmp(hash_b),
-            (StakePayload::Stake(hash_a), StakePayload::Stake(hash_b)) => hash_a.cmp(hash_b),
-        }
-    } else {
-        unreachable!("invalid reward address in withdrawals.");
+    match (a.payload(), b.payload()) {
+        (StakePayload::Script(..), StakePayload::Stake(..)) => Ordering::Less,
+        (StakePayload::Stake(..), StakePayload::Script(..)) => Ordering::Greater,
+        (StakePayload::Script(hash_a), StakePayload::Script(hash_b)) => hash_a.cmp(hash_b),
+        (StakePayload::Stake(hash_a), StakePayload::Stake(hash_b)) => hash_a.cmp(hash_b),
     }
 }
 
@@ -1188,7 +1180,7 @@ fn mk_plutus_script_redeemer_pointers(
     reference_scripts: &[PolicyId],
     tx_body: &TransactionBody,
     utxos: &UTxOs,
-) -> Vec<RedeemersKey> {
+) -> Result<Vec<RedeemersKey>, ValidationError> {
     let mut res: Vec<RedeemersKey> = Vec::new();
     let sorted_inputs: &Vec<TransactionInput> = &sort_inputs(&tx_body.inputs);
     for (index, input) in sorted_inputs.iter().enumerate() {
@@ -1225,31 +1217,33 @@ fn mk_plutus_script_redeemer_pointers(
         }
     }
     if let Some(withdrawals) = &tx_body.withdrawals {
-        for (index, (stake_key_hash_bytes, _amount)) in withdrawals
-            .iter()
-            .sorted_by(|(accnt_a, _), (accnt_b, _)| sort_reward_accounts(accnt_a, accnt_b))
-            .enumerate()
-        {
-            if let Ok(Address::Stake(stake_addr)) = Address::from_bytes(stake_key_hash_bytes) {
-                if stake_addr.is_script() {
-                    let script_hash = stake_addr.payload().as_hash();
-                    if is_phase_2_script(
-                        &script_hash,
-                        plutus_v1_scripts,
-                        plutus_v2_scripts,
-                        plutus_v3_scripts,
-                        reference_scripts,
-                    ) {
-                        res.push(RedeemersKey {
-                            tag: pallas_primitives::conway::RedeemerTag::Reward,
-                            index: index as u32,
-                        })
-                    }
+        let mut parsed: Vec<StakeAddress> = withdrawals
+            .keys()
+            .map(|bytes| match Address::from_bytes(bytes) {
+                Ok(Address::Stake(addr)) => Ok(addr),
+                _ => Err(PostAlonzo(InputDecoding)),
+            })
+            .collect::<Result<_, _>>()?;
+        parsed.sort_by(sort_reward_accounts);
+        for (index, stake_addr) in parsed.iter().enumerate() {
+            if stake_addr.is_script() {
+                let script_hash = stake_addr.payload().as_hash();
+                if is_phase_2_script(
+                    script_hash,
+                    plutus_v1_scripts,
+                    plutus_v2_scripts,
+                    plutus_v3_scripts,
+                    reference_scripts,
+                ) {
+                    res.push(RedeemersKey {
+                        tag: pallas_primitives::conway::RedeemerTag::Reward,
+                        index: index as u32,
+                    })
                 }
             }
         }
     }
-    res
+    Ok(res)
 }
 
 // Lexicographical sorting for PolicyID's.


### PR DESCRIPTION
## Summary
- Add withdrawals to the Conway phase-1 redeemer pointer check (`mk_plutus_script_redeemer_pointers`), so script-locked reward accounts produce a `RedeemerTag::Reward` pointer at the correct sorted index.
- Sort reward accounts by network, then script-vs-key credential, then hash — matching the ledger's canonical ordering for redeemer indexing.
- Replace `.expect()` / `unreachable!()` panics on reward-account decoding with `PostAlonzo(InputDecoding)` propagation, so a malformed withdrawal in untrusted block/mempool input becomes a validation error rather than a node-level panic.

Supersedes #708 — same intent, no panics on adversarial input.

## Test plan
- [x] `cargo build -p pallas-validate`
- [x] `cargo clippy -p pallas-validate --all-targets` (clean)
- [x] `cargo test -p pallas-validate` (all suites pass: alonzo, babbage, byron, conway, shelley_ma)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced transaction validation with comprehensive support for Conway reward redeemers.

* **Bug Fixes**
  * Improved error handling and validation reliability for Plutus redeemer pointer generation. Better handling of withdrawal transactions and reward account processing with enhanced error recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->