### PR TITLE
chore: fix lints, rustdoc, and feature gates across workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build
-        run: cargo build --workspace --all-targets --locked
+        run: cargo build --workspace --all-targets
       - name: Test
         run: cargo test --workspace
       - name: Test blueprint feature

--- a/pallas-crypto/Cargo.toml
+++ b/pallas-crypto/Cargo.toml
@@ -47,3 +47,4 @@ relaxed = []
 harness = false
 name = "summed_kes_benches"
 path = "./src/kes/summed_kes_benches.rs"
+required-features = ["kes"]

--- a/pallas-crypto/src/kes/common.rs
+++ b/pallas-crypto/src/kes/common.rs
@@ -2,9 +2,9 @@
 use crate::hash::Hasher;
 use crate::kes::errors::Error;
 use ed25519_dalek as ed25519;
+use rand_chacha::ChaCha20Rng;
 use rand_core::Rng;
 use rand_core::SeedableRng;
-use rand_chacha::ChaCha20Rng;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::convert::TryInto;

--- a/pallas-crypto/src/key/ed25519.rs
+++ b/pallas-crypto/src/key/ed25519.rs
@@ -6,13 +6,13 @@
 //! transactions.
 //!
 //! However, only the [`SecretKeyExtended`] can be used for HD derivation
-//! (using [ed25519_bip32] or otherwise).
+//! (using `ed25519_bip32` or otherwise).
 
 use crate::memsec::Scrubbed as _;
 use cryptoxide::ed25519::{
     self, EXTENDED_KEY_LENGTH, PRIVATE_KEY_LENGTH, PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH,
 };
-use rand_core::{CryptoRng, RngCore};
+use rand_core::{CryptoRng, Rng};
 use std::{any::type_name, convert::TryFrom, fmt, str::FromStr};
 use thiserror::Error;
 
@@ -22,8 +22,7 @@ pub struct SecretKey([u8; Self::SIZE]);
 
 /// Ed25519 Extended Secret Key
 ///
-/// unlike [`SecretKey`], an extended key can be derived see
-/// [`pallas_crypto::derivation`]
+/// unlike [`SecretKey`], an extended key supports HD derivation.
 #[derive(Clone)]
 pub struct SecretKeyExtended([u8; Self::SIZE]);
 
@@ -85,9 +84,9 @@ impl_size_zero!(Signature, SIGNATURE_LENGTH);
 
 impl SecretKey {
     /// generate a new [`SecretKey`] with the given random number generator
-    pub fn new<Rng>(mut rng: Rng) -> Self
+    pub fn new<R>(mut rng: R) -> Self
     where
-        Rng: RngCore + CryptoRng,
+        R: Rng + CryptoRng,
     {
         let mut s = Self::zero();
         rng.fill_bytes(&mut s.0);
@@ -168,9 +167,9 @@ impl SecretKey {
 impl SecretKeyExtended {
     /// generate a new [`SecretKeyExtended`] with the given random number
     /// generator
-    pub fn new<Rng>(mut rng: Rng) -> Self
+    pub fn new<R>(mut rng: R) -> Self
     where
-        Rng: RngCore + CryptoRng,
+        R: Rng + CryptoRng,
     {
         let mut s = Self::zero();
         rng.fill_bytes(&mut s.0);

--- a/pallas-hardano/src/display/haskell_error.rs
+++ b/pallas-hardano/src/display/haskell_error.rs
@@ -21,7 +21,7 @@ pub fn serialize_error(error: TxValidationError) -> serde_json::Value {
     serde_json::to_value(wrap_error_response(error)).unwrap()
 }
 
-/// https://github.com/IntersectMBO/cardano-node/blob/9dbf0b141e67ec2dfd677c77c63b1673cf9c5f3e/cardano-submit-api/src/Cardano/TxSubmit/Types.hs#L54
+/// <https://github.com/IntersectMBO/cardano-node/blob/9dbf0b141e67ec2dfd677c77c63b1673cf9c5f3e/cardano-submit-api/src/Cardano/TxSubmit/Types.hs#L54>
 #[derive(Debug, Serialize)]
 #[serde(tag = "tag", content = "contents")]
 pub enum TxSubmitFail {
@@ -41,7 +41,7 @@ pub enum TxCmdError {
     TxCmdTxSubmitValidationError(TxValidationErrorInCardanoMode),
 }
 
-/// https://github.com/IntersectMBO/cardano-api/blob/d7c62a04ebf18d194a6ea70e6765eb7691d57668/cardano-api/internal/Cardano/Api/InMode.hs#L259
+/// <https://github.com/IntersectMBO/cardano-api/blob/d7c62a04ebf18d194a6ea70e6765eb7691d57668/cardano-api/internal/Cardano/Api/InMode.hs#L259>
 #[derive(Debug, Serialize)]
 #[serde(tag = "tag", content = "contents")]
 pub enum TxValidationErrorInCardanoMode {
@@ -50,7 +50,7 @@ pub enum TxValidationErrorInCardanoMode {
     EraMismatch(EraMismatch),
 }
 
-/// https://github.com/IntersectMBO/ouroboros-consensus/blob/e86b921443bd6e8ea25e7190eb7cb5788e28f4cc/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs#L208
+/// <https://github.com/IntersectMBO/ouroboros-consensus/blob/e86b921443bd6e8ea25e7190eb7cb5788e28f4cc/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs#L208>
 #[derive(Debug, Serialize)]
 pub struct EraMismatch {
     ledger: String, //  Name of the era of the ledger ("Byron" or "Shelley").
@@ -58,7 +58,7 @@ pub struct EraMismatch {
 }
 
 /// TODO: Implement DecoderError errors from the Haskell codebase.
-/// Lots of errors, skipping for now. https://github.com/IntersectMBO/cardano-base/blob/391a2c5cfd30d2234097e000dbd8d9db21ef94d7/cardano-binary/src/Cardano/Binary/FromCBOR.hs#L90
+/// Lots of errors, skipping for now. <https://github.com/IntersectMBO/cardano-base/blob/391a2c5cfd30d2234097e000dbd8d9db21ef94d7/cardano-binary/src/Cardano/Binary/FromCBOR.hs#L90>
 type DecoderError = String;
 
 //

--- a/pallas-hardano/src/storage/immutable/primary.rs
+++ b/pallas-hardano/src/storage/immutable/primary.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 // See https://input-output-hk.github.io/ouroboros-consensus/pdfs/report.pdf, section 8.2.2
-binary_layout::define_layout!(layout, BigEndian, {
+binary_layout::binary_layout!(layout, BigEndian, {
     secondary_offset: u32,
 });
 

--- a/pallas-hardano/src/storage/immutable/secondary.rs
+++ b/pallas-hardano/src/storage/immutable/secondary.rs
@@ -9,7 +9,7 @@ pub type PrimaryIndex = super::primary::Reader;
 use crate::storage::immutable::{primary, secondary};
 
 // See https://input-output-hk.github.io/ouroboros-consensus/pdfs/report.pdf, section 8.2.2
-binary_layout::define_layout!(layout, BigEndian, {
+binary_layout::binary_layout!(layout, BigEndian, {
     block_offset: u64,
     header_offset: u16,
     header_size: u16,

--- a/pallas-math/src/math.rs
+++ b/pallas-math/src/math.rs
@@ -36,7 +36,7 @@ pub trait FixedPrecision:
     /// Returns the precision of the fixed point number
     fn precision(&self) -> u64;
 
-    /// Performs the 'exp' approximation. First does the scaling of 'x' to [0,1]
+    /// Performs the 'exp' approximation. First does the scaling of 'x' to \[0,1\]
     /// and then calls the continued fraction approximation function.
     fn exp(&self) -> Self;
 

--- a/pallas-network/src/miniprotocols/localstate/codec.rs
+++ b/pallas-network/src/miniprotocols/localstate/codec.rs
@@ -135,6 +135,7 @@ impl<'b> Decode<'b, ()> for Message {
 
 #[cfg(test)]
 pub mod tests {
+    #[cfg(feature = "blueprint")]
     use pallas_codec::minicbor;
 
     /// Decode/encode roundtrip tests for the localstate example queries/results.
@@ -164,6 +165,7 @@ pub mod tests {
     }
 
     // TODO: DRY with other decode/encode roundtripss
+    #[cfg(feature = "blueprint")]
     fn roundtrips<T>(message_str: &str)
     where
         T: for<'b> minicbor::Decode<'b, ()> + minicbor::Encode<()> + std::fmt::Debug,

--- a/pallas-network/src/miniprotocols/localstate/queries_v16/codec.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/codec.rs
@@ -974,6 +974,7 @@ pub mod tests {
 
     // TODO: DRY with other decode/encode roundtripss
     // Decode a value of type T, transform it to U and encode that again to form a roundtrip.
+    #[cfg(feature = "blueprint")]
     fn roundtrips_with<T, U>(message_str: &str, transform: fn(T) -> U)
     where
         T: for<'b> minicbor::Decode<'b, ()> + std::fmt::Debug,

--- a/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs
@@ -251,7 +251,7 @@ pub struct CommitteeMembersState {
     pub epoch: Epoch,
 }
 
-/// DRep thresholds as [in the Haskell sources](https://github.com/IntersectMBO/cardano-ledger/blob/d30a7ae828e802e98277c82e278e570955afc273/libs/cardano-ledger-core/src/Cardano/Ledger/DRep.hs#L52-L57
+/// DRep thresholds as [in the Haskell sources](https://github.com/IntersectMBO/cardano-ledger/blob/d30a7ae828e802e98277c82e278e570955afc273/libs/cardano-ledger-core/src/Cardano/Ledger/DRep.hs#L52-L57)
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub enum DRep {
     KeyHash(Bytes),
@@ -261,7 +261,7 @@ pub enum DRep {
 }
 
 /// Governance action id as defined [in the Haskell sources](https://github.com/IntersectMBO/cardano-ledger/blob/d30a7ae828e802e98277c82e278e570955afc273/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs#L167-L170),
-/// via [Transaction ID](https://github.com/IntersectMBO/cardano-ledger/blob/d30a7ae828e802e98277c82e278e570955afc273/libs/cardano-ledger-core/src/Cardano/Ledger/TxIn.hs#L56
+/// via [Transaction ID](https://github.com/IntersectMBO/cardano-ledger/blob/d30a7ae828e802e98277c82e278e570955afc273/libs/cardano-ledger-core/src/Cardano/Ledger/TxIn.hs#L56)
 /// and [Action Index](https://github.com/IntersectMBO/cardano-ledger/blob/d30a7ae828e802e98277c82e278e570955afc273/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs#L154).
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone, PartialOrd, Ord)]
 pub struct GovActionId {
@@ -604,7 +604,7 @@ pub enum GovAction {
     InfoAction,
 }
 
-/// Proposal procedure state as defined [in the Haskell sources](https://github.com/IntersectMBO/cardano-ledger/blob/d30a7ae828e802e98277c82e278e570955afc273/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs#L476-L481
+/// Proposal procedure state as defined [in the Haskell sources](https://github.com/IntersectMBO/cardano-ledger/blob/d30a7ae828e802e98277c82e278e570955afc273/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs#L476-L481)
 #[derive(Debug, Encode, Decode, Eq, PartialEq, Clone)]
 pub struct ProposalProcedure {
     #[n(0)]

--- a/pallas-network/src/miniprotocols/localtxsubmission/protocol.rs
+++ b/pallas-network/src/miniprotocols/localtxsubmission/protocol.rs
@@ -49,7 +49,7 @@ pub enum Message<Tx, Reject> {
 pub struct EraTx(pub u16, pub Vec<u8>);
 
 /// Era to be used in tx errors
-/// https://github.com/IntersectMBO/cardano-api/blob/a0df586e3a14b98ae4771a192c09391dacb44564/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs#L271
+/// <https://github.com/IntersectMBO/cardano-api/blob/a0df586e3a14b98ae4771a192c09391dacb44564/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs#L271>
 #[derive(Debug, Decode, Encode, Clone, Eq, PartialEq)]
 #[cbor(index_only)]
 pub enum ShelleyBasedEra {

--- a/pallas-traverse/src/tx.rs
+++ b/pallas-traverse/src/tx.rs
@@ -170,7 +170,7 @@ impl<'b> MultiEraTx<'b> {
 
     /// Return the transaction inputs
     ///
-    /// NOTE: It is possible for this to return duplicates before some point in the chain history. See https://github.com/input-output-hk/cardano-ledger/commit/a342b74f5db3d3a75eae3e2abe358a169701b1e7
+    /// NOTE: It is possible for this to return duplicates before some point in the chain history. See <https://github.com/input-output-hk/cardano-ledger/commit/a342b74f5db3d3a75eae3e2abe358a169701b1e7>
     pub fn inputs(&self) -> Vec<MultiEraInput<'_>> {
         match self {
             MultiEraTx::AlonzoCompatible(x, _) => x
@@ -242,7 +242,7 @@ impl<'b> MultiEraTx<'b> {
     /// Return the transaction reference inputs
     ///
     /// NOTE: It is possible for this to return duplicates. See
-    /// https://github.com/input-output-hk/cardano-ledger/commit/a342b74f5db3d3a75eae3e2abe358a169701b1e7
+    /// <https://github.com/input-output-hk/cardano-ledger/commit/a342b74f5db3d3a75eae3e2abe358a169701b1e7>
     pub fn reference_inputs(&self) -> Vec<MultiEraInput<'_>> {
         match self {
             MultiEraTx::Conway(x) => x
@@ -337,7 +337,7 @@ impl<'b> MultiEraTx<'b> {
     /// Return the transaction collateral inputs
     ///
     /// NOTE: It is possible for this to return duplicates. See
-    /// https://github.com/input-output-hk/cardano-ledger/commit/a342b74f5db3d3a75eae3e2abe358a169701b1e7
+    /// <https://github.com/input-output-hk/cardano-ledger/commit/a342b74f5db3d3a75eae3e2abe358a169701b1e7>
     pub fn collateral(&self) -> Vec<MultiEraInput<'_>> {
         match self {
             MultiEraTx::Byron(_) => vec![],


### PR DESCRIPTION
## Summary

The new `ci.yml` workflow exposed several pre-existing issues that the older `validate.yml` wasn't catching. This PR fixes all of them so CI goes green.

- **Rustfmt** — reordered imports in `pallas-crypto/src/kes/common.rs` to satisfy stable `reorder_imports`.
- **Clippy** — replaced deprecated `rand_core::RngCore` with `rand_core::Rng` in `pallas-crypto`'s ed25519 keys (rand 0.10 fallout), replaced deprecated `binary_layout::define_layout!` with `binary_layout!` in `pallas-hardano`, and feature-gated dead test helpers in `pallas-network`'s localstate codecs (the only callers were already `#[cfg(feature = "blueprint")]`).
- **Docs (`-D warnings`)** — wrapped bare URLs in `<...>`, fixed three `[label](url` markdown links missing their closing `)` in `pallas-network`, escaped `[0,1]` in `pallas-math`, and removed two broken intra-doc links in `pallas-crypto/src/key/ed25519.rs`.
- **`--no-default-features`** — added `required-features = ["kes"]` to the `summed_kes_benches` bench so Cargo skips it when the `kes` feature is off (the bench imports `pallas_crypto::kes::*` unconditionally).
- **`ci.yml`** — dropped `--locked` from the build step. Pallas is a virtual workspace and `Cargo.lock` isn't tracked, so `--locked` always errored.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- [x] `cargo check --workspace --all-targets --no-default-features`
- [x] `cargo check --workspace --all-targets --all-features`
- [x] `cargo build --workspace --all-targets`
- [x] `cargo test --workspace`
- [x] Confirm CI is green on this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  - Updated RNG trait constraints in key generation functions
  - Improved internal macro usage and code organization
  - Gated optional benchmark features behind Cargo feature flags

* **Documentation**
  - Enhanced documentation formatting and updated references across modules

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/txpipe/pallas/pull/764)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->