### PR TITLE
chore: hoist common cargo metadata and dependencies to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,11 @@
 [workspace.package]
+version = "1.0.0-alpha.6"
+edition = "2021"
 rust-version = "1.88"
+license = "Apache-2.0"
+repository = "https://github.com/txpipe/pallas"
+homepage = "https://github.com/txpipe/pallas"
+authors = ["TxPipe <hello@txpipe.io>"]
 
 [workspace]
 resolver = "2"
@@ -27,3 +33,32 @@ members = [
   "examples/p2p-responder",
   "examples/p2p-initiator",
 ]
+
+[workspace.dependencies]
+hex = "0.4.3"
+thiserror = "2.0.18"
+serde = { version = "1.0.218", features = ["derive"] }
+serde_json = "1.0.140"
+serde_with = "3.12.0"
+itertools = "0.14.0"
+tracing = "0.1.41"
+chrono = "0.4.41"
+socket2 = "0.6.3"
+byteorder = "1.5.0"
+rand = "0.10.1"
+proptest = "1.7.0"
+
+pallas = { version = "=1.0.0-alpha.6", path = "pallas" }
+pallas-codec = { version = "=1.0.0-alpha.6", path = "pallas-codec" }
+pallas-crypto = { version = "=1.0.0-alpha.6", path = "pallas-crypto" }
+pallas-addresses = { version = "=1.0.0-alpha.6", path = "pallas-addresses" }
+pallas-primitives = { version = "=1.0.0-alpha.6", path = "pallas-primitives" }
+pallas-traverse = { version = "=1.0.0-alpha.6", path = "pallas-traverse" }
+pallas-network = { version = "=1.0.0-alpha.6", path = "pallas-network" }
+pallas-network2 = { version = "=1.0.0-alpha.6", path = "pallas-network2" }
+pallas-configs = { version = "=1.0.0-alpha.6", path = "pallas-configs" }
+pallas-txbuilder = { version = "=1.0.0-alpha.6", path = "pallas-txbuilder" }
+pallas-utxorpc = { version = "=1.0.0-alpha.6", path = "pallas-utxorpc" }
+pallas-hardano = { version = "=1.0.0-alpha.6", path = "pallas-hardano" }
+pallas-math = { version = "=1.0.0-alpha.6", path = "pallas-math" }
+pallas-validate = { version = "=1.0.0-alpha.6", path = "pallas-validate" }

--- a/pallas-addresses/Cargo.toml
+++ b/pallas-addresses/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "pallas-addresses"
 description = "Ergonomic library to work with different Cardano addresses"
-version = "1.0.0-alpha.6"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 rust-version.workspace = true
-repository = "https://github.com/txpipe/pallas"
-homepage = "https://github.com/txpipe/pallas"
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+authors.workspace = true
 documentation = "https://docs.rs/pallas-byron"
-license = "Apache-2.0"
 readme = "README.md"
-authors = ["Santiago Carmuega <santiago@carmuega.me>"]
 
 [dependencies]
-hex = "0.4.3"
-pallas-crypto = { version = "=1.0.0-alpha.6", path = "../pallas-crypto" }
-pallas-codec = { version = "=1.0.0-alpha.6", path = "../pallas-codec" }
+hex.workspace = true
+pallas-crypto.workspace = true
+pallas-codec.workspace = true
 base58 = "0.2.0"
 bech32 = "0.11.1"
-thiserror = "2.0"
+thiserror.workspace = true
 crc = "3.0.1"
 cryptoxide = "0.4"

--- a/pallas-codec/Cargo.toml
+++ b/pallas-codec/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "pallas-codec"
 description = "Pallas common CBOR encoding interface and utilities"
-version = "1.0.0-alpha.6"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 rust-version.workspace = true
-repository = "https://github.com/txpipe/pallas"
-homepage = "https://github.com/txpipe/pallas"
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
 documentation = "https://docs.rs/pallas-codec"
-license = "Apache-2.0"
 readme = "README.md"
 authors = [
   "Santiago Carmuega <santiago@carmuega.me>",
@@ -19,11 +19,11 @@ authors = [
 default = []
 
 [dependencies]
-hex = "0.4.3"
+hex.workspace = true
 minicbor = { version = "0.26.0", features = ["std", "half", "derive"] }
 num-bigint = { version = "0.4.4", optional = true }
-serde = { version = "1.0.143", features = ["derive"] }
-thiserror = "2.0.18"
+serde.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
-proptest = "1.1.0"
+proptest.workspace = true

--- a/pallas-codec/Cargo.toml
+++ b/pallas-codec/Cargo.toml
@@ -9,11 +9,7 @@ homepage.workspace = true
 license.workspace = true
 documentation = "https://docs.rs/pallas-codec"
 readme = "README.md"
-authors = [
-  "Santiago Carmuega <santiago@carmuega.me>",
-  "Lucas Rosa <x@rvcas.dev>",
-  "Kasey White <kwhitemsg@gmail.com>",
-]
+authors.workspace = true
 
 [features]
 default = []

--- a/pallas-configs/Cargo.toml
+++ b/pallas-configs/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
 name = "pallas-configs"
 description = "Config structs and utilities matching the Haskell implementation"
-version = "1.0.0-alpha.6"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 rust-version.workspace = true
-repository = "https://github.com/txpipe/pallas"
-homepage = "https://github.com/txpipe/pallas"
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+authors.workspace = true
 documentation = "https://docs.rs/pallas-configs"
-license = "Apache-2.0"
 readme = "README.md"
-authors = ["Santiago Carmuega <santiago@carmuega.me>"]
 
 [dependencies]
-pallas-addresses = { version = "=1.0.0-alpha.6", path = "../pallas-addresses" }
-pallas-crypto = { version = "=1.0.0-alpha.6", path = "../pallas-crypto" }
-pallas-primitives = { version = "=1.0.0-alpha.6", path = "../pallas-primitives" }
-serde = { version = "1.0.136", optional = true, features = ["derive"] }
-serde_json = { version = "1.0.79", optional = true }
+pallas-addresses.workspace = true
+pallas-crypto.workspace = true
+pallas-primitives.workspace = true
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 base64 = "0.22.0"
-serde_with = "3.7.0"
+serde_with.workspace = true
 num-rational = "0.4.2"
 
 [features]

--- a/pallas-crypto/Cargo.toml
+++ b/pallas-crypto/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "pallas-crypto"
 description = "Cryptographic primitives for Cardano"
-version = "1.0.0-alpha.6"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 rust-version.workspace = true
-repository = "https://github.com/txpipe/pallas"
-homepage = "https://github.com/txpipe/pallas"
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
 documentation = "https://docs.rs/pallas-crypto"
-license = "Apache-2.0"
 readme = "README.md"
 authors = [
     "Nicolas Di Prima <nicolas@primetype.co.uk>",
@@ -15,27 +15,27 @@ authors = [
 ]
 
 [dependencies]
-hex = "0.4"
+hex.workspace = true
 cryptoxide = { version = "0.4.4" }
-thiserror = "2.0"
+thiserror.workspace = true
 rand_core = "0.10"
-serde = { version = "1.0.143", features = ["derive"] }
-pallas-codec = { version = "=1.0.0-alpha.6", path = "../pallas-codec" }
+serde.workspace = true
+pallas-codec.workspace = true
 
 # kes dependencies
-rand = { version = "0.10", optional = true }
+rand = { workspace = true, optional = true }
 rand_chacha = { version = "0.10", optional = true }
-serde_with = { version = "3.11.0", optional = true }
+serde_with = { workspace = true, optional = true }
 ed25519-dalek = { version = "2", features = ["serde"], optional = true }
 zeroize = { version = "1.8.1", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
-itertools = "0.13"
+itertools.workspace = true
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
-proptest = "1.6"
-serde_json = "1"
+proptest.workspace = true
+serde_json.workspace = true
 serde_test = "1.0.143"
 
 [features]

--- a/pallas-crypto/Cargo.toml
+++ b/pallas-crypto/Cargo.toml
@@ -9,10 +9,7 @@ homepage.workspace = true
 license.workspace = true
 documentation = "https://docs.rs/pallas-crypto"
 readme = "README.md"
-authors = [
-    "Nicolas Di Prima <nicolas@primetype.co.uk>",
-    "Andrew Westberg <andrewwestberg@gmail.com>",
-]
+authors.workspace = true
 
 [dependencies]
 hex.workspace = true

--- a/pallas-hardano/Cargo.toml
+++ b/pallas-hardano/Cargo.toml
@@ -1,32 +1,31 @@
 [package]
 name = "pallas-hardano"
 description = "Pallas interoperability with the Haskel Cardano node implementation"
-version = "1.0.0-alpha.6"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 rust-version.workspace = true
-repository = "https://github.com/txpipe/pallas"
-homepage = "https://github.com/txpipe/pallas"
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+authors.workspace = true
 documentation = "https://docs.rs/pallas-hardano"
-license = "Apache-2.0"
 readme = "README.md"
-authors = ["Santiago Carmuega <santiago@carmuega.me>"]
 
 [dependencies]
-thiserror = "2.0.18"
+thiserror.workspace = true
 binary-layout = "4.0.2"
 tap = "1.0.1"
-tracing = "0.1.40"
-pallas-traverse = { version = "=1.0.0-alpha.6", path = "../pallas-traverse" }
-pallas-network = { version = "=1.0.0-alpha.6", path = "../pallas-network" }
-pallas-addresses = { version = "=1.0.0-alpha.6", path = "../pallas-addresses" }
-pallas-crypto = { version = "=1.0.0-alpha.6", path = "../pallas-crypto" }
-pallas-codec = { version = "=1.0.0-alpha.6", path = "../pallas-codec" }
+tracing.workspace = true
+pallas-traverse.workspace = true
+pallas-network.workspace = true
+pallas-addresses.workspace = true
+pallas-crypto.workspace = true
+pallas-codec.workspace = true
 
-serde = { version = "1.0.218", features = ["derive"] }
-hex = "0.4.3"
-serde_with = "3.12.0"
-serde_json = "1.0.140"
+serde.workspace = true
+hex.workspace = true
+serde_with.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 tracing-subscriber = "0.3.17"
-hex = "0.4.3"

--- a/pallas-math/Cargo.toml
+++ b/pallas-math/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 license.workspace = true
 documentation = "https://docs.rs/pallas-math"
 readme = "README.md"
-authors = ["Andrew Westberg <andrewwestberg@gmail.com>"]
+authors.workspace = true
 exclude = ["tests/data/*"]
 
 [dependencies]

--- a/pallas-math/Cargo.toml
+++ b/pallas-math/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "pallas-math"
 description = "Mathematics functions for Cardano"
-version = "1.0.0-alpha.6"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 rust-version.workspace = true
-repository = "https://github.com/txpipe/pallas"
-homepage = "https://github.com/txpipe/pallas"
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
 documentation = "https://docs.rs/pallas-math"
-license = "Apache-2.0"
 readme = "README.md"
 authors = ["Andrew Westberg <andrewwestberg@gmail.com>"]
 exclude = ["tests/data/*"]
@@ -16,7 +16,7 @@ exclude = ["tests/data/*"]
 dashu-int = "0.4.1"
 dashu-base = "0.4.1"
 regex = "1.10.5"
-thiserror = "2.0.18"
+thiserror.workspace = true
 
 [dev-dependencies]
-proptest = "1.5"
+proptest.workspace = true

--- a/pallas-network/Cargo.toml
+++ b/pallas-network/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "pallas-network"
 description = "Ouroboros networking stack using async IO"
-version = "1.0.0-alpha.6"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 rust-version.workspace = true
-repository = "https://github.com/txpipe/pallas"
-homepage = "https://github.com/txpipe/pallas"
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
 documentation = "https://docs.rs/pallas"
-license = "Apache-2.0"
 readme = "README.md"
 authors = [
     "Santiago Carmuega <santiago@carmuega.me>",
@@ -15,14 +15,14 @@ authors = [
 ]
 
 [dependencies]
-byteorder = "1.4.3"
-hex = "0.4.3"
-itertools = "0.13.0"
-pallas-codec = { version = "=1.0.0-alpha.6", path = "../pallas-codec" }
-pallas-crypto = { version = "=1.0.0-alpha.6", path = "../pallas-crypto" }
-rand = "0.10.1"
-socket2 = "0.6.3"
-thiserror = "2.0.18"
+byteorder.workspace = true
+hex.workspace = true
+itertools.workspace = true
+pallas-codec.workspace = true
+pallas-crypto.workspace = true
+rand.workspace = true
+socket2.workspace = true
+thiserror.workspace = true
 tokio = { version = "1", features = [
     "rt",
     "net",
@@ -31,7 +31,7 @@ tokio = { version = "1", features = [
     "sync",
     "macros",
 ] }
-tracing = "0.1.37"
+tracing.workspace = true
 
 [dev-dependencies]
 tracing-subscriber = "0.3.16"

--- a/pallas-network/Cargo.toml
+++ b/pallas-network/Cargo.toml
@@ -9,10 +9,7 @@ homepage.workspace = true
 license.workspace = true
 documentation = "https://docs.rs/pallas"
 readme = "README.md"
-authors = [
-    "Santiago Carmuega <santiago@carmuega.me>",
-    "Pi Lanningham <pi.lanningham@gmail.com>",
-]
+authors.workspace = true
 
 [dependencies]
 byteorder.workspace = true

--- a/pallas-network2/Cargo.toml
+++ b/pallas-network2/Cargo.toml
@@ -1,29 +1,29 @@
 [package]
 name = "pallas-network2"
 description = "Ouroboros networking stack for P2P interactions"
-version = "1.0.0-alpha.6"
+version.workspace = true
 edition = "2024"
 rust-version.workspace = true
-repository = "https://github.com/txpipe/pallas"
-homepage = "https://github.com/txpipe/pallas"
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+authors.workspace = true
 documentation = "https://docs.rs/pallas"
-license = "Apache-2.0"
 readme = "README.md"
-authors = ["Santiago Carmuega <santiago@carmuega.me>"]
 
 [dependencies]
 futures = "0.3.31"
 trait-variant = "0.1.2"
-rand = { version = "0.10.1", optional = true }
+rand = { workspace = true, optional = true }
 tokio = { version = "1.45.1", optional = true, features = ["full"] }
-pallas-codec = { version = "=1.0.0-alpha.6", path = "../pallas-codec" }
-chrono = "0.4.41"
+pallas-codec.workspace = true
+chrono.workspace = true
 opentelemetry = "0.30.0"
-tracing = "0.1.41"
-byteorder = "1.5.0"
-socket2 = "0.6.0"
-thiserror = "2.0.16"
-hex = "0.4.3"
+tracing.workspace = true
+byteorder.workspace = true
+socket2.workspace = true
+thiserror.workspace = true
+hex.workspace = true
 
 [features]
 emulation = ["tokio", "rand"]

--- a/pallas-primitives/Cargo.toml
+++ b/pallas-primitives/Cargo.toml
@@ -9,10 +9,7 @@ homepage.workspace = true
 license.workspace = true
 documentation = "https://docs.rs/pallas-primitives"
 readme = "README.md"
-authors = [
-    "Santiago Carmuega <santiago@carmuega.me>",
-    "Lucas Rosa <x@rvcas.dev>",
-]
+authors.workspace = true
 
 [dependencies]
 hex.workspace = true

--- a/pallas-primitives/Cargo.toml
+++ b/pallas-primitives/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "pallas-primitives"
 description = "Ledger primitives and cbor codec for the different Cardano eras"
-version = "1.0.0-alpha.6"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 rust-version.workspace = true
-repository = "https://github.com/txpipe/pallas"
-homepage = "https://github.com/txpipe/pallas"
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
 documentation = "https://docs.rs/pallas-primitives"
-license = "Apache-2.0"
 readme = "README.md"
 authors = [
     "Santiago Carmuega <santiago@carmuega.me>",
@@ -15,14 +15,14 @@ authors = [
 ]
 
 [dependencies]
-hex = "0.4.3"
-pallas-crypto = { version = "=1.0.0-alpha.6", path = "../pallas-crypto" }
-pallas-codec = { version = "=1.0.0-alpha.6", path = "../pallas-codec" }
-serde = { version = "1.0.136", optional = true, features = ["derive"] }
-serde_json = { version = "1.0.79", optional = true }
+hex.workspace = true
+pallas-crypto.workspace = true
+pallas-codec.workspace = true
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 
 [dev-dependencies]
-proptest = { version = "1.7.0", features = ["alloc"] }
+proptest = { workspace = true, features = ["alloc"] }
 test-case = "3.3.1"
 
 [features]

--- a/pallas-traverse/Cargo.toml
+++ b/pallas-traverse/Cargo.toml
@@ -1,28 +1,28 @@
 [package]
 name = "pallas-traverse"
 description = "Utilities to traverse over multi-era block data"
-version = "1.0.0-alpha.6"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 rust-version.workspace = true
-repository = "https://github.com/txpipe/pallas"
-homepage = "https://github.com/txpipe/pallas"
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+authors.workspace = true
 documentation = "https://docs.rs/pallas-traverse"
-license = "Apache-2.0"
 readme = "README.md"
-authors = ["Santiago Carmuega <santiago@carmuega.me>"]
 
 [dependencies]
-pallas-primitives = { version = "=1.0.0-alpha.6", path = "../pallas-primitives" }
-pallas-addresses = { version = "=1.0.0-alpha.6", path = "../pallas-addresses" }
-pallas-crypto = { version = "=1.0.0-alpha.6", path = "../pallas-crypto" }
-pallas-codec = { version = "=1.0.0-alpha.6", path = "../pallas-codec" }
-hex = "0.4.3"
-thiserror = "2.0.18"
+pallas-primitives.workspace = true
+pallas-addresses.workspace = true
+pallas-crypto.workspace = true
+pallas-codec.workspace = true
+hex.workspace = true
+thiserror.workspace = true
 paste = "1.0.14"
-itertools = "0.13.0"
+itertools.workspace = true
 
 # TODO: remove once GenesisValue moves into new genesis crate
-serde = "1.0.155"
+serde.workspace = true
 
 [features]
 unstable = []

--- a/pallas-txbuilder/Cargo.toml
+++ b/pallas-txbuilder/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 license.workspace = true
 documentation = "https://docs.rs/pallas-txbuilder"
 readme = "README.md"
-authors = ["Santiago Carmuega <santiago@carmuega.me>", "Cainã Costa <me@cfcosta.com>"]
+authors.workspace = true
 
 [dependencies]
 pallas-codec.workspace = true

--- a/pallas-txbuilder/Cargo.toml
+++ b/pallas-txbuilder/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name = "pallas-txbuilder"
 description = "An ergonomic Cardano transaction builder"
-version = "1.0.0-alpha.6"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 rust-version.workspace = true
-repository = "https://github.com/txpipe/pallas"
-homepage = "https://github.com/txpipe/pallas"
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
 documentation = "https://docs.rs/pallas-txbuilder"
-license = "Apache-2.0"
 readme = "README.md"
 authors = ["Santiago Carmuega <santiago@carmuega.me>", "Cainã Costa <me@cfcosta.com>"]
 
 [dependencies]
-pallas-codec = { path = "../pallas-codec", version = "=1.0.0-alpha.6" }
-pallas-crypto = { path = "../pallas-crypto", version = "=1.0.0-alpha.6" }
-pallas-primitives = { path = "../pallas-primitives", version = "=1.0.0-alpha.6" }
-pallas-traverse = { path = "../pallas-traverse", version = "=1.0.0-alpha.6" }
-pallas-addresses = { path = "../pallas-addresses", version = "=1.0.0-alpha.6" }
-serde = { version = "1.0.188", features = ["derive"] }
-serde_json = "1.0.107"
-thiserror = "2.0.18"
-hex = "0.4.3"
+pallas-codec.workspace = true
+pallas-crypto.workspace = true
+pallas-primitives.workspace = true
+pallas-traverse.workspace = true
+pallas-addresses.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+hex.workspace = true

--- a/pallas-utxorpc/Cargo.toml
+++ b/pallas-utxorpc/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "pallas-utxorpc"
 description = "Pallas interoperability with the UTxORPC spec"
-version = "1.0.0-alpha.6"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 rust-version.workspace = true
-repository = "https://github.com/txpipe/pallas"
-homepage = "https://github.com/txpipe/pallas"
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+authors.workspace = true
 documentation = "https://docs.rs/pallas-utxorpc"
-license = "Apache-2.0"
 readme = "README.md"
-authors = ["Santiago Carmuega <santiago@carmuega.me>"]
 
 [dependencies]
 # utxorpc-spec = { path = "../../../utxorpc/spec/gen/rust" }
@@ -26,12 +26,12 @@ utxorpc-spec = { version = "0.19", default-features = false, features = [
     "utxorpc-v1beta-watch",
 ] }
 
-pallas-traverse = { version = "=1.0.0-alpha.6", path = "../pallas-traverse" }
-pallas-primitives = { version = "=1.0.0-alpha.6", path = "../pallas-primitives" }
-pallas-codec = { version = "=1.0.0-alpha.6", path = "../pallas-codec" }
-pallas-crypto = { version = "=1.0.0-alpha.6", path = "../pallas-crypto" }
+pallas-traverse.workspace = true
+pallas-primitives.workspace = true
+pallas-codec.workspace = true
+pallas-crypto.workspace = true
 prost-types = "0.13.1"
-pallas-validate = { version = "=1.0.0-alpha.6", path = "../pallas-validate" }
+pallas-validate.workspace = true
 
 [features]
 default = ["u5c-v1alpha-compat"]
@@ -41,7 +41,7 @@ default = ["u5c-v1alpha-compat"]
 u5c-v1alpha-compat = []
 
 [dev-dependencies]
-hex = "0.4.3"
-serde_json = "1.0.120"
+hex.workspace = true
+serde_json.workspace = true
 pretty_assertions = "1.4.0"
 prost = "0.13"

--- a/pallas-validate/Cargo.toml
+++ b/pallas-validate/Cargo.toml
@@ -1,28 +1,28 @@
 [package]
 name = "pallas-validate"
 description = "Utilities for validating transactions"
-version = "1.0.0-alpha.6"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 rust-version.workspace = true
-repository = "https://github.com/txpipe/pallas"
-homepage = "https://github.com/txpipe/pallas"
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+authors.workspace = true
 documentation = "https://docs.rs/pallas-validate"
-license = "Apache-2.0"
 readme = "README.md"
-authors = ["TxPipe <hello@txpipe.io>"]
 
 [dependencies]
-pallas-addresses = { version = "=1.0.0-alpha.6", path = "../pallas-addresses" }
-pallas-codec = { version = "=1.0.0-alpha.6", path = "../pallas-codec" }
-pallas-crypto = { version = "=1.0.0-alpha.6", path = "../pallas-crypto" }
-pallas-primitives = { version = "=1.0.0-alpha.6", path = "../pallas-primitives" }
-pallas-traverse = { version = "=1.0.0-alpha.6", path = "../pallas-traverse" }
-hex = "0.4"
-chrono = "0.4.39"
-thiserror = "2.0.18"
-serde = { version = "1.0.136", features = ["derive"] }
-itertools = "0.14.0"
-tracing = "0.1.41"
+pallas-addresses.workspace = true
+pallas-codec.workspace = true
+pallas-crypto.workspace = true
+pallas-primitives.workspace = true
+pallas-traverse.workspace = true
+hex.workspace = true
+chrono.workspace = true
+thiserror.workspace = true
+serde.workspace = true
+itertools.workspace = true
+tracing.workspace = true
 
 # phase2 dependencies
 amaru-uplc = { version = "0.1.0", optional = true }

--- a/pallas/Cargo.toml
+++ b/pallas/Cargo.toml
@@ -1,29 +1,29 @@
 [package]
 name = "pallas"
 description = "Rust-native building blocks for the Cardano blockchain ecosystem."
-version = "1.0.0-alpha.6"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 rust-version.workspace = true
-repository = "https://github.com/txpipe/pallas"
-homepage = "https://github.com/txpipe/pallas"
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+authors.workspace = true
 documentation = "https://docs.rs/pallas"
-license = "Apache-2.0"
 readme = "../README.md"
-authors = ["Santiago Carmuega <santiago@carmuega.me>"]
 
 [dependencies]
-pallas-network = { version = "=1.0.0-alpha.6", path = "../pallas-network/" }
-pallas-primitives = { version = "=1.0.0-alpha.6", path = "../pallas-primitives/" }
-pallas-traverse = { version = "=1.0.0-alpha.6", path = "../pallas-traverse/" }
-pallas-addresses = { version = "=1.0.0-alpha.6", path = "../pallas-addresses/" }
-pallas-crypto = { version = "=1.0.0-alpha.6", path = "../pallas-crypto/" }
-pallas-codec = { version = "=1.0.0-alpha.6", path = "../pallas-codec/" }
-pallas-utxorpc = { version = "=1.0.0-alpha.6", path = "../pallas-utxorpc/" }
-pallas-configs = { version = "=1.0.0-alpha.6", path = "../pallas-configs/" }
-pallas-txbuilder = { version = "=1.0.0-alpha.6", path = "../pallas-txbuilder/" }
-pallas-validate = { version = "=1.0.0-alpha.6", path = "../pallas-validate/" }
-pallas-hardano = { version = "=1.0.0-alpha.6", path = "../pallas-hardano/", optional = true }
-pallas-network2 = { version = "=1.0.0-alpha.6", path = "../pallas-network2/", optional = true }
+pallas-network.workspace = true
+pallas-primitives.workspace = true
+pallas-traverse.workspace = true
+pallas-addresses.workspace = true
+pallas-crypto.workspace = true
+pallas-codec.workspace = true
+pallas-utxorpc.workspace = true
+pallas-configs.workspace = true
+pallas-txbuilder.workspace = true
+pallas-validate.workspace = true
+pallas-hardano = { workspace = true, optional = true }
+pallas-network2 = { workspace = true, optional = true }
 
 [features]
 hardano = ["pallas-hardano"]


### PR DESCRIPTION
## Summary

- Hoist shared `[package]` metadata (`version`, `edition`, `license`, `repository`, `homepage`, `authors`) into `[workspace.package]`. `pallas-network2` keeps its literal `edition = "2024"` override; per-crate `description`, `documentation`, `readme`, and multi-author `authors` lists stay literal.
- Add `[workspace.dependencies]` for every multi-crate dependency (`hex`, `thiserror`, `serde` +derive, `serde_json`, `serde_with`, `itertools`, `tracing`, `chrono`, `socket2`, `byteorder`, `rand`, `proptest`) plus all intra-workspace `pallas-*` crates. Each member crate switches to `<dep>.workspace = true` (with `optional`/extra-`features` overrides preserved).
- Standardize each drifted dependency to the **latest version already present in the tree** — same-major bumps, no version higher than what we were already pulling. Notable resolutions: `serde 1.0.218`, `serde_json 1.0.140`, `thiserror 2.0.18`, `hex 0.4.3`, `itertools 0.14.0`, `tracing 0.1.41`, `serde_with 3.12.0`, `proptest 1.7.0`.
- `tokio` is intentionally **not** hoisted: the only two consumers (`pallas-network`, `pallas-network2`) use very different feature sets and version pins.
- Drops a redundant `[dev-dependencies] hex = ...` from `pallas-hardano` (already covered by the `[dependencies]` entry).
- `pallas-bech32` and the `examples/*` crates are intentionally untouched (out of scope for this pass).

## Test plan

- [x] `cargo metadata --format-version=1 --no-deps` parses without errors.
- [x] `cargo check --workspace --all-features` succeeds.
- [x] `cargo test --workspace --no-run` builds every test target.
- [x] `cargo tree -d --workspace` shows no remaining drift among direct deps; residual duplicates are all transitive (`tonic`, `reqwest`, `pbjson`) or single-use dev deps (`criterion 0.5` vs `0.7`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace version to 1.0.0-alpha.6 and minimum supported Rust version to 1.88.
  * Consolidated dependency management across internal crates for improved consistency and maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/txpipe/pallas/pull/766)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->