### PR TITLE
docs: add missing crate and module-level documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,8 @@ RELEASE.md
 .idea
 .vscode
 
+# local agents
+.claude
+
 # temp while local development
 pallas-client

--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ common integration patterns:
 | [p2p-responder](/examples/p2p-responder)         | Accept incoming P2P connections using `pallas-network2`              |
 | [p2p-discovery](/examples/p2p-discovery)         | Peer discovery using `pallas-network2`                               |
 | [wallet](/examples/wallet)                       | Wallet key generation, BIP-39 mnemonics, address derivation          |
-| [otel](/examples/otel)                           | OpenTelemetry collector configuration for tracing the examples above |
 
 ## Minimum Supported Rust Version
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ pallas
 ├── interop
 │   ├── utxorpc      — UTxO RPC interop
 │   └── hardano      — Haskell-node interop (feature `hardano`)
-└── wallet
-    └── txbuilder    — ergonomic transaction builder
+└── txbuilder        — ergonomic transaction builder
 ```
 
 ### Feature Flags

--- a/pallas-addresses/README.md
+++ b/pallas-addresses/README.md
@@ -12,8 +12,8 @@ follows [CIP-19](https://cips.cardano.org/cips/cip19/).
 use pallas_addresses::Address;
 
 let addr = Address::from_bech32(
-    "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8\
-     ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp",
+    "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3\
+     n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x",
 )?;
 
 match addr {

--- a/pallas-addresses/src/lib.rs
+++ b/pallas-addresses/src/lib.rs
@@ -1,13 +1,53 @@
-//! Interact with Cardano addresses of any type
+//! Encode and decode Cardano addresses of every kind.
 //!
-//! This module contains utilities to decode / encode Cardano addresses from /
-//! to different formats. The entry point to most of the methods is the
-//! [Address] enum, which holds the decoded values of either a Byron, Shelley or
-//! Stake address.
+//! Byron, Shelley payment, and stake addresses are all parsed through the same
+//! [`Address`] entry point: feed it a bech32 / base58 / hex string (or raw
+//! bytes), match on the variant, and inspect the network, payment credential,
+//! delegation, or pointer parts. Address shape follows
+//! [CIP-19](https://cips.cardano.org/cips/cip19/).
 //!
-//! For more information regarding Cardano addresses and their formats, please refer to [CIP-19](https://cips.cardano.org/cips/cip19/).
+//! # Usage
+//!
+//! ```
+//! use pallas_addresses::Address;
+//!
+//! let addr = Address::from_bech32(
+//!     "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3\
+//!      n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x",
+//! )?;
+//!
+//! match addr {
+//!     Address::Byron(b)   => println!("byron:   {}", b.to_base58()),
+//!     Address::Shelley(s) => println!("shelley: {} on {:?}", s.to_bech32()?, s.network()),
+//!     Address::Stake(s)   => println!("stake:   {}", s.to_bech32()?),
+//! }
+//! # Ok::<_, pallas_addresses::Error>(())
+//! ```
+//!
+//! # Overview
+//!
+//! - [`Address`] — top-level decoded form, dispatching to the three variants.
+//! - [`ByronAddress`], [`ShelleyAddress`], [`StakeAddress`] — per-kind
+//!   decoded representations.
+//! - [`ShelleyPaymentPart`], [`ShelleyDelegationPart`], [`StakePayload`],
+//!   [`Pointer`] — the structural pieces that make up a Shelley / stake
+//!   address.
+//! - [`Network`] — Mainnet / Testnet / `Other(u8)` discriminator parsed from
+//!   the address header.
+//! - [`byron`] submodule — Byron-specific structures and CBOR helpers.
+//! - [`varuint`] submodule — variable-length integer codec used by stake
+//!   pointers.
+//!
+//! # Usage as part of `pallas`
+//!
+//! When depending on the umbrella [`pallas`] crate, this crate is re-exported
+//! as `pallas::ledger::addresses`.
+//!
+//! [`pallas`]: https://crates.io/crates/pallas
 
+/// Byron-era addresses (base58, CBOR-encoded).
 pub mod byron;
+/// Variable-length unsigned integer codec used inside Shelley pointer addresses.
 pub mod varuint;
 
 use std::{fmt::Display, io::Cursor, str::FromStr};
@@ -15,57 +55,78 @@ use std::{fmt::Display, io::Cursor, str::FromStr};
 use pallas_crypto::hash::Hash;
 use thiserror::Error;
 
+/// Errors produced while decoding or encoding a Cardano address.
 #[derive(Error, Debug)]
 pub enum Error {
+    /// Failed to decode a bech32 string.
     #[error("error decoding from bech32 {0}")]
     BadBech32(bech32::DecodeError),
 
+    /// Failed to decode a base58 string.
     #[error("error decoding base58 value")]
     BadBase58(base58::FromBase58Error),
 
+    /// Failed to decode a hexadecimal string.
     #[error("error decoding hex value")]
     BadHex,
 
+    /// The input string does not match any recognized address format.
     #[error("unknown or bad string format for address {0}")]
     UnknownStringFormat(String),
 
+    /// The address byte sequence is empty and has no header byte.
     #[error("address header not found")]
     MissingHeader,
 
+    /// The address header byte does not match any defined Cardano address type.
     #[error("address header is invalid {0:08b}")]
     InvalidHeader(u8),
 
+    /// The requested operation does not apply to Byron addresses.
     #[error("invalid operation for Byron address")]
     InvalidForByron,
 
+    /// The requested operation does not apply to this address content.
     #[error("invalid operation for address content")]
     InvalidForContent,
 
+    /// The Byron address payload is not valid CBOR.
     #[error("invalid CBOR for Byron address {0}")]
     InvalidByronCbor(pallas_codec::minicbor::decode::Error),
 
+    /// The network nibble in the header does not map to a known bech32 HRP.
     #[error("unkown hrp for network {0:08b}")]
     UnknownNetworkHrp(u8),
 
+    /// An embedded hash had an unexpected byte length.
     #[error("invalid hash size {0}")]
     InvalidHashSize(usize),
 
+    /// The total address byte length is shorter than required by its type.
     #[error("invalid address length {0}")]
     InvalidAddressLength(usize),
 
+    /// The pointer payload of a Shelley pointer address could not be parsed.
     #[error("invalid pointer data")]
     InvalidPointerData,
 
+    /// A variable-length uint inside a pointer address failed to decode.
     #[error("variable-length uint error: {0}")]
     VarUintError(varuint::Error),
 }
 
+/// Hash of a payment verification key (Blake2b-224).
 pub type PaymentKeyHash = Hash<28>;
+/// Hash of a stake verification key (Blake2b-224).
 pub type StakeKeyHash = Hash<28>;
+/// Hash of a script (Blake2b-224).
 pub type ScriptHash = Hash<28>;
 
+/// Absolute slot number on the Cardano chain.
 pub type Slot = u64;
+/// Index of a transaction within a block.
 pub type TxIdx = u64;
+/// Index of a certificate within a transaction.
 pub type CertIdx = u64;
 
 /// An on-chain pointer to a stake key
@@ -83,10 +144,12 @@ fn slice_to_hash(slice: &[u8]) -> Result<Hash<28>, Error> {
 }
 
 impl Pointer {
+    /// Build a pointer from its three components.
     pub fn new(slot: Slot, tx_idx: TxIdx, cert_idx: CertIdx) -> Self {
         Pointer(slot, tx_idx, cert_idx)
     }
 
+    /// Parse a pointer from its variable-length byte encoding.
     pub fn parse(bytes: &[u8]) -> Result<Self, Error> {
         let mut cursor = Cursor::new(bytes);
         let a = varuint::read(&mut cursor).map_err(Error::VarUintError)?;
@@ -96,6 +159,7 @@ impl Pointer {
         Ok(Pointer(a, b, c))
     }
 
+    /// Encode the pointer as its variable-length byte representation.
     pub fn to_vec(&self) -> Vec<u8> {
         let mut cursor = Cursor::new(vec![]);
         varuint::write(&mut cursor, self.0);
@@ -105,36 +169,43 @@ impl Pointer {
         cursor.into_inner()
     }
 
+    /// Slot number component of the pointer.
     pub fn slot(&self) -> u64 {
         self.0
     }
 
+    /// Transaction index component of the pointer.
     pub fn tx_idx(&self) -> u64 {
         self.1
     }
 
+    /// Certificate index component of the pointer.
     pub fn cert_idx(&self) -> u64 {
         self.2
     }
 }
 
-/// The payment part of a Shelley address
+/// The payment part of a Shelley address.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
 pub enum ShelleyPaymentPart {
+    /// Payment is controlled by a verification key with the given hash.
     Key(PaymentKeyHash),
+    /// Payment is controlled by a script with the given hash.
     Script(ScriptHash),
 }
 
 impl ShelleyPaymentPart {
+    /// Build a key-hash payment part.
     pub fn key_hash(hash: Hash<28>) -> Self {
         Self::Key(hash)
     }
 
+    /// Build a script-hash payment part.
     pub fn script_hash(hash: Hash<28>) -> Self {
         Self::Script(hash)
     }
 
-    /// Get a reference to the inner hash of this address part
+    /// Get a reference to the inner hash of this address part.
     pub fn as_hash(&self) -> &Hash<28> {
         match self {
             Self::Key(x) => x,
@@ -142,7 +213,7 @@ impl ShelleyPaymentPart {
         }
     }
 
-    /// Encodes this address as a sequence of bytes
+    /// Encodes this address part as its 28 raw bytes.
     pub fn to_vec(&self) -> Vec<u8> {
         match self {
             Self::Key(x) => x.to_vec(),
@@ -150,11 +221,13 @@ impl ShelleyPaymentPart {
         }
     }
 
+    /// Encode the payment part as a lowercase hexadecimal string.
     pub fn to_hex(&self) -> String {
         let bytes = self.to_vec();
         hex::encode(bytes)
     }
 
+    /// Encode the payment part as a bech32 string under its CIP-5 HRP.
     pub fn to_bech32(&self) -> String {
         let hrp = match self {
             Self::Key(_) => "addr_vkh",
@@ -164,36 +237,43 @@ impl ShelleyPaymentPart {
         encode_bech32(&bytes, hrp)
     }
 
-    /// Indicates if this is the hash of a script
+    /// Indicates if this is the hash of a script.
     pub fn is_script(&self) -> bool {
         matches!(self, Self::Script(_))
     }
 }
 
-/// The delegation part of a Shelley address
+/// The delegation part of a Shelley address.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
 pub enum ShelleyDelegationPart {
+    /// Delegation is controlled by a stake key with the given hash.
     Key(StakeKeyHash),
+    /// Delegation is controlled by a script with the given hash.
     Script(ScriptHash),
+    /// Delegation is identified by a pointer to a stake-key registration.
     Pointer(Pointer),
+    /// Address has no delegation part (enterprise address).
     Null,
 }
 
 impl ShelleyDelegationPart {
+    /// Build a key-hash delegation part.
     pub fn key_hash(hash: Hash<28>) -> Self {
         Self::Key(hash)
     }
 
+    /// Build a script-hash delegation part.
     pub fn script_hash(hash: Hash<28>) -> Self {
         Self::Script(hash)
     }
 
+    /// Build a pointer delegation part by parsing its variable-length encoding.
     pub fn from_pointer(bytes: &[u8]) -> Result<Self, Error> {
         let pointer = Pointer::parse(bytes)?;
         Ok(Self::Pointer(pointer))
     }
 
-    /// Get a reference to the inner hash of this address part
+    /// Get a reference to the inner hash of this address part, if it carries one.
     pub fn as_hash(&self) -> Option<&Hash<28>> {
         match self {
             Self::Key(x) => Some(x),
@@ -203,6 +283,7 @@ impl ShelleyDelegationPart {
         }
     }
 
+    /// Encode the delegation part as its raw byte representation.
     pub fn to_vec(&self) -> Vec<u8> {
         match self {
             Self::Key(x) => x.to_vec(),
@@ -212,11 +293,13 @@ impl ShelleyDelegationPart {
         }
     }
 
+    /// Encode the delegation part as a lowercase hexadecimal string.
     pub fn to_hex(&self) -> String {
         let bytes = self.to_vec();
         hex::encode(bytes)
     }
 
+    /// Encode the delegation part as a bech32 string under its CIP-5 HRP.
     pub fn to_bech32(&self) -> Result<String, Error> {
         let hrp = match self {
             Self::Key(_) => "stake_vkh",
@@ -228,6 +311,7 @@ impl ShelleyDelegationPart {
         Ok(encode_bech32(&bytes, hrp))
     }
 
+    /// Indicates if this is the hash of a script.
     pub fn is_script(&self) -> bool {
         matches!(self, ShelleyDelegationPart::Script(_))
     }
@@ -242,11 +326,12 @@ impl StakePayload {
         slice_to_hash(bytes).map(StakePayload::Script)
     }
 
+    /// Indicates if this is the hash of a script.
     pub fn is_script(&self) -> bool {
         matches!(self, StakePayload::Script(_))
     }
 
-    /// Get a reference to the inner hash of this address part
+    /// Get a reference to the inner hash of this address part.
     pub fn as_hash(&self) -> &Hash<28> {
         match self {
             StakePayload::Stake(x) => x,
@@ -255,11 +340,14 @@ impl StakePayload {
     }
 }
 
-/// The network tag of an address
+/// The network tag of an address.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
 pub enum Network {
+    /// The Cardano testnet (network id 0).
     Testnet,
+    /// The Cardano mainnet (network id 1).
     Mainnet,
+    /// Any other network id (custom or unrecognized).
     Other(u8),
 }
 
@@ -273,28 +361,33 @@ impl From<u8> for Network {
     }
 }
 
-/// A decoded Shelley address
+/// A decoded Shelley address.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
 pub struct ShelleyAddress(Network, ShelleyPaymentPart, ShelleyDelegationPart);
 
-/// The payload of a Stake address
+/// The payload of a stake address.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
 pub enum StakePayload {
+    /// Stake credential controlled by a verification-key hash.
     Stake(StakeKeyHash),
+    /// Stake credential controlled by a script hash.
     Script(ScriptHash),
 }
 
-/// A decoded Stake address
+/// A decoded stake address.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
 pub struct StakeAddress(Network, StakePayload);
 
 pub use byron::ByronAddress;
 
-/// A decoded Cardano address of any type
+/// A decoded Cardano address of any type.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
 pub enum Address {
+    /// A Byron-era base58/CBOR address.
     Byron(ByronAddress),
+    /// A Shelley-era payment address.
     Shelley(ShelleyAddress),
+    /// A stake address.
     Stake(StakeAddress),
 }
 
@@ -429,10 +522,12 @@ fn bech32_to_address(bech32: &str) -> Result<Address, Error> {
 }
 
 impl Network {
+    /// True if this is the Cardano mainnet.
     pub fn is_mainnet(&self) -> bool {
         matches!(self, Network::Mainnet)
     }
 
+    /// Numeric network id encoded in the address header.
     pub fn value(&self) -> u8 {
         match self {
             Network::Testnet => 0,
@@ -443,6 +538,7 @@ impl Network {
 }
 
 impl ShelleyAddress {
+    /// Build a Shelley address from its network, payment, and delegation parts.
     pub fn new(
         network: Network,
         payment: ShelleyPaymentPart,
@@ -451,12 +547,12 @@ impl ShelleyAddress {
         Self(network, payment, delegation)
     }
 
-    /// Gets the network assoaciated with this address
+    /// Gets the network associated with this address.
     pub fn network(&self) -> Network {
         self.0
     }
 
-    /// Gets a numeric id describing the type of the address
+    /// Gets a numeric id describing the type of the address.
     pub fn typeid(&self) -> u8 {
         match (&self.1, &self.2) {
             (ShelleyPaymentPart::Key(_), ShelleyDelegationPart::Key(_)) => 0b0000,
@@ -470,6 +566,7 @@ impl ShelleyAddress {
         }
     }
 
+    /// Combine the type id and network nibbles into the address header byte.
     pub fn to_header(&self) -> u8 {
         let type_id = self.typeid();
         let type_id = type_id << 4;
@@ -478,15 +575,17 @@ impl ShelleyAddress {
         type_id | network
     }
 
+    /// Get a reference to the payment part of this address.
     pub fn payment(&self) -> &ShelleyPaymentPart {
         &self.1
     }
 
+    /// Get a reference to the delegation part of this address.
     pub fn delegation(&self) -> &ShelleyDelegationPart {
         &self.2
     }
 
-    /// Gets the bech32 human-readable-part for this address
+    /// Gets the bech32 human-readable-part for this address.
     pub fn hrp(&self) -> Result<&'static str, Error> {
         match &self.0 {
             Network::Testnet => Ok("addr_test"),
@@ -495,6 +594,7 @@ impl ShelleyAddress {
         }
     }
 
+    /// Encode the address as its raw byte representation (header + payload).
     pub fn to_vec(&self) -> Vec<u8> {
         let header = self.to_header();
         let payment = self.1.to_vec();
@@ -503,18 +603,20 @@ impl ShelleyAddress {
         [&[header], payment.as_slice(), delegation.as_slice()].concat()
     }
 
+    /// Encode the address as a lowercase hexadecimal string.
     pub fn to_hex(&self) -> String {
         let bytes = self.to_vec();
         hex::encode(bytes)
     }
 
+    /// Encode the address as a bech32 string under its network HRP.
     pub fn to_bech32(&self) -> Result<String, Error> {
         let hrp = self.hrp()?;
         let bytes = self.to_vec();
         Ok(encode_bech32(&bytes, hrp))
     }
 
-    /// Indicates if either the payment or delegation part is a script
+    /// Indicates if either the payment or delegation part is a script.
     pub fn has_script(&self) -> bool {
         self.payment().is_script() || self.delegation().is_script()
     }
@@ -544,16 +646,17 @@ impl AsRef<[u8]> for StakePayload {
 }
 
 impl StakeAddress {
+    /// Build a stake address from its network and payload.
     pub fn new(network: Network, payload: StakePayload) -> Self {
         Self(network, payload)
     }
 
-    /// Gets the network assoaciated with this address
+    /// Gets the network associated with this address.
     pub fn network(&self) -> Network {
         self.0
     }
 
-    /// Gets a numeric id describing the type of the address
+    /// Gets a numeric id describing the type of the address.
     pub fn typeid(&self) -> u8 {
         match &self.1 {
             StakePayload::Stake(_) => 0b1110,
@@ -561,7 +664,7 @@ impl StakeAddress {
         }
     }
 
-    /// Builds the header for this address
+    /// Builds the header byte for this address.
     pub fn to_header(&self) -> u8 {
         let type_id = self.typeid();
         let type_id = type_id << 4;
@@ -570,12 +673,12 @@ impl StakeAddress {
         type_id | network
     }
 
-    /// Gets the payload of this address
+    /// Gets the payload of this address.
     pub fn payload(&self) -> &StakePayload {
         &self.1
     }
 
-    /// Gets the bech32 human-readable-part for this address
+    /// Gets the bech32 human-readable-part for this address.
     pub fn hrp(&self) -> Result<&'static str, Error> {
         match &self.0 {
             Network::Testnet => Ok("stake_test"),
@@ -584,23 +687,27 @@ impl StakeAddress {
         }
     }
 
+    /// Encode the address as its raw byte representation (header + payload).
     pub fn to_vec(&self) -> Vec<u8> {
         let header = self.to_header();
 
         [&[header], self.1.as_ref()].concat()
     }
 
+    /// Encode the address as a lowercase hexadecimal string.
     pub fn to_hex(&self) -> String {
         let bytes = self.to_vec();
         hex::encode(bytes)
     }
 
+    /// Encode the address as a bech32 string under its network HRP.
     pub fn to_bech32(&self) -> Result<String, Error> {
         let hrp = self.hrp()?;
         let bytes = self.to_vec();
         Ok(encode_bech32(&bytes, hrp))
     }
 
+    /// Indicates if this stake address is controlled by a script.
     pub fn is_script(&self) -> bool {
         self.payload().is_script()
     }
@@ -621,12 +728,12 @@ impl Address {
         bech32_to_address(bech32)
     }
 
-    // Tries to decode the raw bytes of an address
+    /// Tries to decode the raw bytes of an address.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         bytes_to_address(bytes)
     }
 
-    // Tries to parse a hex value into an Address
+    /// Tries to parse a hex value into an Address.
     pub fn from_hex(bytes: &str) -> Result<Self, Error> {
         let bytes = hex::decode(bytes).map_err(|_| Error::BadHex)?;
         bytes_to_address(&bytes)
@@ -676,6 +783,7 @@ impl Address {
         }
     }
 
+    /// Encode the address as its raw byte representation.
     pub fn to_vec(&self) -> Vec<u8> {
         match self {
             Address::Byron(x) => x.to_vec(),
@@ -684,6 +792,7 @@ impl Address {
         }
     }
 
+    /// Encode the address as a lowercase hexadecimal string.
     pub fn to_hex(&self) -> String {
         match self {
             Address::Byron(x) => x.to_hex(),

--- a/pallas-bech32/src/lib.rs
+++ b/pallas-bech32/src/lib.rs
@@ -1,3 +1,37 @@
-pub mod cip14;
-pub mod cip5;
+//! Bech32 conventions for Cardano.
+//!
+//! Two CIP-defined surfaces:
+//!
+//! - [CIP-5] — human-readable prefixes for keys, hashes, and addresses
+//!   (`addr`, `stake`, `pool`, `vrf_vk`, …).
+//! - [CIP-14] — Blake2b-160 asset fingerprints (`asset1…`) for
+//!   `(policy id, asset name)` pairs.
+//!
+//! [CIP-5]: https://cips.cardano.org/cips/cip5/
+//! [CIP-14]: https://cips.cardano.org/cips/cip14/
+//!
+//! # Usage
+//!
+//! ```
+//! use pallas_bech32::cip14::AssetFingerprint;
+//!
+//! let fp = AssetFingerprint::from_parts(
+//!     "7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373",
+//!     "",
+//! )?;
+//!
+//! assert_eq!(fp.finger_print()?, "asset1rjklcrnsdzqp65wjgrg55sy9723kw09mlgvlc3");
+//! # Ok::<_, Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! # Overview
+//!
+//! - [`cip5`] — `KEYS`, `HASHES`, and `MISCELLANEOUS` constants holding the
+//!   bech32 HRPs assigned by CIP-5.
+//! - [`cip14`] — [`cip14::AssetFingerprint`] builds and prints the
+//!   `asset1…` fingerprint for a `(policy id, asset name)` pair.
 
+/// CIP-14 asset fingerprints.
+pub mod cip14;
+/// CIP-5 bech32 prefix constants.
+pub mod cip5;

--- a/pallas-codec/src/lib.rs
+++ b/pallas-codec/src/lib.rs
@@ -1,16 +1,78 @@
-/// Flat encoding/decoding for Plutus Core
+//! The encoding foundation the rest of the Pallas workspace builds on.
+//!
+//! Provides [`minicbor`] for CBOR (re-exported as-is) and a Rust port of the
+//! Plutus Core [flat] format. Most users won't depend on this crate directly
+//! — they'll get its types transitively through `pallas-primitives`,
+//! `pallas-traverse`, `pallas-txbuilder`, and so on. Reach for it when you
+//! need to define your own minicbor-encoded type, or when you need the
+//! round-trip helpers ([`utils::KeepRaw`], [`utils::Nullable`],
+//! [`utils::Set`], …) used by the higher-level era types.
+//!
+//! [flat]: https://github.com/Quid2/flat
+//!
+//! # Usage
+//!
+//! ```
+//! use pallas_codec::minicbor;
+//!
+//! #[derive(minicbor::Encode, minicbor::Decode, Debug, PartialEq)]
+//! struct Pair(#[n(0)] u64, #[n(1)] String);
+//!
+//! let bytes = minicbor::to_vec(Pair(1, "hi".into()))?;
+//! let back: Pair = minicbor::decode(&bytes)?;
+//! assert_eq!(back, Pair(1, "hi".into()));
+//! # Ok::<_, Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! # Overview
+//!
+//! - [`minicbor`] — re-exported as-is; this is the workspace's single source
+//!   of truth for CBOR.
+//! - [`flat`] — Rust port of the Haskell [flat] reference implementation,
+//!   used for Plutus Core scripts.
+//! - [`utils`] — round-trip-friendly helper types ([`utils::KeepRaw`],
+//!   [`utils::KeyValuePairs`], [`utils::MaybeIndefArray`],
+//!   [`utils::NonEmptySet`], [`utils::Nullable`], [`utils::PositiveCoin`],
+//!   …) reused by the higher-level era types.
+//! - [`Fragment`] trait — blanket-implemented for any type that is both
+//!   [`minicbor::Encode`] and [`minicbor::Decode`]; used as a bound where
+//!   the workspace wants "any CBOR-roundtrippable type".
+//! - [`codec_by_datatype!`] macro — derives a tag-free CBOR codec for enums
+//!   whose variants are distinguished by their data-type rather than a
+//!   discriminant.
+//!
+//! # Usage as part of `pallas`
+//!
+//! When depending on the umbrella [`pallas`] crate, this crate is re-exported
+//! as `pallas::codec`.
+//!
+//! [`pallas`]: https://crates.io/crates/pallas
+
+/// Flat encoding/decoding for Plutus Core.
 pub mod flat;
 
-/// Shared re-export of minicbor lib across all Pallas
+/// Shared re-export of `minicbor` across all Pallas crates.
 pub use minicbor;
 
-/// Round-trip friendly common helper structs
+/// Round-trip friendly common helper structs (`Bytes`, `Nullable`, `Set`, …).
 pub mod utils;
 
+/// Blanket trait for any type that can be CBOR-encoded and decoded with
+/// [`minicbor`]. Implemented automatically for every such type.
 pub trait Fragment: Sized + for<'b> minicbor::Decode<'b, ()> + minicbor::Encode<()> {}
 
 impl<T> Fragment for T where T: for<'b> minicbor::Decode<'b, ()> + minicbor::Encode<()> + Sized {}
 
+/// Derive a `minicbor` [`Decode`]/[`Encode`] implementation for an enum by
+/// dispatching on the incoming CBOR datatype.
+///
+/// Useful for sum types whose variants carry distinct CBOR shapes (e.g. one
+/// variant is an array, another is a map). The macro maps each CBOR datatype
+/// to a single-payload variant, and an `Array` fallback handles a many-field
+/// variant.
+///
+/// [`Decode`]: minicbor::Decode
+/// [`Encode`]: minicbor::Encode
 #[macro_export]
 macro_rules! codec_by_datatype {
     (

--- a/pallas-configs/src/lib.rs
+++ b/pallas-configs/src/lib.rs
@@ -1,7 +1,41 @@
-//! Genesis data structs and utilities
+//! Strongly typed parsers for Cardano genesis files and protocol parameters.
+//!
+//! One module per era exposes the canonical genesis shape and a `from_file`
+//! helper, so tools that need to reason about staking metadata, cost models,
+//! or other configuration data don't have to hand-roll JSON shapes.
+//!
+//! # Usage
+//!
+//! ```no_run
+//! use pallas_configs::shelley;
+//!
+//! let config = shelley::from_file(std::path::Path::new("genesis.json"))?;
+//!
+//! if let Some(staking) = config.staking {
+//!     if let Some(pools) = staking.pools {
+//!         for (pool_id, pool) in pools {
+//!             println!("pool {pool_id} has pledge {}", pool.pledge);
+//!         }
+//!     }
+//! }
+//! # Ok::<_, std::io::Error>(())
+//! ```
+//!
+//! # Overview
+//!
+//! - [`byron`], [`shelley`], [`alonzo`], [`conway`] — one module per era,
+//!   each exposing a `GenesisFile` (or equivalent) struct and a `from_file`
+//!   helper.
+//! - [`cost_models`] — typed views over Plutus cost-model tables, shared
+//!   across eras.
 
+/// Alonzo-era genesis parameters (cost models, prices, max collateral).
 pub mod alonzo;
+/// Byron-era genesis configuration.
 pub mod byron;
+/// Conway-era genesis parameters (governance, committees, hard-fork init).
 pub mod conway;
+/// Built-in Plutus V1/V2/V3 cost-model snapshots.
 pub mod cost_models;
+/// Shelley-era genesis configuration (network start, system start, k, …).
 pub mod shelley;

--- a/pallas-crypto/src/hash/mod.rs
+++ b/pallas-crypto/src/hash/mod.rs
@@ -2,10 +2,10 @@
 //!
 //! we expose two helper objects:
 //!
-//! * [`Hasher`] to help streaming objects or bytes into a hasher and computing
+//! * `Hasher` to help streaming objects or bytes into a hasher and computing
 //!   a hash without allocating extra memory due to the required **CBOR**
 //!   encoding for everything by the cardano protocol
-//! * [`struct@Hash`] a conveniently strongly typed byte array
+//! * `Hash` a conveniently strongly typed byte array
 //!
 //! The algorithm exposed here is `Blake2b`. We currently support two
 //! digest size for the algorithm: 224 bits and 256 bits. They are the

--- a/pallas-crypto/src/lib.rs
+++ b/pallas-crypto/src/lib.rs
@@ -1,7 +1,69 @@
+//! Cryptographic primitives required to participate in the Cardano protocol.
+//!
+//! Blake2b hashing, Ed25519 signing (regular and BIP32-extended), VRF, KES
+//! forward-secure signatures, and the nonce evolution used by the Ouroboros
+//! leader-selection schedule. Algorithm choices follow the ones made by the
+//! Cardano protocol.
+//!
+//! # Usage
+//!
+//! ```
+//! use pallas_crypto::hash::Hasher;
+//!
+//! let mut h = Hasher::<256>::new();
+//! h.input(b"hello");
+//! let digest = h.finalize();
+//! println!("blake2b-256 = {}", digest);
+//! ```
+//!
+//! # Overview
+//!
+//! - [`hash`] — `Hash<N>` and `Hasher<N>` over Blake2b. The const generic is
+//!   in bits, so `Hasher::<224>` and `Hasher::<256>` cover the common
+//!   Cardano digest sizes.
+//! - [`key::ed25519`] — regular and extended Ed25519 key pairs, signing and
+//!   verification.
+//! - `kes` — KES (Key Evolving Signature) primitives used by block
+//!   producers (feature `kes`).
+//! - [`nonce`] — epoch / chain-nonce evolution helpers.
+//! - [`memsec`] — secure-memory utilities used to wipe key material.
+//!
+//! # Status
+//!
+//! - [x] Blake2b 256
+//! - [x] Blake2b 224
+//! - [x] Ed25519 asymmetric key pair and EdDSA
+//! - [x] Ed25519 Extended asymmetric key pair
+//! - [ ] BIP32-Ed25519 key derivation
+//! - [ ] BIP39 mnemonics
+//! - [x] VRF
+//! - [x] KES
+//! - [ ] SECP256k1
+//! - [x] Nonce calculations
+//!
+//! # Feature flags
+//!
+//! - `kes` — pulls in the `kes` module and its KES (Key Evolving
+//!   Signature) primitives.
+//! - `relaxed` — relax some validation checks; useful when round-tripping
+//!   non-canonical historical artifacts.
+//!
+//! # Usage as part of `pallas`
+//!
+//! When depending on the umbrella [`pallas`] crate, this crate is re-exported
+//! as `pallas::crypto`.
+//!
+//! [`pallas`]: https://crates.io/crates/pallas
+
 extern crate core;
 
+/// Fixed-size byte hashes used throughout Cardano (Blake2b-224, Blake2b-256, …).
 pub mod hash;
+/// KES (Key Evolving Signature) primitives used by block producers.
 pub mod kes;
+/// Ed25519 keys and signatures used by wallets, witnesses, and operational certificates.
 pub mod key;
+/// Secure-memory utilities used to wipe key material.
 pub mod memsec;
+/// Nonce derivation utilities used by the Ouroboros leader-selection schedule.
 pub mod nonce;

--- a/pallas-hardano/src/lib.rs
+++ b/pallas-hardano/src/lib.rs
@@ -1,2 +1,42 @@
+//! Interoperability with implementation-specific artifacts of the Haskell
+//! Cardano node.
+//!
+//! Today the main job is reading the node's immutable on-disk chunks (the
+//! `immutable/` directory of a synced node), so a Rust process can iterate
+//! the chain without re-syncing. A small [`display`] module also covers the
+//! textual representations the upstream node uses for human-facing output.
+//!
+//! # Usage
+//!
+//! ```no_run
+//! use std::path::Path;
+//! use pallas_hardano::storage::immutable;
+//!
+//! for block in immutable::read_blocks(Path::new("/var/cardano/data/immutable"))? {
+//!     let _bytes = block?;
+//!     // hand `_bytes` to pallas-traverse / pallas-primitives for typed access
+//! }
+//! # Ok::<_, Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! # Overview
+//!
+//! - [`storage::immutable`] — readers over the node's chunk / primary /
+//!   secondary index files. Top-level entry points:
+//!   [`storage::immutable::read_blocks`],
+//!   [`storage::immutable::read_blocks_from_point`],
+//!   [`storage::immutable::get_tip`].
+//! - [`display`] — pretty-printing helpers for the structures above.
+//!
+//! # Usage as part of `pallas`
+//!
+//! When depending on the umbrella [`pallas`] crate (with the `hardano`
+//! feature), this crate is re-exported as
+//! `pallas::interop::hardano::storage`.
+//!
+//! [`pallas`]: https://crates.io/crates/pallas
+
+/// Pretty-printing helpers for the structures exposed by [`storage`].
 pub mod display;
+/// Readers over the Haskell Cardano node's on-disk chain database.
 pub mod storage;

--- a/pallas-math/src/lib.rs
+++ b/pallas-math/src/lib.rs
@@ -1,2 +1,42 @@
+//! Fixed-precision arithmetic for the parts of the Cardano protocol that
+//! need `ln`, `exp`, and `pow` to high precision.
+//!
+//! The Praos VRF leader-check formula and the reward / pool-saturation
+//! calculations both require deterministic transcendental math; this crate
+//! supplies it. Backed by [`dashu`] for the underlying big-integer
+//! representation.
+//!
+//! [`dashu`]: https://docs.rs/dashu
+//!
+//! # Usage
+//!
+//! ```
+//! use pallas_math::math::{FixedDecimal, FixedPrecision};
+//!
+//! let x = FixedDecimal::from_str("2", 34)?;   // 2.0 with 34 fractional digits
+//! let y = x.ln();                             // ≈ 0.6931471805599453…
+//! println!("ln(2) ≈ {y}");
+//! # Ok::<_, pallas_math::math::Error>(())
+//! ```
+//!
+//! # Overview
+//!
+//! - [`math`] — the public surface: [`math::FixedDecimal`] (the
+//!   fixed-precision number type) and the [`math::FixedPrecision`] trait it
+//!   implements (`new`, `from_str`, `precision`, `exp`, `ln`, `pow`,
+//!   `exp_cmp`, `round` / `floor` / `ceil` / `trunc`).
+//! - [`math_dashu`] — `dashu`-backed implementation that
+//!   [`math::FixedDecimal`] aliases.
+//! - [`math::DEFAULT_PRECISION`] (34), and the lazy [`math::ZERO`],
+//!   [`math::ONE`], [`math::MINUS_ONE`] constants for convenience.
+//!
+//! # Usage as part of `pallas`
+//!
+//! `pallas-math` is not currently re-exported from the umbrella `pallas`
+//! crate; depend on it directly.
+
+/// Public surface: the [`math::FixedDecimal`] type, the [`math::FixedPrecision`] trait,
+/// and the shared constants.
 pub mod math;
+/// `dashu`-backed implementation of [`math::FixedPrecision`].
 pub mod math_dashu;

--- a/pallas-network/src/facades.rs
+++ b/pallas-network/src/facades.rs
@@ -23,45 +23,60 @@ use crate::miniprotocols::{
 
 use crate::multiplexer::{self, Bearer, RunningPlexer};
 
+/// Errors produced by the high-level peer/node facades.
 #[derive(Debug, Error)]
 pub enum Error {
+    /// Underlying multiplexer failure.
     #[error("error in multiplexer")]
     PlexerFailure(#[source] multiplexer::Error),
 
+    /// Failed to open or accept the bearer connection.
     #[error("error connecting bearer")]
     ConnectFailure(#[source] tokio::io::Error),
 
+    /// Handshake mini-protocol error.
     #[error("handshake protocol error")]
     HandshakeProtocol(handshake::Error),
 
+    /// Keep-alive loop reported a client-side error.
     #[error("keepalive client loop error")]
     KeepAliveClientLoop(keepalive::ClientError),
 
+    /// Keep-alive loop reported a server-side error.
     #[error("keepalive server loop error")]
     KeepAliveServerLoop(keepalive::ServerError),
 
+    /// The remote rejected every version offered in the handshake.
     #[error("handshake version not accepted")]
     IncompatibleVersion,
 }
 
+/// Default interval between keep-alive pings.
 pub const DEFAULT_KEEP_ALIVE_INTERVAL_SEC: u64 = 20;
 
+/// Handle to a spawned keep-alive loop.
 pub type KeepAliveHandle = tokio::task::JoinHandle<Result<(), Error>>;
 
+/// A keep-alive loop on either side of the connection.
 pub enum KeepAliveLoop {
+    /// Client-side loop: ping the peer at the given interval.
     Client(keepalive::Client, Duration),
+    /// Server-side loop: respond to pings from the peer.
     Server(keepalive::Server),
 }
 
 impl KeepAliveLoop {
+    /// Build a client-side loop that pings every `interval`.
     pub fn client(client: keepalive::Client, interval: Duration) -> Self {
         Self::Client(client, interval)
     }
 
+    /// Build a server-side loop that responds to incoming pings.
     pub fn server(server: keepalive::Server) -> Self {
         Self::Server(server)
     }
 
+    /// Drive a client-side keep-alive loop until it errors.
     pub async fn run_client(
         mut client: keepalive::Client,
         interval: Duration,
@@ -79,6 +94,7 @@ impl KeepAliveLoop {
         }
     }
 
+    /// Drive a server-side keep-alive loop until it errors.
     pub async fn run_server(mut server: keepalive::Server) -> Result<(), Error> {
         loop {
             debug!("waiting keepalive request");
@@ -90,6 +106,7 @@ impl KeepAliveLoop {
         }
     }
 
+    /// Spawn the loop on the current Tokio runtime.
     pub fn spawn(self) -> KeepAliveHandle {
         match self {
             KeepAliveLoop::Client(client, interval) => {
@@ -100,17 +117,25 @@ impl KeepAliveLoop {
     }
 }
 
-/// Client of N2N Ouroboros
+/// Node-to-node Ouroboros client. Bundles the chain-sync, block-fetch,
+/// tx-submission, peer-sharing, and keep-alive protocols over a single bearer.
 pub struct PeerClient {
+    /// Underlying running multiplexer.
     pub plexer: RunningPlexer,
+    /// Handle to the spawned keep-alive task.
     pub keepalive: KeepAliveHandle,
+    /// Chain-sync client (node-to-node).
     pub chainsync: chainsync::N2NClient,
+    /// Block-fetch client.
     pub blockfetch: blockfetch::Client,
+    /// Tx-submission client.
     pub txsubmission: txsubmission::Client,
+    /// Peer-sharing client.
     pub peersharing: peersharing::Client,
 }
 
 impl PeerClient {
+    /// Connect to `addr` and perform the N2N handshake using the given network magic.
     pub async fn connect(addr: impl ToSocketAddrs, magic: u64) -> Result<Self, Error> {
         let bearer = Bearer::connect_tcp(addr)
             .await
@@ -161,6 +186,8 @@ impl PeerClient {
         Ok(client)
     }
 
+    /// Connect, issue a query-mode handshake, and return the peer's advertised
+    /// version table without keeping the connection alive.
     pub async fn handshake_query(
         addr: impl ToSocketAddrs,
         magic: u64,
@@ -201,10 +228,12 @@ impl PeerClient {
         Ok(version_table)
     }
 
+    /// Get mutable access to the chain-sync client.
     pub fn chainsync(&mut self) -> &mut chainsync::N2NClient {
         &mut self.chainsync
     }
 
+    /// Run an operation against the chain-sync client on a background task.
     pub async fn with_chainsync<T, O, Fut>(&mut self, op: T) -> tokio::task::JoinHandle<O>
     where
         T: FnOnce(&mut chainsync::N2NClient) -> Fut,
@@ -214,37 +243,50 @@ impl PeerClient {
         tokio::spawn(op(&mut self.chainsync))
     }
 
+    /// Get mutable access to the block-fetch client.
     pub fn blockfetch(&mut self) -> &mut blockfetch::Client {
         &mut self.blockfetch
     }
 
+    /// Get mutable access to the tx-submission client.
     pub fn txsubmission(&mut self) -> &mut txsubmission::Client {
         &mut self.txsubmission
     }
 
+    /// Get mutable access to the peer-sharing client.
     pub fn peersharing(&mut self) -> &mut peersharing::Client {
         &mut self.peersharing
     }
 
+    /// Tear down the underlying multiplexer and abort all spawned tasks.
     pub async fn abort(self) {
         self.plexer.abort().await
     }
 }
 
-/// Server of N2N Ouroboros
+/// Node-to-node Ouroboros server. Accepts a peer connection and exposes the
+/// server side of each mini-protocol carried over the bearer.
 pub struct PeerServer {
+    /// Underlying running multiplexer.
     pub plexer: RunningPlexer,
+    /// Handshake server.
     pub handshake: handshake::N2NServer,
+    /// Chain-sync server.
     pub chainsync: chainsync::N2NServer,
+    /// Block-fetch server.
     pub blockfetch: blockfetch::Server,
+    /// Tx-submission server.
     pub txsubmission: txsubmission::Server,
+    /// Keep-alive server.
     pub keepalive: keepalive::Server,
+    /// Peer-sharing server.
     pub peersharing: peersharing::Server,
     accepted_address: Option<SocketAddr>,
     accepted_version: Option<(u64, n2n::VersionData)>,
 }
 
 impl PeerServer {
+    /// Build a server over an already-accepted bearer.
     pub fn new(bearer: Bearer) -> Self {
         let mut plexer = multiplexer::Plexer::new(bearer);
 
@@ -277,6 +319,7 @@ impl PeerServer {
         }
     }
 
+    /// Accept the next connection from `listener` and complete the N2N handshake.
     pub async fn accept(listener: &TcpListener, magic: u64) -> Result<Self, Error> {
         let (bearer, address) = Bearer::accept_tcp(listener)
             .await
@@ -300,38 +343,47 @@ impl PeerServer {
         }
     }
 
+    /// Get mutable access to the handshake server.
     pub fn handshake(&mut self) -> &mut handshake::N2NServer {
         &mut self.handshake
     }
 
+    /// Get mutable access to the chain-sync server.
     pub fn chainsync(&mut self) -> &mut chainsync::N2NServer {
         &mut self.chainsync
     }
 
+    /// Get mutable access to the block-fetch server.
     pub fn blockfetch(&mut self) -> &mut blockfetch::Server {
         &mut self.blockfetch
     }
 
+    /// Get mutable access to the tx-submission server.
     pub fn txsubmission(&mut self) -> &mut txsubmission::Server {
         &mut self.txsubmission
     }
 
+    /// Get mutable access to the keep-alive server.
     pub fn keepalive(&mut self) -> &mut keepalive::Server {
         &mut self.keepalive
     }
 
+    /// Get mutable access to the peer-sharing server.
     pub fn peersharing(&mut self) -> &mut peersharing::Server {
         &mut self.peersharing
     }
 
+    /// Remote socket address of the accepted peer.
     pub fn accepted_address(&self) -> Option<&SocketAddr> {
         self.accepted_address.as_ref()
     }
 
+    /// Version number negotiated with the accepted peer plus its version data.
     pub fn accepted_version(&self) -> Option<&(u64, n2n::VersionData)> {
         self.accepted_version.as_ref()
     }
 
+    /// Tear down the underlying multiplexer.
     pub async fn abort(self) {
         self.plexer.abort().await
     }
@@ -348,6 +400,7 @@ pub struct NodeClient {
 }
 
 impl NodeClient {
+    /// Build a client over an already-opened bearer (does not perform the handshake).
     pub fn new(bearer: Bearer) -> Self {
         let mut plexer = multiplexer::Plexer::new(bearer);
 
@@ -369,6 +422,7 @@ impl NodeClient {
         }
     }
 
+    /// Connect to a Unix-domain node socket at `path` and perform the N2C handshake.
     #[cfg(unix)]
     pub async fn connect(path: impl AsRef<Path>, magic: u64) -> Result<Self, Error> {
         let bearer = Bearer::connect_unix(path)
@@ -393,6 +447,7 @@ impl NodeClient {
         Ok(client)
     }
 
+    /// Connect to a Windows named-pipe node socket and perform the N2C handshake.
     #[cfg(windows)]
     pub async fn connect(
         pipe_name: impl AsRef<std::ffi::OsStr>,
@@ -423,6 +478,8 @@ impl NodeClient {
         Ok(client)
     }
 
+    /// Issue a query-mode handshake over `bearer` and return the node's
+    /// advertised version table.
     #[cfg(unix)]
     pub async fn handshake_query(
         bearer: Bearer,
@@ -458,38 +515,49 @@ impl NodeClient {
         }
     }
 
+    /// Get mutable access to the handshake client.
     pub fn handshake(&mut self) -> &mut handshake::N2CClient {
         &mut self.handshake
     }
 
+    /// Get mutable access to the chain-sync client (N2C).
     pub fn chainsync(&mut self) -> &mut chainsync::N2CClient {
         &mut self.chainsync
     }
 
+    /// Get mutable access to the local-state-query client.
     pub fn statequery(&mut self) -> &mut localstate::Client {
         &mut self.statequery
     }
 
+    /// Get mutable access to the local-tx-submission client.
     pub fn submission(&mut self) -> &mut localtxsubmission::Client {
         &mut self.submission
     }
 
+    /// Get mutable access to the tx-monitor client.
     pub fn monitor(&mut self) -> &mut txmonitor::Client {
         &mut self.monitor
     }
 
+    /// Tear down the underlying multiplexer.
     pub async fn abort(self) {
         self.plexer.abort().await
     }
 }
 
-/// Server of N2C Ouroboros.
+/// Node-to-client Ouroboros server (the node side of a local connection).
 #[cfg(unix)]
 pub struct NodeServer {
+    /// Underlying running multiplexer.
     pub plexer: RunningPlexer,
+    /// Handshake server.
     pub handshake: handshake::N2CServer,
+    /// Chain-sync server (N2C).
     pub chainsync: chainsync::N2CServer,
+    /// Local-state-query server.
     pub statequery: localstate::Server,
+    /// Local-tx-submission server.
     pub localtxsubmission: localtxsubmission::Server,
     accepted_address: Option<UnixSocketAddr>,
     accpeted_version: Option<(VersionNumber, n2c::VersionData)>,
@@ -497,6 +565,7 @@ pub struct NodeServer {
 
 #[cfg(unix)]
 impl NodeServer {
+    /// Build a server over an already-accepted bearer.
     pub async fn new(bearer: Bearer) -> Self {
         let mut plexer = multiplexer::Plexer::new(bearer);
 
@@ -523,6 +592,7 @@ impl NodeServer {
         }
     }
 
+    /// Accept the next Unix-domain connection from `listener` and complete the N2C handshake.
     pub async fn accept(listener: &UnixListener, magic: u64) -> Result<Self, Error> {
         let (bearer, address) = Bearer::accept_unix(listener)
             .await
@@ -546,30 +616,37 @@ impl NodeServer {
         }
     }
 
+    /// Get mutable access to the handshake server.
     pub fn handshake(&mut self) -> &mut handshake::N2CServer {
         &mut self.handshake
     }
 
+    /// Get mutable access to the chain-sync server (N2C).
     pub fn chainsync(&mut self) -> &mut chainsync::N2CServer {
         &mut self.chainsync
     }
 
+    /// Get mutable access to the local-state-query server.
     pub fn statequery(&mut self) -> &mut localstate::Server {
         &mut self.statequery
     }
 
+    /// Get mutable access to the local-tx-submission server.
     pub fn localtxsubmission(&mut self) -> &mut localtxsubmission::Server {
         &mut self.localtxsubmission
     }
 
+    /// Remote address of the accepted local client.
     pub fn accepted_address(&self) -> Option<&UnixSocketAddr> {
         self.accepted_address.as_ref()
     }
 
+    /// Version negotiated with the accepted local client.
     pub fn accepted_version(&self) -> Option<&(u64, n2c::VersionData)> {
         self.accpeted_version.as_ref()
     }
 
+    /// Tear down the underlying multiplexer.
     pub async fn abort(self) {
         self.plexer.abort().await
     }
@@ -586,6 +663,7 @@ pub struct DmqClient {
 }
 
 impl DmqClient {
+    /// Build a DMQ client over an already-opened bearer.
     pub fn new(bearer: Bearer) -> Self {
         let mut plexer = multiplexer::Plexer::new(bearer);
 
@@ -603,6 +681,7 @@ impl DmqClient {
         }
     }
 
+    /// Connect to a DMQ node socket at `path` and perform the DMQ handshake.
     #[cfg(unix)]
     pub async fn connect(path: impl AsRef<Path>, magic: u64) -> Result<Self, Error> {
         let bearer = Bearer::connect_unix(path)
@@ -627,6 +706,7 @@ impl DmqClient {
         Ok(client)
     }
 
+    /// Connect to a DMQ node over a Windows named pipe and perform the handshake.
     #[cfg(windows)]
     pub async fn connect(
         pipe_name: impl AsRef<std::ffi::OsStr>,
@@ -657,6 +737,7 @@ impl DmqClient {
         Ok(client)
     }
 
+    /// Issue a DMQ query-mode handshake and return the node's advertised version table.
     #[cfg(unix)]
     pub async fn handshake_query(
         bearer: Bearer,
@@ -692,18 +773,22 @@ impl DmqClient {
         }
     }
 
+    /// Get mutable access to the handshake client.
     pub fn handshake(&mut self) -> &mut handshake::N2CClient {
         &mut self.handshake
     }
 
+    /// Get mutable access to the DMQ message-submission client.
     pub fn msg_submission(&mut self) -> &mut localmsgsubmission::Client {
         &mut self.msg_submission
     }
 
+    /// Get mutable access to the DMQ message-notification client.
     pub fn msg_notification(&mut self) -> &mut localmsgnotification::Client {
         &mut self.msg_notification
     }
 
+    /// Tear down the underlying multiplexer.
     pub async fn abort(self) {
         self.plexer.abort().await
     }
@@ -714,9 +799,13 @@ impl DmqClient {
 /// Described in [CIP-0137](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0137)
 #[cfg(unix)]
 pub struct DmqServer {
+    /// Underlying running multiplexer.
     pub plexer: RunningPlexer,
+    /// Handshake server.
     pub handshake: handshake::N2CServer,
+    /// DMQ message-notification server.
     pub msg_notification: localmsgnotification::Server,
+    /// DMQ message-submission server.
     pub msg_submission: localmsgsubmission::Server,
     accepted_address: Option<UnixSocketAddr>,
     accpeted_version: Option<(VersionNumber, n2c::VersionData)>,
@@ -724,6 +813,7 @@ pub struct DmqServer {
 
 #[cfg(unix)]
 impl DmqServer {
+    /// Build a DMQ server over an already-accepted bearer.
     pub async fn new(bearer: Bearer) -> Self {
         let mut plexer = multiplexer::Plexer::new(bearer);
 
@@ -747,6 +837,7 @@ impl DmqServer {
         }
     }
 
+    /// Accept the next DMQ connection from `listener` and complete the handshake.
     pub async fn accept(listener: &UnixListener, magic: u64) -> Result<Self, Error> {
         let (bearer, address) = Bearer::accept_unix(listener)
             .await
@@ -770,26 +861,32 @@ impl DmqServer {
         }
     }
 
+    /// Get mutable access to the handshake server.
     pub fn handshake(&mut self) -> &mut handshake::N2CServer {
         &mut self.handshake
     }
 
+    /// Get mutable access to the DMQ message-notification server.
     pub fn msg_notification(&mut self) -> &mut localmsgnotification::Server {
         &mut self.msg_notification
     }
 
+    /// Get mutable access to the DMQ message-submission server.
     pub fn msg_submission(&mut self) -> &mut localmsgsubmission::Server {
         &mut self.msg_submission
     }
 
+    /// Remote address of the accepted DMQ client.
     pub fn accepted_address(&self) -> Option<&UnixSocketAddr> {
         self.accepted_address.as_ref()
     }
 
+    /// Version negotiated with the accepted DMQ client.
     pub fn accepted_version(&self) -> Option<&(u64, n2c::VersionData)> {
         self.accpeted_version.as_ref()
     }
 
+    /// Tear down the underlying multiplexer.
     pub async fn abort(self) {
         self.plexer.abort().await
     }

--- a/pallas-network/src/lib.rs
+++ b/pallas-network/src/lib.rs
@@ -1,5 +1,61 @@
-//! Network stack compatible with the Ouroboros protocol
+//! Implementation of the Ouroboros networking stack.
+//!
+//! A multiplexer plus state-machines for each Cardano mini-protocol
+//! (handshake, chain-sync, block-fetch, tx-submission, local-state-query,
+//! …), exposed through ergonomic per-role facades. Async, tokio-backed.
+//!
+//! This is the original, single-connection / client-server-shaped stack. A
+//! peer-to-peer rewrite is in progress in `pallas-network2`; once that is
+//! mature it is intended to replace this crate.
+//!
+//! # Usage
+//!
+//! ```no_run
+//! use pallas_network::facades::PeerClient;
+//! use pallas_network::miniprotocols::MAINNET_MAGIC;
+//!
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut peer = PeerClient::connect(
+//!     "relays-new.cardano-mainnet.iohk.io:3001",
+//!     MAINNET_MAGIC,
+//! ).await?;
+//!
+//! let _chainsync  = peer.chainsync();   // &mut chainsync::N2NClient
+//! let _blockfetch = peer.blockfetch();  // &mut blockfetch::Client
+//! # Ok(()) }
+//! ```
+//!
+//! # Overview
+//!
+//! - [`facades`] — opinionated client / server bundles per role:
+//!   [`facades::PeerClient`] / [`facades::PeerServer`] (N2N),
+//!   [`facades::NodeClient`] / [`facades::NodeServer`] (N2C),
+//!   [`facades::DmqClient`] / [`facades::DmqServer`]. Each owns a
+//!   multiplexer and exposes the relevant mini-protocols through accessor
+//!   methods.
+//! - [`multiplexer`] — the segment-level transport:
+//!   [`multiplexer::RunningPlexer`], [`multiplexer::Bearer`].
+//! - [`miniprotocols`] — every Ouroboros mini-protocol: `handshake`,
+//!   `chainsync`, `blockfetch`, `txsubmission`, `localstate`,
+//!   `localtxsubmission`, `txmonitor`, `keepalive`, `peersharing`,
+//!   `localmsgnotification`, `localmsgsubmission`. Network-magic constants
+//!   ([`miniprotocols::MAINNET_MAGIC`], [`miniprotocols::TESTNET_MAGIC`],
+//!   [`miniprotocols::PREVIEW_MAGIC`], [`miniprotocols::PREPROD_MAGIC`],
+//!   [`miniprotocols::SANCHONET_MAGIC`]) are re-exported from this module.
+//!
+//! # Usage as part of `pallas`
+//!
+//! When depending on the umbrella [`pallas`] crate, this crate is re-exported
+//! as `pallas::network`.
+//!
+//! [`pallas`]: https://crates.io/crates/pallas
 
+/// High-level client/server facades (node-to-node, node-to-client).
 pub mod facades;
+/// State-machines for every Ouroboros mini-protocol (handshake, chain-sync,
+/// block-fetch, tx-submission, local-state-query, …) and the shared
+/// network-magic constants.
 pub mod miniprotocols;
+/// Segment-level transport that multiplexes mini-protocol traffic over a
+/// single bearer.
 pub mod multiplexer;

--- a/pallas-network/src/miniprotocols/blockfetch/client.rs
+++ b/pallas-network/src/miniprotocols/blockfetch/client.rs
@@ -6,31 +6,41 @@ use crate::multiplexer;
 
 use super::{Message, State};
 
+/// Errors produced by the block-fetch client agent.
 #[derive(Error, Debug)]
 pub enum ClientError {
+    /// Tried to receive while we hold agency.
     #[error("attempted to receive message while agency is ours")]
     AgencyIsOurs,
 
+    /// Tried to send while the peer holds agency.
     #[error("attempted to send message while agency is theirs")]
     AgencyIsTheirs,
 
+    /// Inbound message is not valid for the current state.
     #[error("inbound message is not valid for current state")]
     InvalidInbound,
 
+    /// Outbound message is not valid for the current state.
     #[error("outbound message is not valid for current state")]
     InvalidOutbound,
 
+    /// Server replied `NoBlocks` for the requested range.
     #[error("requested range doesn't contain any blocks")]
     NoBlocks,
 
+    /// Underlying multiplexer error.
     #[error("error while sending or receiving data through the multiplexer")]
     Plexer(multiplexer::Error),
 }
 
+/// Raw CBOR bytes of a block body.
 pub type Body = Vec<u8>;
 
+/// Inclusive `(start, end)` chain-point range.
 pub type Range = (Point, Point);
 
+/// `Some(())` if the server is about to stream blocks, `None` for empty ranges.
 pub type HasBlocks = Option<()>;
 
 /// Represents the client for the BlockFetch mini-protocol.
@@ -108,6 +118,7 @@ impl Client {
         }
     }
 
+    /// Low-level send.
     pub async fn send_message(&mut self, msg: &Message) -> Result<(), ClientError> {
         self.assert_agency_is_ours()?;
         self.assert_outbound_state(msg)?;
@@ -119,6 +130,7 @@ impl Client {
         Ok(())
     }
 
+    /// Low-level receive.
     pub async fn recv_message(&mut self) -> Result<Message, ClientError> {
         self.assert_agency_is_theirs()?;
         let msg = self.1.recv_full_msg().await.map_err(ClientError::Plexer)?;
@@ -127,6 +139,7 @@ impl Client {
         Ok(msg)
     }
 
+    /// Send a `RequestRange` for the inclusive `(start, end)` block range.
     pub async fn send_request_range(&mut self, range: (Point, Point)) -> Result<(), ClientError> {
         let msg = Message::RequestRange { range };
         self.send_message(&msg).await?;
@@ -135,6 +148,7 @@ impl Client {
         Ok(())
     }
 
+    /// Wait for the server's response to a [`Self::send_request_range`].
     pub async fn recv_while_busy(&mut self) -> Result<HasBlocks, ClientError> {
         match self.recv_message().await? {
             Message::StartBatch => {

--- a/pallas-network/src/miniprotocols/blockfetch/protocol.rs
+++ b/pallas-network/src/miniprotocols/blockfetch/protocol.rs
@@ -1,19 +1,37 @@
 use crate::miniprotocols::Point;
 
+/// Block-fetch state machine state.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum State {
+    /// Idle: client may request a range or terminate.
     Idle,
+    /// Server is deciding whether to serve the requested range.
     Busy,
+    /// Server is streaming `Block` messages.
     Streaming,
+    /// Protocol is terminated.
     Done,
 }
 
+/// Block-fetch protocol message.
 #[derive(Debug)]
 pub enum Message {
-    RequestRange { range: (Point, Point) },
+    /// Client → server: request all blocks in the inclusive range `[start, end]`.
+    RequestRange {
+        /// Inclusive `(start, end)` chain points.
+        range: (Point, Point),
+    },
+    /// Client → server: terminate the protocol.
     ClientDone,
+    /// Server → client: range is available; start streaming.
     StartBatch,
+    /// Server → client: range cannot be served.
     NoBlocks,
-    Block { body: Vec<u8> },
+    /// Server → client: one block body in the streamed batch.
+    Block {
+        /// Raw CBOR bytes of the block body.
+        body: Vec<u8>,
+    },
+    /// Server → client: end of the current batch.
     BatchDone,
 }

--- a/pallas-network/src/miniprotocols/blockfetch/server.rs
+++ b/pallas-network/src/miniprotocols/blockfetch/server.rs
@@ -4,24 +4,31 @@ use crate::multiplexer;
 
 use super::{Body, Message, Range, State};
 
+/// Errors produced by the block-fetch server agent.
 #[derive(Error, Debug)]
 pub enum ServerError {
+    /// Tried to receive while we hold agency.
     #[error("attempted to receive message while agency is ours")]
     AgencyIsOurs,
 
+    /// Tried to send while the peer holds agency.
     #[error("attempted to send message while agency is theirs")]
     AgencyIsTheirs,
 
+    /// Inbound message is not valid for the current state.
     #[error("inbound message is not valid for current state")]
     InvalidInbound,
 
+    /// Outbound message is not valid for the current state.
     #[error("outbound message is not valid for current state")]
     InvalidOutbound,
 
+    /// Underlying multiplexer error.
     #[error("error while sending or receiving data through the multiplexer")]
     Plexer(multiplexer::Error),
 }
 
+/// Block range a client just asked the server to serve.
 #[derive(Debug)]
 pub struct BlockRequest(pub Range);
 
@@ -96,6 +103,7 @@ impl Server {
         }
     }
 
+    /// Low-level send.
     pub async fn send_message(&mut self, msg: &Message) -> Result<(), ServerError> {
         self.assert_agency_is_ours()?;
         self.assert_outbound_state(msg)?;
@@ -107,6 +115,7 @@ impl Server {
         Ok(())
     }
 
+    /// Low-level receive.
     pub async fn recv_message(&mut self) -> Result<Message, ServerError> {
         self.assert_agency_is_theirs()?;
         let msg = self.1.recv_full_msg().await.map_err(ServerError::Plexer)?;
@@ -115,6 +124,7 @@ impl Server {
         Ok(msg)
     }
 
+    /// Tell the client a batch is starting; transition to `Streaming`.
     pub async fn send_start_batch(&mut self) -> Result<(), ServerError> {
         let msg = Message::StartBatch;
         self.send_message(&msg).await?;
@@ -123,6 +133,7 @@ impl Server {
         Ok(())
     }
 
+    /// Tell the client no blocks are available for the requested range.
     pub async fn send_no_blocks(&mut self) -> Result<(), ServerError> {
         let msg = Message::NoBlocks;
         self.send_message(&msg).await?;
@@ -131,6 +142,7 @@ impl Server {
         Ok(())
     }
 
+    /// Stream a single block body to the client.
     pub async fn send_block(&mut self, body: Body) -> Result<(), ServerError> {
         let msg = Message::Block { body };
         self.send_message(&msg).await?;
@@ -138,6 +150,7 @@ impl Server {
         Ok(())
     }
 
+    /// Signal end-of-batch and transition back to `Idle`.
     pub async fn send_batch_done(&mut self) -> Result<(), ServerError> {
         let msg = Message::BatchDone;
         self.send_message(&msg).await?;

--- a/pallas-network/src/miniprotocols/chainsync/buffer.rs
+++ b/pallas-network/src/miniprotocols/chainsync/buffer.rs
@@ -29,12 +29,16 @@ impl Default for RollbackBuffer {
     }
 }
 
+/// Result of attempting a rollback against the buffer.
 pub enum RollbackEffect {
+    /// Rollback point was within the buffer; orphaned points were dropped.
     Handled,
+    /// Rollback point was older than anything in the buffer; the whole buffer was cleared.
     OutOfScope,
 }
 
 impl RollbackBuffer {
+    /// Create an empty buffer.
     pub fn new() -> Self {
         Self {
             points: VecDeque::new(),

--- a/pallas-network/src/miniprotocols/chainsync/client.rs
+++ b/pallas-network/src/miniprotocols/chainsync/client.rs
@@ -8,34 +8,47 @@ use crate::multiplexer;
 
 use super::{BlockContent, HeaderContent, IntersectResponse, Message, State, Tip};
 
+/// Errors produced by the chain-sync client agent.
 #[derive(Error, Debug)]
 pub enum ClientError {
+    /// Tried to receive while we hold agency.
     #[error("attempted to receive message while agency is ours")]
     AgencyIsOurs,
 
+    /// Tried to send while the peer holds agency.
     #[error("attempted to send message while agency is theirs")]
     AgencyIsTheirs,
 
+    /// Inbound message is not valid for the current state.
     #[error("inbound message is not valid for current state")]
     InvalidInbound,
 
+    /// Outbound message is not valid for the current state.
     #[error("outbound message is not valid for current state")]
     InvalidOutbound,
 
+    /// None of the points offered by the client are on the server's chain.
     #[error("no intersection point found")]
     IntersectionNotFound,
 
+    /// Underlying multiplexer error.
     #[error("error while sending or receiving data through the channel")]
     Plexer(multiplexer::Error),
 }
 
+/// Outcome of a single `request_next` step.
 #[derive(Debug)]
 pub enum NextResponse<CONTENT> {
+    /// Chain advances with new content.
     RollForward(CONTENT, Tip),
+    /// Chain rolls back to the given point.
     RollBackward(Point, Tip),
+    /// No update is available yet; the server is awaiting one.
     Await,
 }
 
+/// Chain-sync client agent generic over the content type (`HeaderContent` for
+/// node-to-node, `BlockContent` for node-to-client).
 pub struct Client<O>(State, multiplexer::ChannelBuffer, PhantomData<O>)
 where
     Message<O>: Fragment;
@@ -216,6 +229,7 @@ where
         self.recv_intersect_response().await
     }
 
+    /// Send a `RequestNext` message and transition to `CanAwait`.
     pub async fn send_request_next(&mut self) -> Result<(), ClientError> {
         let msg = Message::RequestNext;
         self.send_message(&msg).await?;
@@ -324,6 +338,7 @@ where
         point.ok_or(ClientError::IntersectionNotFound)
     }
 
+    /// Send a `Done` message and terminate the protocol.
     pub async fn send_done(&mut self) -> Result<(), ClientError> {
         let msg = Message::Done;
         self.send_message(&msg).await?;
@@ -333,6 +348,8 @@ where
     }
 }
 
+/// Node-to-node chain-sync client (streams `HeaderContent`).
 pub type N2NClient = Client<HeaderContent>;
 
+/// Node-to-client chain-sync client (streams whole `BlockContent`).
 pub type N2CClient = Client<BlockContent>;

--- a/pallas-network/src/miniprotocols/chainsync/protocol.rs
+++ b/pallas-network/src/miniprotocols/chainsync/protocol.rs
@@ -2,41 +2,61 @@ use std::{fmt::Debug, ops::Deref};
 
 use crate::miniprotocols::Point;
 
-/// The tip of a chain, characterized by a point and its block height
+/// The tip of a chain, characterized by a point and its block height.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Tip(pub Point, pub u64);
 
+/// Result of [`Message::FindIntersect`]: the agreed-upon point (if any) plus the peer's current tip.
 pub type IntersectResponse = (Option<Point>, Tip);
 
+/// Chain-sync state machine state.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum State {
+    /// Idle: client may request next or look for an intersection.
     Idle,
+    /// Server has been asked for next; peer may already have one to send.
     CanAwait,
+    /// Server is awaiting a new block before replying.
     MustReply,
+    /// Client is awaiting an intersect response.
     Intersect,
+    /// Protocol is terminated.
     Done,
 }
 
-/// A generic chain-sync message for either header or block content
+/// A generic chain-sync message for either header or block content.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Message<C> {
+    /// Client → server: deliver the next chain update.
     RequestNext,
+    /// Server → client: no update available right now; wait for one.
     AwaitReply,
+    /// Server → client: chain advances with new content and the current tip.
     RollForward(C, Tip),
+    /// Server → client: roll back to the given point, with the current tip.
     RollBackward(Point, Tip),
+    /// Client → server: find the most recent point in this list that the server has.
     FindIntersect(Vec<Point>),
+    /// Server → client: intersection found at the given point, with the current tip.
     IntersectFound(Point, Tip),
+    /// Server → client: none of the offered points are on the server's chain.
     IntersectNotFound(Tip),
+    /// Client → server: terminate the protocol.
     Done,
 }
 
+/// Block header content delivered by node-to-node chain-sync.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HeaderContent {
+    /// Era tag from the CBOR multi-era wrapper.
     pub variant: u8,
+    /// Byron-only payload prefix when `variant` is a Byron variant.
     pub byron_prefix: Option<(u8, u64)>,
+    /// Era-specific header CBOR bytes.
     pub cbor: Vec<u8>,
 }
 
+/// Whole-block content delivered by node-to-client chain-sync.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BlockContent(pub Vec<u8>);
 
@@ -54,5 +74,6 @@ impl From<BlockContent> for Vec<u8> {
     }
 }
 
+/// Placeholder content for chain-sync flavors that omit the body payload.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SkippedContent;

--- a/pallas-network/src/miniprotocols/chainsync/server.rs
+++ b/pallas-network/src/miniprotocols/chainsync/server.rs
@@ -8,30 +8,40 @@ use crate::multiplexer;
 
 use super::{BlockContent, HeaderContent, Message, State, Tip};
 
+/// Errors produced by the chain-sync server agent.
 #[derive(Error, Debug)]
 pub enum ServerError {
+    /// Tried to receive while we hold agency.
     #[error("attempted to receive message while agency is ours")]
     AgencyIsOurs,
 
+    /// Tried to send while the peer holds agency.
     #[error("attempted to send message while agency is theirs")]
     AgencyIsTheirs,
 
+    /// Inbound message is not valid for the current state.
     #[error("inbound message is not valid for current state")]
     InvalidInbound,
 
+    /// Outbound message is not valid for the current state.
     #[error("outbound message is not valid for current state")]
     InvalidOutbound,
 
+    /// Underlying multiplexer error.
     #[error("error while sending or receiving data through the channel")]
     Plexer(multiplexer::Error),
 }
 
+/// Decoded inbound request the server needs to react to.
 #[derive(Debug)]
 pub enum ClientRequest {
+    /// Client asked the server to find an intersection in the given list of points.
     Intersect(Vec<Point>),
+    /// Client asked for the next chain update.
     RequestNext,
 }
 
+/// Chain-sync server agent generic over the content type.
 pub struct Server<O>(State, multiplexer::ChannelBuffer, PhantomData<O>)
 where
     Message<O>: Fragment;
@@ -287,6 +297,8 @@ where
     }
 }
 
+/// Node-to-node chain-sync server (sends `HeaderContent`).
 pub type N2NServer = Server<HeaderContent>;
 
+/// Node-to-client chain-sync server (sends whole `BlockContent`).
 pub type N2CServer = Server<BlockContent>;

--- a/pallas-network/src/miniprotocols/common.rs
+++ b/pallas-network/src/miniprotocols/common.rs
@@ -63,10 +63,10 @@ pub const PROTOCOL_N2C_CHAIN_SYNC: u16 = 5;
 /// Protocol channel number for node-to-client tx-submission
 pub const PROTOCOL_N2C_TX_SUBMISSION: u16 = 6;
 
-// Protocol channel number for node-to-client state queries
+/// Protocol channel number for node-to-client state queries
 pub const PROTOCOL_N2C_STATE_QUERY: u16 = 7;
 
-// Protocol channel number for node-to-client mempool monitor
+/// Protocol channel number for node-to-client mempool monitor
 pub const PROTOCOL_N2C_TX_MONITOR: u16 = 9;
 
 /// Protocol channel number for node-to-client local message submission
@@ -77,14 +77,17 @@ pub const PROTOCOL_N2C_MSG_SUBMISSION: u16 = 14;
 /// This protocol is available only on the DMQ node.
 pub const PROTOCOL_N2C_MSG_NOTIFICATION: u16 = 15;
 
-/// A point within a chain
+/// A point within a chain.
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub enum Point {
+    /// The chain origin (genesis), before any block exists.
     Origin,
+    /// A specific block, identified by its slot and header hash.
     Specific(u64, Vec<u8>),
 }
 
 impl Point {
+    /// Return the point's slot number, or 0 for [`Point::Origin`].
     pub fn slot_or_default(&self) -> u64 {
         match self {
             Point::Origin => 0,
@@ -103,6 +106,7 @@ impl Debug for Point {
 }
 
 impl Point {
+    /// Build a [`Point::Specific`] from a slot number and a header hash.
     pub fn new(slot: u64, hash: Vec<u8>) -> Self {
         Point::Specific(slot, hash)
     }

--- a/pallas-network/src/miniprotocols/handshake/client.rs
+++ b/pallas-network/src/miniprotocols/handshake/client.rs
@@ -6,13 +6,18 @@ use tracing::debug;
 use super::{Error, Message, RefuseReason, State, VersionNumber, VersionTable};
 use crate::multiplexer;
 
+/// Outcome of a completed handshake exchange.
 #[derive(Debug)]
 pub enum Confirmation<D: Debug + Clone> {
+    /// Server accepted the given version and payload.
     Accepted(VersionNumber, D),
+    /// Server refused the handshake for the stated reason.
     Rejected(RefuseReason),
+    /// Server replied in query mode with the versions it supports.
     QueryReply(VersionTable<D>),
 }
 
+/// Handshake client agent generic over the version-data payload type.
 pub struct Client<D>(State, multiplexer::ChannelBuffer, PhantomData<D>);
 
 impl<D> Client<D>
@@ -20,6 +25,7 @@ where
     D: Debug + Clone,
     Message<D>: Fragment,
 {
+    /// Build a client over a freshly subscribed agent channel.
     pub fn new(channel: multiplexer::AgentChannel) -> Self {
         Self(
             State::Propose,
@@ -28,14 +34,17 @@ where
         )
     }
 
+    /// Current state-machine state.
     pub fn state(&self) -> &State {
         &self.0
     }
 
+    /// True if the protocol has terminated.
     pub fn is_done(&self) -> bool {
         self.0 == State::Done
     }
 
+    /// True if the client holds agency in the current state.
     pub fn has_agency(&self) -> bool {
         match self.state() {
             State::Propose => true,
@@ -76,6 +85,7 @@ where
         }
     }
 
+    /// Low-level send.
     pub async fn send_message(&mut self, msg: &Message<D>) -> Result<(), Error> {
         self.assert_agency_is_ours()?;
         self.assert_outbound_state(msg)?;
@@ -84,6 +94,7 @@ where
         Ok(())
     }
 
+    /// Low-level receive.
     pub async fn recv_message(&mut self) -> Result<Message<D>, Error> {
         self.assert_agency_is_theirs()?;
         let msg = self.1.recv_full_msg().await.map_err(Error::Plexer)?;
@@ -92,6 +103,7 @@ where
         Ok(msg)
     }
 
+    /// Send a `Propose` message with the given offered versions.
     pub async fn send_propose(&mut self, versions: VersionTable<D>) -> Result<(), Error> {
         let msg = Message::Propose(versions);
         self.send_message(&msg).await?;
@@ -102,6 +114,7 @@ where
         Ok(())
     }
 
+    /// Wait for the server's response to our proposal.
     pub async fn recv_while_confirm(&mut self) -> Result<Confirmation<D>, Error> {
         match self.recv_message().await? {
             Message::Accept(v, m) => {
@@ -125,16 +138,20 @@ where
         }
     }
 
+    /// Propose `versions` and wait for the server's response in one call.
     pub async fn handshake(&mut self, versions: VersionTable<D>) -> Result<Confirmation<D>, Error> {
         self.send_propose(versions).await?;
         self.recv_while_confirm().await
     }
 
+    /// Discard the protocol wrapper and return the raw agent channel.
     pub fn unwrap(self) -> multiplexer::AgentChannel {
         self.1.unwrap()
     }
 }
 
+/// Node-to-node handshake client.
 pub type N2NClient = Client<super::n2n::VersionData>;
 
+/// Node-to-client handshake client.
 pub type N2CClient = Client<super::n2c::VersionData>;

--- a/pallas-network/src/miniprotocols/handshake/mod.rs
+++ b/pallas-network/src/miniprotocols/handshake/mod.rs
@@ -2,7 +2,9 @@ mod client;
 mod protocol;
 mod server;
 
+/// Node-to-client handshake version table.
 pub mod n2c;
+/// Node-to-node handshake version table.
 pub mod n2n;
 
 pub use client::*;

--- a/pallas-network/src/miniprotocols/handshake/n2c.rs
+++ b/pallas-network/src/miniprotocols/handshake/n2c.rs
@@ -5,6 +5,7 @@ use pallas_codec::minicbor::{decode, encode, Decode, Decoder, Encode, Encoder};
 
 use super::protocol::NetworkMagic;
 
+/// N2C-specific instantiation of the generic handshake version table.
 pub type VersionTable = super::protocol::VersionTable<VersionData>;
 
 const PROTOCOL_V1: u64 = 1;
@@ -34,6 +35,7 @@ const PROTOCOL_V23: u64 = 32791;
 const PROTOCOL_DMQ_V1: u64 = 4097;
 
 impl VersionTable {
+    /// Build a version table offering every N2C version from 1 up.
     pub fn v1_and_above(network_magic: u64) -> VersionTable {
         let values = vec![
             (PROTOCOL_V1, VersionData(network_magic, None)),
@@ -66,6 +68,7 @@ impl VersionTable {
         VersionTable { values }
     }
 
+    /// Build a version table offering only N2C version 10.
     pub fn only_v10(network_magic: u64) -> VersionTable {
         let values = vec![(PROTOCOL_V10, VersionData(network_magic, None))]
             .into_iter()
@@ -74,6 +77,7 @@ impl VersionTable {
         VersionTable { values }
     }
 
+    /// Build a version table offering every N2C version from 10 up.
     pub fn v10_and_above(network_magic: u64) -> VersionTable {
         let values = vec![
             (PROTOCOL_V10, VersionData(network_magic, None)),
@@ -97,6 +101,7 @@ impl VersionTable {
         VersionTable { values }
     }
 
+    /// Build a single-entry version table for N2C v15 query-mode handshake.
     pub fn v15_with_query(network_magic: u64) -> VersionTable {
         let values = vec![(PROTOCOL_V15, VersionData(network_magic, Some(true)))]
             .into_iter()
@@ -105,6 +110,7 @@ impl VersionTable {
         VersionTable { values }
     }
 
+    /// Build a single-entry version table for the DMQ handshake.
     pub fn dmq(network_magic: u64) -> VersionTable {
         let values = vec![(PROTOCOL_DMQ_V1, VersionData(network_magic, Some(false)))]
             .into_iter()
@@ -114,10 +120,12 @@ impl VersionTable {
     }
 }
 
+/// Per-version payload for the N2C handshake: `(network_magic, query?)`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct VersionData(NetworkMagic, Option<bool>);
 
 impl VersionData {
+    /// Build a [`VersionData`] from its components.
     pub fn new(magic: NetworkMagic, param: Option<bool>) -> Self {
         Self(magic, param)
     }

--- a/pallas-network/src/miniprotocols/handshake/n2n.rs
+++ b/pallas-network/src/miniprotocols/handshake/n2n.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use pallas_codec::minicbor::{decode, encode, Decode, Decoder, Encode, Encoder};
 
+/// N2N-specific instantiation of the generic handshake version table.
 pub type VersionTable = super::protocol::VersionTable<VersionData>;
 
 const PROTOCOL_V7: u64 = 7;
@@ -16,6 +17,7 @@ const PROTOCOL_V14: u64 = 14;
 const PEER_SHARING_DISABLED: u8 = 0;
 
 impl VersionTable {
+    /// Deprecated: forwards to [`Self::v7_and_above`] for backward compatibility.
     #[deprecated(note = "no longer supported by spec")]
     pub fn v4_and_above(network_magic: u64) -> VersionTable {
         // Older versions are not supported anymore (removed from network-spec.pdf).
@@ -23,6 +25,7 @@ impl VersionTable {
         Self::v7_and_above(network_magic)
     }
 
+    /// Deprecated: forwards to [`Self::v7_and_above`] for backward compatibility.
     #[deprecated(note = "no longer supported by spec")]
     pub fn v6_and_above(network_magic: u64) -> VersionTable {
         // Older versions are not supported anymore (removed from network-spec.pdf).
@@ -30,6 +33,7 @@ impl VersionTable {
         Self::v7_and_above(network_magic)
     }
 
+    /// Build a version table offering N2N protocol versions 7 through 10.
     pub fn v7_to_v10(network_magic: u64) -> VersionTable {
         let values = vec![
             (
@@ -55,10 +59,12 @@ impl VersionTable {
         VersionTable { values }
     }
 
+    /// Build a version table offering N2N versions 7 and up with `query=false`.
     pub fn v7_and_above(network_magic: u64) -> VersionTable {
         Self::v7_and_above_with_query(network_magic, false)
     }
 
+    /// Build a version table offering N2N versions 7 and up with the given query flag.
     pub fn v7_and_above_with_query(network_magic: u64, query: bool) -> VersionTable {
         let values = vec![
             (
@@ -120,10 +126,12 @@ impl VersionTable {
         VersionTable { values }
     }
 
+    /// Build a version table offering N2N versions 11 and up with `query=false`.
     pub fn v11_and_above(network_magic: u64) -> VersionTable {
         Self::v11_and_above_with_query(network_magic, false)
     }
 
+    /// Build a version table offering N2N versions 11 and up with the given query flag.
     pub fn v11_and_above_with_query(network_magic: u64, query: bool) -> VersionTable {
         let values = vec![
             (
@@ -170,15 +178,21 @@ impl VersionTable {
     }
 }
 
+/// Per-version payload for the N2N handshake.
 #[derive(Debug, Clone, PartialEq)]
 pub struct VersionData {
+    /// Network identifier (mainnet / testnet / …).
     pub network_magic: u64,
+    /// Whether the peer is initiator-only (no responder duties).
     pub initiator_only_diffusion_mode: bool,
+    /// Peer-sharing capability flag, when negotiated.
     pub peer_sharing: Option<u8>,
+    /// Whether this exchange is a query-mode handshake.
     pub query: Option<bool>,
 }
 
 impl VersionData {
+    /// Build a [`VersionData`] from its individual fields.
     pub fn new(
         network_magic: u64,
         initiator_only_diffusion_mode: bool,

--- a/pallas-network/src/miniprotocols/handshake/protocol.rs
+++ b/pallas-network/src/miniprotocols/handshake/protocol.rs
@@ -5,29 +5,37 @@ use thiserror::*;
 
 use crate::multiplexer;
 
+/// Errors produced by the handshake protocol.
 #[derive(Error, Debug)]
 pub enum Error {
+    /// Tried to receive while we hold agency.
     #[error("attempted to receive message while agency is ours")]
     AgencyIsOurs,
 
+    /// Tried to send while the peer holds agency.
     #[error("attempted to send message while agency is theirs")]
     AgencyIsTheirs,
 
+    /// Inbound message is not valid for the current state.
     #[error("inbound message is not valid for current state")]
     InvalidInbound,
 
+    /// Outbound message is not valid for the current state.
     #[error("outbound message is not valid for current state")]
     InvalidOutbound,
 
+    /// Underlying multiplexer error.
     #[error("error while sending or receiving data through the channel")]
     Plexer(multiplexer::Error),
 }
 
+/// Map of protocol version numbers to their version-specific payload.
 #[derive(Debug, Clone)]
 pub struct VersionTable<T>
 where
     T: Debug + Clone,
 {
+    /// Underlying version → version-data map.
     pub values: HashMap<u64, T>,
 }
 
@@ -70,18 +78,25 @@ where
     }
 }
 
+/// Network identifier exchanged at handshake (mainnet, testnet, …).
 pub type NetworkMagic = u64;
 
+/// Numeric protocol version, where higher means more recent.
 pub type VersionNumber = u64;
 
+/// Handshake protocol message.
 #[derive(Debug)]
 pub enum Message<D>
 where
     D: Debug + Clone,
 {
+    /// Initiator → responder: offered versions and their payloads.
     Propose(VersionTable<D>),
+    /// Responder → initiator: accepted version plus the agreed payload.
     Accept(VersionNumber, D),
+    /// Responder → initiator: handshake refused for a stated reason.
     Refuse(RefuseReason),
+    /// Responder → initiator: query-mode response listing supported versions.
     QueryReply(VersionTable<D>),
 }
 
@@ -153,17 +168,25 @@ where
     }
 }
 
+/// Handshake state-machine state.
 #[derive(Debug, PartialEq, Eq)]
 pub enum State {
+    /// Initiator side: waiting to send `Propose`.
     Propose,
+    /// Responder side: waiting to send `Accept`/`Refuse`/`QueryReply`.
     Confirm,
+    /// Protocol terminated.
     Done,
 }
 
+/// Reason a responder gave for refusing the handshake.
 #[derive(Debug)]
 pub enum RefuseReason {
+    /// None of the offered versions overlap with the responder's set.
     VersionMismatch(Vec<VersionNumber>),
+    /// The version-data payload for the chosen version failed to decode.
     HandshakeDecodeError(VersionNumber, String),
+    /// The responder refused the chosen version with an explanatory message.
     Refused(VersionNumber, String),
 }
 

--- a/pallas-network/src/miniprotocols/handshake/server.rs
+++ b/pallas-network/src/miniprotocols/handshake/server.rs
@@ -6,6 +6,7 @@ use tracing::{debug, warn};
 use super::{Error, Message, RefuseReason, State, VersionNumber, VersionTable};
 use crate::multiplexer;
 
+/// Handshake server agent generic over the version-data payload type.
 pub struct Server<D>(State, multiplexer::ChannelBuffer, PhantomData<D>);
 
 impl<D> Server<D>
@@ -13,6 +14,7 @@ where
     D: std::fmt::Debug + Clone + std::cmp::PartialEq,
     Message<D>: Fragment,
 {
+    /// Build a server over a freshly subscribed agent channel.
     pub fn new(channel: multiplexer::AgentChannel) -> Self {
         Self(
             State::Propose,
@@ -21,14 +23,17 @@ where
         )
     }
 
+    /// Current state-machine state.
     pub fn state(&self) -> &State {
         &self.0
     }
 
+    /// True if the protocol has terminated.
     pub fn is_done(&self) -> bool {
         self.0 == State::Done
     }
 
+    /// True if the server holds agency in the current state.
     pub fn has_agency(&self) -> bool {
         matches!(self.state(), State::Confirm)
     }
@@ -64,6 +69,7 @@ where
         }
     }
 
+    /// Low-level send.
     pub async fn send_message(&mut self, msg: &Message<D>) -> Result<(), Error> {
         self.assert_agency_is_ours()?;
         self.assert_outbound_state(msg)?;
@@ -72,6 +78,7 @@ where
         Ok(())
     }
 
+    /// Low-level receive.
     pub async fn recv_message(&mut self) -> Result<Message<D>, Error> {
         self.assert_agency_is_theirs()?;
         let msg = self.1.recv_full_msg().await.map_err(Error::Plexer)?;
@@ -80,6 +87,7 @@ where
         Ok(msg)
     }
 
+    /// Receive the client's `Propose` message and return the offered versions.
     pub async fn receive_proposed_versions(&mut self) -> Result<VersionTable<D>, Error> {
         match self.recv_message().await? {
             Message::Propose(v) => {
@@ -90,6 +98,7 @@ where
         }
     }
 
+    /// Send an `Accept` confirming the given version and payload.
     pub async fn accept_version(
         &mut self,
         version: VersionNumber,
@@ -102,6 +111,7 @@ where
         Ok(())
     }
 
+    /// Send a `Refuse` with the given reason.
     pub async fn refuse(&mut self, reason: RefuseReason) -> Result<(), Error> {
         let message = Message::Refuse(reason);
         self.send_message(&message).await?;
@@ -174,11 +184,14 @@ where
         Ok(None)
     }
 
+    /// Discard the protocol wrapper and return the raw agent channel.
     pub fn unwrap(self) -> multiplexer::AgentChannel {
         self.1.unwrap()
     }
 }
 
+/// Node-to-node handshake server.
 pub type N2NServer = Server<super::n2n::VersionData>;
 
+/// Node-to-client handshake server.
 pub type N2CServer = Server<super::n2c::VersionData>;

--- a/pallas-network/src/miniprotocols/keepalive/client.rs
+++ b/pallas-network/src/miniprotocols/keepalive/client.rs
@@ -6,38 +6,49 @@ use tracing::debug;
 use super::protocol::*;
 use crate::multiplexer;
 
+/// Errors produced by the keep-alive client agent.
 #[derive(Error, Debug)]
 pub enum ClientError {
+    /// Tried to receive while the client holds agency.
     #[error("attempted to receive message while agency is ours")]
     AgencyIsOurs,
 
+    /// Tried to send while the peer holds agency.
     #[error("attempted to send message while agency is theirs")]
     AgencyIsTheirs,
 
+    /// Inbound message is not valid for the current state.
     #[error("inbound message is not valid for current state")]
     InvalidInbound,
 
+    /// Outbound message is not valid for the current state.
     #[error("outbound message is not valid for current state")]
     InvalidOutbound,
 
+    /// Server echoed a cookie that does not match the one we sent.
     #[error("keepalive cookie mismatch")]
     KeepAliveCookieMismatch,
 
+    /// Underlying multiplexer error.
     #[error("error while sending or receiving data through the channel")]
     Plexer(multiplexer::Error),
 }
 
+/// Keep-alive client agent.
 pub struct Client(State, multiplexer::ChannelBuffer);
 
 impl Client {
+    /// Build a client over a freshly subscribed agent channel.
     pub fn new(channel: multiplexer::AgentChannel) -> Self {
         Self(State::Client, multiplexer::ChannelBuffer::new(channel))
     }
 
+    /// Current state-machine state.
     pub fn state(&self) -> &State {
         &self.0
     }
 
+    /// True if the protocol has terminated.
     pub fn is_done(&self) -> bool {
         self.0 == State::Done
     }
@@ -81,6 +92,7 @@ impl Client {
         }
     }
 
+    /// Low-level send. Use [`Self::keepalive_roundtrip`] for the common case.
     pub async fn send_message(&mut self, msg: &Message) -> Result<(), ClientError> {
         self.assert_agency_is_ours()?;
         self.assert_outbound_state(msg)?;
@@ -92,6 +104,7 @@ impl Client {
         Ok(())
     }
 
+    /// Low-level receive. Use [`Self::keepalive_roundtrip`] for the common case.
     pub async fn recv_message(&mut self) -> Result<Message, ClientError> {
         self.assert_agency_is_theirs()?;
         let msg = self.1.recv_full_msg().await.map_err(ClientError::Plexer)?;
@@ -100,6 +113,7 @@ impl Client {
         Ok(msg)
     }
 
+    /// Send a `KeepAlive` request carrying a freshly generated cookie.
     pub async fn send_keepalive_request(&mut self) -> Result<(), ClientError> {
         // generate random cookie value
         let cookie = rand::rng().random::<Cookie>();
@@ -111,6 +125,7 @@ impl Client {
         Ok(())
     }
 
+    /// Receive the matching `ResponseKeepAlive` and verify the cookie.
     pub async fn recv_keepalive_response(&mut self) -> Result<(), ClientError> {
         match self.recv_message().await? {
             Message::ResponseKeepAlive(cookie) => {
@@ -128,6 +143,7 @@ impl Client {
         }
     }
 
+    /// Send a ping and wait for its matching response.
     pub async fn keepalive_roundtrip(&mut self) -> Result<(), ClientError> {
         self.send_keepalive_request().await?;
         self.recv_keepalive_response().await?;

--- a/pallas-network/src/miniprotocols/keepalive/protocol.rs
+++ b/pallas-network/src/miniprotocols/keepalive/protocol.rs
@@ -1,15 +1,24 @@
+/// Opaque token echoed in a keep-alive round trip to match request to response.
 pub type Cookie = u16;
 
+/// Keep-alive state machine state.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum State {
+    /// Client may send another ping (or close the protocol).
     Client,
+    /// Server owes a response carrying the given cookie.
     Server(Cookie),
+    /// Protocol is terminated.
     Done,
 }
 
+/// Keep-alive protocol message.
 #[derive(Debug, Clone)]
 pub enum Message {
+    /// Client → server: ping carrying a cookie to echo back.
     KeepAlive(Cookie),
+    /// Server → client: response echoing the cookie from the ping.
     ResponseKeepAlive(Cookie),
+    /// Client → server: terminate the protocol.
     Done,
 }

--- a/pallas-network/src/miniprotocols/keepalive/server.rs
+++ b/pallas-network/src/miniprotocols/keepalive/server.rs
@@ -5,35 +5,45 @@ use tracing::debug;
 use super::protocol::*;
 use crate::multiplexer;
 
+/// Errors produced by the keep-alive server agent.
 #[derive(Error, Debug)]
 pub enum ServerError {
+    /// Tried to receive while the server holds agency.
     #[error("attempted to receive message while agency is ours")]
     AgencyIsOurs,
 
+    /// Tried to send while the peer holds agency.
     #[error("attempted to send message while agency is theirs")]
     AgencyIsTheirs,
 
+    /// Inbound message is not valid for the current state.
     #[error("inbound message is not valid for current state")]
     InvalidInbound,
 
+    /// Outbound message is not valid for the current state.
     #[error("outbound message is not valid for current state")]
     InvalidOutbound,
 
+    /// Underlying multiplexer error.
     #[error("error while sending or receiving data through the channel")]
     Plexer(multiplexer::Error),
 }
 
+/// Keep-alive server agent.
 pub struct Server(State, multiplexer::ChannelBuffer);
 
 impl Server {
+    /// Build a server over a freshly subscribed agent channel.
     pub fn new(channel: multiplexer::AgentChannel) -> Self {
         Self(State::Client, multiplexer::ChannelBuffer::new(channel))
     }
 
+    /// Current state-machine state.
     pub fn state(&self) -> &State {
         &self.0
     }
 
+    /// True if the protocol has terminated.
     pub fn is_done(&self) -> bool {
         self.0 == State::Done
     }
@@ -77,6 +87,7 @@ impl Server {
         }
     }
 
+    /// Low-level send.
     pub async fn send_message(&mut self, msg: &Message) -> Result<(), ServerError> {
         self.assert_agency_is_ours()?;
         self.assert_outbound_state(msg)?;
@@ -88,6 +99,7 @@ impl Server {
         Ok(())
     }
 
+    /// Low-level receive.
     pub async fn recv_message(&mut self) -> Result<Message, ServerError> {
         self.assert_agency_is_theirs()?;
         let msg = self.1.recv_full_msg().await.map_err(ServerError::Plexer)?;
@@ -96,6 +108,7 @@ impl Server {
         Ok(msg)
     }
 
+    /// Wait for the next `KeepAlive` (or `Done`) and update state accordingly.
     pub async fn recv_keepalive_request(&mut self) -> Result<(), ServerError> {
         match self.recv_message().await? {
             Message::KeepAlive(cookie) => {
@@ -112,6 +125,7 @@ impl Server {
         }
     }
 
+    /// Echo back the cookie of the most recent `KeepAlive` request.
     pub async fn send_keepalive_response(&mut self) -> Result<(), ServerError> {
         if let State::Server(cookie) = self.state().clone() {
             let msg = Message::ResponseKeepAlive(cookie);
@@ -123,6 +137,7 @@ impl Server {
         Ok(())
     }
 
+    /// Receive one keep-alive request and respond to it.
     pub async fn keepalive_roundtrip(&mut self) -> Result<(), ServerError> {
         self.recv_keepalive_request().await?;
         self.send_keepalive_response().await?;

--- a/pallas-network/src/miniprotocols/localmsgnotification/client.rs
+++ b/pallas-network/src/miniprotocols/localmsgnotification/client.rs
@@ -4,6 +4,7 @@ use crate::{miniprotocols::localmsgsubmission::DmqMsg, multiplexer};
 
 use super::{protocol::Error, Message, State};
 
+/// Server reply to a request: messages plus a `has_more` flag (always `false` for blocking requests).
 #[derive(Debug, PartialEq, Eq)]
 pub struct Reply(pub Vec<DmqMsg>, pub bool);
 
@@ -16,14 +17,17 @@ impl Client
 where
     Message: Fragment,
 {
+    /// Build a client over a freshly subscribed agent channel.
     pub fn new(channel: multiplexer::AgentChannel) -> Self {
         Self(State::Idle, multiplexer::ChannelBuffer::new(channel))
     }
 
+    /// Current state-machine state.
     pub fn state(&self) -> &State {
         &self.0
     }
 
+    /// True if the protocol has terminated.
     pub fn is_done(&self) -> bool {
         self.0 == State::Done
     }
@@ -67,6 +71,7 @@ where
         }
     }
 
+    /// Low-level send.
     pub async fn send_message(&mut self, msg: &Message) -> Result<(), Error> {
         self.assert_agency_is_ours()?;
         self.assert_outbound_state(msg)?;
@@ -75,6 +80,7 @@ where
         Ok(())
     }
 
+    /// Low-level receive.
     pub async fn recv_message(&mut self) -> Result<Message, Error> {
         self.assert_agency_is_theirs()?;
         let msg = self.1.recv_full_msg().await.map_err(Error::Plexer)?;
@@ -83,6 +89,7 @@ where
         Ok(msg)
     }
 
+    /// Ask the server to return queued messages without blocking.
     pub async fn send_request_messages_non_blocking(&mut self) -> Result<(), Error> {
         let msg = Message::RequestMessagesNonBlocking;
         self.send_message(&msg).await?;
@@ -91,6 +98,7 @@ where
         Ok(())
     }
 
+    /// Ask the server to block until at least one message is available.
     pub async fn send_request_messages_blocking(&mut self) -> Result<(), Error> {
         let msg = Message::RequestMessagesBlocking;
         self.send_message(&msg).await?;
@@ -99,6 +107,7 @@ where
         Ok(())
     }
 
+    /// Wait for the server's reply (blocking or non-blocking).
     pub async fn recv_next_reply(&mut self) -> Result<Reply, Error> {
         match self.recv_message().await? {
             Message::ReplyMessagesNonBlocking(msgs, has_more) => {
@@ -115,6 +124,7 @@ where
         }
     }
 
+    /// Terminate the protocol.
     pub async fn send_done(&mut self) -> Result<(), Error> {
         let msg = Message::ClientDone;
         self.send_message(&msg).await?;

--- a/pallas-network/src/miniprotocols/localmsgnotification/protocol.rs
+++ b/pallas-network/src/miniprotocols/localmsgnotification/protocol.rs
@@ -3,40 +3,58 @@ use thiserror::Error;
 use crate::miniprotocols::localmsgsubmission::DmqMsg;
 use crate::multiplexer;
 
+/// Errors produced by the local-message-notification protocol.
 #[derive(Error, Debug)]
 pub enum Error {
+    /// Tried to receive while we hold agency.
     #[error("attempted to receive message while agency is ours")]
     AgencyIsOurs,
 
+    /// Tried to send while the peer holds agency.
     #[error("attempted to send message while agency is theirs")]
     AgencyIsTheirs,
 
+    /// Inbound message is not valid for the current state.
     #[error("inbound message is not valid for current state")]
     InvalidInbound,
 
+    /// Outbound message is not valid for the current state.
     #[error("outbound message is not valid for current state")]
     InvalidOutbound,
 
+    /// Caller tried to re-initialize an already-running protocol.
     #[error("protocol is already initialized, no need to wait for init message")]
     AlreadyInitialized,
 
+    /// Underlying multiplexer error.
     #[error("error while sending or receiving data through the channel")]
     Plexer(multiplexer::Error),
 }
 
+/// Local-message-notification state-machine state.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum State {
+    /// Idle: client may request messages or terminate.
     Idle,
+    /// Server is collecting messages, blocking until at least one arrives.
     BusyBlocking,
+    /// Server is collecting messages, returning whatever is available immediately.
     BusyNonBlocking,
+    /// Protocol terminated.
     Done,
 }
 
+/// Local-message-notification protocol message.
 #[derive(Debug)]
 pub enum Message {
+    /// Client → server: return queued messages without blocking.
     RequestMessagesNonBlocking,
+    /// Server → client: messages plus a flag indicating whether more are available.
     ReplyMessagesNonBlocking(Vec<DmqMsg>, bool),
+    /// Client → server: block until at least one message is available.
     RequestMessagesBlocking,
+    /// Server → client: the awaited batch of messages.
     ReplyMessagesBlocking(Vec<DmqMsg>),
+    /// Client → server: terminate the protocol.
     ClientDone,
 }

--- a/pallas-network/src/miniprotocols/localmsgnotification/server.rs
+++ b/pallas-network/src/miniprotocols/localmsgnotification/server.rs
@@ -4,9 +4,12 @@ use crate::{miniprotocols::localmsgsubmission::DmqMsg, multiplexer};
 
 use super::{protocol::Error, Message, State};
 
+/// Decoded inbound request from the DMQ client.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Request {
+    /// Return queued messages without blocking.
     NonBlocking,
+    /// Block until at least one message is available.
     Blocking,
 }
 
@@ -19,14 +22,17 @@ impl Server
 where
     Message: Fragment,
 {
+    /// Build a server over a freshly subscribed agent channel.
     pub fn new(channel: multiplexer::AgentChannel) -> Self {
         Self(State::Idle, multiplexer::ChannelBuffer::new(channel))
     }
 
+    /// Current state-machine state.
     pub fn state(&self) -> &State {
         &self.0
     }
 
+    /// True if the protocol has terminated.
     pub fn is_done(&self) -> bool {
         self.0 == State::Done
     }
@@ -70,6 +76,7 @@ where
         }
     }
 
+    /// Low-level send.
     pub async fn send_message(&mut self, msg: &Message) -> Result<(), Error> {
         self.assert_agency_is_ours()?;
         self.assert_outbound_state(msg)?;
@@ -78,6 +85,7 @@ where
         Ok(())
     }
 
+    /// Low-level receive.
     pub async fn recv_message(&mut self) -> Result<Message, Error> {
         self.assert_agency_is_theirs()?;
         let msg = self.1.recv_full_msg().await.map_err(Error::Plexer)?;
@@ -86,6 +94,7 @@ where
         Ok(msg)
     }
 
+    /// Reply with messages plus a `has_more` flag (non-blocking flow).
     pub async fn send_reply_messages_non_blocking(
         &mut self,
         msgs: Vec<DmqMsg>,
@@ -98,6 +107,7 @@ where
         Ok(())
     }
 
+    /// Reply with the messages that satisfied a blocking request.
     pub async fn send_reply_messages_blocking(&mut self, msgs: Vec<DmqMsg>) -> Result<(), Error> {
         let msg = Message::ReplyMessagesBlocking(msgs);
         self.send_message(&msg).await?;
@@ -106,6 +116,7 @@ where
         Ok(())
     }
 
+    /// Wait for the next request (`Blocking` or `NonBlocking`).
     pub async fn recv_next_request(&mut self) -> Result<Request, Error> {
         match self.recv_message().await? {
             Message::RequestMessagesNonBlocking => {
@@ -122,6 +133,7 @@ where
         }
     }
 
+    /// Wait for the client's `ClientDone` to terminate the protocol.
     pub async fn recv_done(&mut self) -> Result<(), Error> {
         match self.recv_message().await? {
             Message::ClientDone => {

--- a/pallas-network/src/miniprotocols/localmsgsubmission/protocol.rs
+++ b/pallas-network/src/miniprotocols/localmsgsubmission/protocol.rs
@@ -46,9 +46,13 @@ impl DmqMsgPayload {
 /// The representation of an operational certificate in a DMQ message.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct DmqMsgOperationalCertificate {
+    /// KES verification key being certified.
     pub kes_vk: Vec<u8>,
+    /// Monotonic certificate issue number (rotates on key reuse).
     pub issue_number: u64,
+    /// KES period the certificate becomes valid in.
     pub start_kes_period: u64,
+    /// Cold-key signature over the rest of the certificate.
     pub cert_sig: Vec<u8>,
 }
 

--- a/pallas-network/src/miniprotocols/localstate/client.rs
+++ b/pallas-network/src/miniprotocols/localstate/client.rs
@@ -6,29 +6,38 @@ use super::{AcquireFailure, Message, State};
 use crate::miniprotocols::Point;
 use crate::multiplexer;
 
+/// Errors produced by the local-state-query client agent.
 #[derive(Error, Debug)]
 pub enum ClientError {
+    /// Tried to receive while we hold agency.
     #[error("attempted to receive message while agency is ours")]
     AgencyIsOurs,
 
+    /// Tried to send while the peer holds agency.
     #[error("attempted to send message while agency is theirs")]
     AgencyIsTheirs,
 
+    /// Inbound message is not valid for the current state.
     #[error("inbound message is not valid for current state")]
     InvalidInbound,
 
+    /// Outbound message is not valid for the current state.
     #[error("outbound message is not valid for current state")]
     InvalidOutbound,
 
+    /// Requested point is not on the server's current chain.
     #[error("failure acquiring point, not found")]
     AcquirePointNotFound,
 
+    /// Requested point is older than the server's rolling window.
     #[error("failure acquiring point, too old")]
     AcquirePointTooOld,
 
+    /// Query result could not be CBOR-decoded.
     #[error("failure decoding CBOR data")]
     InvalidCbor(pallas_codec::minicbor::decode::Error),
 
+    /// Underlying multiplexer error.
     #[error("error while sending or receiving data through the channel")]
     Plexer(multiplexer::Error),
 }
@@ -42,17 +51,21 @@ impl From<AcquireFailure> for ClientError {
     }
 }
 
+/// Local-state-query client agent.
 pub struct GenericClient(State, multiplexer::ChannelBuffer);
 
 impl GenericClient {
+    /// Build a client over a freshly subscribed agent channel.
     pub fn new(channel: multiplexer::AgentChannel) -> Self {
         Self(State::Idle, multiplexer::ChannelBuffer::new(channel))
     }
 
+    /// Current state-machine state.
     pub fn state(&self) -> &State {
         &self.0
     }
 
+    /// True if the protocol has terminated.
     pub fn is_done(&self) -> bool {
         self.0 == State::Done
     }
@@ -102,6 +115,7 @@ impl GenericClient {
         }
     }
 
+    /// Low-level send.
     pub async fn send_message(&mut self, msg: &Message) -> Result<(), ClientError> {
         self.assert_agency_is_ours()?;
         self.assert_outbound_state(msg)?;
@@ -113,6 +127,7 @@ impl GenericClient {
         Ok(())
     }
 
+    /// Low-level receive.
     pub async fn recv_message(&mut self) -> Result<Message, ClientError> {
         self.assert_agency_is_theirs()?;
         let msg = self.1.recv_full_msg().await.map_err(ClientError::Plexer)?;
@@ -121,6 +136,7 @@ impl GenericClient {
         Ok(msg)
     }
 
+    /// Send an `Acquire(point)` and transition to `Acquiring`.
     pub async fn send_acquire(&mut self, point: Option<Point>) -> Result<(), ClientError> {
         let msg = Message::Acquire(point);
         self.send_message(&msg).await?;
@@ -129,6 +145,7 @@ impl GenericClient {
         Ok(())
     }
 
+    /// Drop the current snapshot and acquire `point` instead.
     pub async fn send_reacquire(&mut self, point: Option<Point>) -> Result<(), ClientError> {
         let msg = Message::ReAcquire(point);
         self.send_message(&msg).await?;
@@ -137,6 +154,7 @@ impl GenericClient {
         Ok(())
     }
 
+    /// Release the current snapshot.
     pub async fn send_release(&mut self) -> Result<(), ClientError> {
         let msg = Message::Release;
         self.send_message(&msg).await?;
@@ -145,6 +163,7 @@ impl GenericClient {
         Ok(())
     }
 
+    /// Terminate the protocol.
     pub async fn send_done(&mut self) -> Result<(), ClientError> {
         let msg = Message::Done;
         self.send_message(&msg).await?;
@@ -153,6 +172,7 @@ impl GenericClient {
         Ok(())
     }
 
+    /// Wait for the server's `Acquired` (or `Failure`).
     pub async fn recv_while_acquiring(&mut self) -> Result<(), ClientError> {
         match self.recv_message().await? {
             Message::Acquired => {
@@ -167,11 +187,13 @@ impl GenericClient {
         }
     }
 
+    /// Acquire a snapshot at `point` (or the tip when `None`).
     pub async fn acquire(&mut self, point: Option<Point>) -> Result<(), ClientError> {
         self.send_acquire(point).await?;
         self.recv_while_acquiring().await
     }
 
+    /// Send a `Query` carrying an arbitrary CBOR-encoded request.
     pub async fn send_query(&mut self, request: AnyCbor) -> Result<Message, ClientError> {
         let msg = Message::Query(request);
         self.send_message(&msg).await?;
@@ -180,6 +202,7 @@ impl GenericClient {
         Ok(msg)
     }
 
+    /// Wait for the server's `Result` reply.
     pub async fn recv_while_querying(&mut self) -> Result<AnyCbor, ClientError> {
         match self.recv_message().await? {
             Message::Result(result) => {
@@ -190,11 +213,13 @@ impl GenericClient {
         }
     }
 
+    /// Run one untyped query, returning the raw CBOR result.
     pub async fn query_any(&mut self, request: AnyCbor) -> Result<AnyCbor, ClientError> {
         self.send_query(request).await?;
         self.recv_while_querying().await
     }
 
+    /// Run one strongly-typed query, encoding the request and decoding the response.
     pub async fn query<Q, R>(&mut self, request: Q) -> Result<R, ClientError>
     where
         Q: pallas_codec::minicbor::Encode<()>,
@@ -207,4 +232,5 @@ impl GenericClient {
     }
 }
 
+/// Concrete local-state-query client (default instantiation).
 pub type Client = GenericClient;

--- a/pallas-network/src/miniprotocols/localstate/mod.rs
+++ b/pallas-network/src/miniprotocols/localstate/mod.rs
@@ -3,6 +3,7 @@ mod codec;
 mod protocol;
 mod server;
 
+/// Concrete ledger queries available in the local-state-query v16 protocol.
 pub mod queries_v16;
 
 pub use client::*;

--- a/pallas-network/src/miniprotocols/localstate/protocol.rs
+++ b/pallas-network/src/miniprotocols/localstate/protocol.rs
@@ -4,29 +4,47 @@ use pallas_codec::utils::AnyCbor;
 
 use crate::miniprotocols::Point;
 
+/// Local-state-query state-machine state.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum State {
+    /// Idle: client may acquire a snapshot or terminate.
     Idle,
+    /// Awaiting confirmation of an acquire attempt.
     Acquiring,
+    /// A snapshot is acquired; client may query, re-acquire, or release.
     Acquired,
+    /// Awaiting the result of a query.
     Querying,
+    /// Protocol terminated.
     Done,
 }
 
+/// Reason a snapshot could not be acquired.
 #[derive(Debug)]
 pub enum AcquireFailure {
+    /// The requested point is too old to be available.
     PointTooOld,
+    /// The requested point is not on the current chain.
     PointNotOnChain,
 }
 
+/// Local-state-query protocol message.
 #[derive(Debug)]
 pub enum Message {
+    /// Client → server: acquire a snapshot at `Point` (or the tip when `None`).
     Acquire(Option<Point>),
+    /// Server → client: acquire failed for the stated reason.
     Failure(AcquireFailure),
+    /// Server → client: snapshot acquired.
     Acquired,
+    /// Client → server: run a query against the current snapshot.
     Query(AnyCbor),
+    /// Server → client: result of the previous query.
     Result(AnyCbor),
+    /// Client → server: drop the current snapshot and acquire a new one.
     ReAcquire(Option<Point>),
+    /// Client → server: release the current snapshot.
     Release,
+    /// Client → server: terminate the protocol.
     Done,
 }

--- a/pallas-network/src/miniprotocols/localstate/queries_v16/primitives.rs
+++ b/pallas-network/src/miniprotocols/localstate/queries_v16/primitives.rs
@@ -5,29 +5,41 @@ pub use pallas_crypto::hash::Hash;
 
 use pallas_codec::minicbor::{self, Decode, Encode};
 
+/// Stake pool metadata reference: URL plus the hash of the pointed-to JSON.
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct PoolMetadata {
+    /// URL serving the pool metadata JSON.
     #[n(0)]
     pub url: String,
 
+    /// Hash of the JSON document served at `url`.
     #[n(1)]
     pub hash: PoolMetadataHash,
 }
 
+/// Hash of stake pool metadata (Blake2b-256).
 pub type PoolMetadataHash = Bytes;
 
+/// TCP/UDP port number.
 pub type Port = u32;
 
+/// IPv4 address bytes (4 bytes, big-endian).
 pub type IPv4 = Bytes;
 
+/// IPv6 address bytes (16 bytes, big-endian).
 pub type IPv6 = Bytes;
 
+/// DNS name (A or SRV record) used in relay declarations.
 pub type DnsName = String;
 
+/// Network endpoint declared by a stake pool's relay.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Relay {
+    /// IP-based relay with optional port and either or both IPv4/IPv6.
     SingleHostAddr(Nullable<Port>, Nullable<IPv4>, Nullable<IPv6>),
+    /// DNS A-record relay with optional port and a hostname.
     SingleHostName(Nullable<Port>, DnsName),
+    /// DNS SRV-record relay (port and host both come from the SRV record).
     MultiHostName(DnsName),
 }
 

--- a/pallas-network/src/miniprotocols/localstate/server.rs
+++ b/pallas-network/src/miniprotocols/localstate/server.rs
@@ -6,42 +6,55 @@ use super::{AcquireFailure, Message, State};
 use crate::miniprotocols::Point;
 use crate::multiplexer;
 
+/// Errors produced by the local-state-query server agent.
 #[derive(Error, Debug)]
 pub enum Error {
+    /// Tried to receive while we hold agency.
     #[error("attempted to receive message while agency is ours")]
     AgencyIsOurs,
+    /// Tried to send while the peer holds agency.
     #[error("attempted to send message while agency is theirs")]
     AgencyIsTheirs,
+    /// Inbound message is not valid for the current state.
     #[error("inbound message is not valid for current state")]
     InvalidInbound,
+    /// Outbound message is not valid for the current state.
     #[error("outbound message is not valid for current state")]
     InvalidOutbound,
+    /// Underlying multiplexer error.
     #[error("error while sending or receiving data through the channel")]
     Plexer(multiplexer::Error),
 }
 
-/// Request received from the client to acquire the ledger
+/// Request received from the client to acquire the ledger.
 pub struct ClientAcquireRequest(pub Option<Point>);
 
-/// Request received from the client when in the Acquired state
+/// Request received from the client while in the Acquired state.
 #[derive(Debug)]
 pub enum ClientQueryRequest {
+    /// Drop the current snapshot and acquire a new one.
     ReAcquire(Option<Point>),
+    /// Run a query against the current snapshot.
     Query(AnyCbor),
+    /// Release the current snapshot.
     Release,
 }
 
+/// Local-state-query server agent.
 pub struct GenericServer(State, multiplexer::ChannelBuffer);
 
 impl GenericServer {
+    /// Build a server over a freshly subscribed agent channel.
     pub fn new(channel: multiplexer::AgentChannel) -> Self {
         Self(State::Idle, multiplexer::ChannelBuffer::new(channel))
     }
 
+    /// Current state-machine state.
     pub fn state(&self) -> &State {
         &self.0
     }
 
+    /// True if the protocol has terminated.
     pub fn is_done(&self) -> bool {
         self.0 == State::Done
     }
@@ -86,6 +99,7 @@ impl GenericServer {
         }
     }
 
+    /// Low-level send.
     pub async fn send_message(&mut self, msg: &Message) -> Result<(), Error> {
         self.assert_agency_is_ours()?;
         self.assert_outbound_state(msg)?;
@@ -94,6 +108,7 @@ impl GenericServer {
         Ok(())
     }
 
+    /// Low-level receive.
     pub async fn recv_message(&mut self) -> Result<Message, Error> {
         self.assert_agency_is_theirs()?;
         let msg = self.1.recv_full_msg().await.map_err(Error::Plexer)?;
@@ -102,6 +117,7 @@ impl GenericServer {
         Ok(msg)
     }
 
+    /// Reject the pending acquire with the given reason.
     pub async fn send_failure(&mut self, reason: AcquireFailure) -> Result<(), Error> {
         let msg = Message::Failure(reason);
         self.send_message(&msg).await?;
@@ -110,6 +126,7 @@ impl GenericServer {
         Ok(())
     }
 
+    /// Confirm the pending acquire.
     pub async fn send_acquired(&mut self) -> Result<(), Error> {
         let msg = Message::Acquired;
         self.send_message(&msg).await?;
@@ -118,6 +135,7 @@ impl GenericServer {
         Ok(())
     }
 
+    /// Reply to the pending query with the given CBOR-encoded result.
     pub async fn send_result(&mut self, response: AnyCbor) -> Result<(), Error> {
         let msg = Message::Result(response);
         self.send_message(&msg).await?;
@@ -126,10 +144,8 @@ impl GenericServer {
         Ok(())
     }
 
-    /// Receive a message from the Client when the protocol is in the Idle state
-    ///
-    /// Returns the client's request to acquire the ledger or None if a Done
-    /// message was received from the client causing the protocol to finish.
+    /// Wait for the next request while the protocol is in the `Idle` state.
+    /// Returns `None` if the client terminated the protocol.
     pub async fn recv_while_idle(&mut self) -> Result<Option<ClientAcquireRequest>, Error> {
         match self.recv_message().await? {
             Message::Acquire(point) => {
@@ -144,6 +160,7 @@ impl GenericServer {
         }
     }
 
+    /// Wait for the next request while the protocol is in the `Acquired` state.
     pub async fn recv_while_acquired(&mut self) -> Result<ClientQueryRequest, Error> {
         match self.recv_message().await? {
             Message::ReAcquire(point) => {
@@ -163,4 +180,5 @@ impl GenericServer {
     }
 }
 
+/// Concrete local-state-query server (default instantiation).
 pub type Server = GenericServer;

--- a/pallas-network/src/miniprotocols/localtxsubmission/client.rs
+++ b/pallas-network/src/miniprotocols/localtxsubmission/client.rs
@@ -187,8 +187,11 @@ where
     }
 }
 
+/// Server's reply to a transaction submission.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Response<Reject> {
+    /// Transaction was accepted into the mempool.
     Accepted,
+    /// Transaction was rejected; carries the rejection reason.
     Rejected(Reject),
 }

--- a/pallas-network/src/miniprotocols/localtxsubmission/mod.rs
+++ b/pallas-network/src/miniprotocols/localtxsubmission/mod.rs
@@ -7,4 +7,5 @@ mod codec;
 mod protocol;
 mod server;
 
+/// CBOR-encoded primitives reported by the local node when a submission is rejected.
 pub mod primitives;

--- a/pallas-network/src/miniprotocols/localtxsubmission/primitives.rs
+++ b/pallas-network/src/miniprotocols/localtxsubmission/primitives.rs
@@ -12,53 +12,86 @@ use pallas_codec::{
     utils::{Bytes, NonEmptyKeyValuePairs, Nullable, Set},
 };
 
+/// Multi-asset value: `policy → asset_name → quantity`.
 pub type Multiasset<A> = NonEmptyKeyValuePairs<PolicyId, NonEmptyKeyValuePairs<AssetName, A>>;
 
+/// Mint/burn payload (signed quantities).
 pub type Mint = Multiasset<i64>;
 
+/// On-chain credential: a script hash or a verification-key hash.
 // https://github.com/IntersectMBO/cardano-ledger/blob/33e90ea03447b44a389985ca2b158568e5f4ad65/libs/cardano-ledger-core/src/Cardano/Ledger/Credential.hs#L82
 #[derive(Debug, Decode, Encode, Clone, Hash, PartialEq, Eq)]
 #[cbor(flat)]
 pub enum Credential {
+    /// Credential backed by a script hash.
     #[n(0)]
     ScriptHashObj(#[n(0)] ScriptHash),
+    /// Credential backed by a verification-key hash.
     #[n(1)]
     KeyHashObj(#[n(0)] AddrKeyhash),
 }
 
+/// On-chain certificate (Shelley + Conway era variants).
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Certificate {
+    /// Register a stake credential (pre-Conway).
     StakeRegistration(StakeCredential),
+    /// Deregister a stake credential (pre-Conway).
     StakeDeregistration(StakeCredential),
+    /// Delegate a stake credential to a stake pool.
     StakeDelegation(StakeCredential, PoolKeyhash),
+    /// Register a new stake pool with its full parameter set.
     PoolRegistration {
+        /// Pool operator (cold) key hash.
         operator: PoolKeyhash,
+        /// Pool VRF key hash.
         vrf_keyhash: VrfKeyhash,
+        /// Pledge in lovelace.
         pledge: Coin,
+        /// Per-epoch fixed cost in lovelace.
         cost: Coin,
+        /// Pool margin (rational in `[0, 1]`).
         margin: UnitInterval,
+        /// Reward account that collects pool fees.
         reward_account: RewardAccount,
+        /// Hashes of accounts that own the pool.
         pool_owners: Set<AddrKeyhash>,
+        /// Declared relays serving the pool.
         relays: Vec<Relay>,
+        /// Optional pool metadata pointer.
         pool_metadata: Nullable<PoolMetadata>,
     },
+    /// Retire a stake pool at the given epoch.
     PoolRetirement(PoolKeyhash, Epoch),
 
+    /// Conway: register a stake credential with explicit deposit.
     Reg(StakeCredential, Coin),
+    /// Conway: deregister a stake credential, returning its deposit.
     UnReg(StakeCredential, Coin),
+    /// Conway: delegate voting rights to a DRep.
     VoteDeleg(StakeCredential, DRep),
+    /// Conway: delegate both stake (to a pool) and voting rights (to a DRep).
     StakeVoteDeleg(StakeCredential, PoolKeyhash, DRep),
+    /// Conway: register, take a deposit, and delegate stake in one certificate.
     StakeRegDeleg(StakeCredential, PoolKeyhash, Coin),
+    /// Conway: register, take a deposit, and delegate voting rights in one certificate.
     VoteRegDeleg(StakeCredential, DRep, Coin),
+    /// Conway: register and delegate both stake and voting rights in one certificate.
     StakeVoteRegDeleg(StakeCredential, PoolKeyhash, DRep, Coin),
 
+    /// Conway: authorize a hot key for a constitutional-committee member.
     AuthCommitteeHot(CommitteeColdCredential, CommitteeHotCredential),
+    /// Conway: resign a constitutional-committee cold credential.
     ResignCommitteeCold(CommitteeColdCredential, Nullable<Anchor>),
+    /// Conway: register a DRep with deposit and optional anchor.
     RegDRepCert(DRepCredential, Coin, Nullable<Anchor>),
+    /// Conway: deregister a DRep, returning its deposit.
     UnRegDRepCert(DRepCredential, Coin),
+    /// Conway: update a DRep's anchor metadata.
     UpdateDRepCert(DRepCredential, Nullable<Anchor>),
 }
 
+/// On-chain credential controlling a stake address.
 #[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Clone, Hash, Encode, Decode)]
 // !! NOTE / IMPORTANT !!
 // It is tempting to swap the order of the two constructors so that AddrKeyHash
@@ -72,59 +105,91 @@ pub enum Certificate {
 // avoid hard to troubleshoot issues down the line.
 #[cbor(flat)]
 pub enum StakeCredential {
+    /// Stake credential backed by a script hash.
     #[n(1)]
     ScriptHash(#[n(0)] ScriptHash),
+    /// Stake credential backed by a verification-key hash.
     #[n(0)]
     AddrKeyhash(#[n(0)] AddrKeyhash),
 }
 
+/// Hash of a stake pool's cold key (Blake2b-224).
 pub type PoolKeyhash = Hash<28>;
+/// Hash of a VRF verification key (Blake2b-256).
 pub type VrfKeyhash = Hash<32>;
+/// Credential identifying a DRep (same shape as a stake credential).
 pub type DRepCredential = StakeCredential;
+/// Cold credential of a constitutional-committee member.
 pub type CommitteeColdCredential = StakeCredential;
+/// Hot credential of a constitutional-committee member.
 pub type CommitteeHotCredential = StakeCredential;
+/// Hash of an address verification key (Blake2b-224).
 pub type AddrKeyhash = Hash<28>;
 
+/// Identity of a voter in a Conway governance vote.
 #[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Clone)]
 pub enum Voter {
+    /// Vote cast by a constitutional-committee key.
     ConstitutionalCommitteeKey(AddrKeyhash),
+    /// Vote cast by a constitutional-committee script.
     ConstitutionalCommitteeScript(ScriptHash),
+    /// Vote cast by a DRep key.
     DRepKey(AddrKeyhash),
+    /// Vote cast by a DRep script.
     DRepScript(ScriptHash),
+    /// Vote cast by a stake-pool operator.
     StakePoolKey(AddrKeyhash),
 }
 
+/// Plutus language version.
 #[derive(Encode, Decode, Debug, Clone, Eq, PartialEq)]
 #[cbor(index_only)]
 pub enum Language {
+    /// Plutus V1.
     #[n(0)]
     PlutusV1,
+    /// Plutus V2.
     #[n(1)]
     PlutusV2,
+    /// Plutus V3.
     #[n(2)]
     PlutusV3,
 }
 
+/// Generic on-chain script: a native script or a Plutus script of any version.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum PseudoScript<T1> {
+    /// Cardano native script (timelock and signature combinators).
     NativeScript(T1),
+    /// Plutus V1 script bytes.
     PlutusV1Script(PlutusScript<1>),
+    /// Plutus V2 script bytes.
     PlutusV2Script(PlutusScript<2>),
+    /// Plutus V3 script bytes.
     PlutusV3Script(PlutusScript<3>),
 }
 
+/// Raw bytes of a Plutus script of language version `VERSION`.
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 #[cbor(transparent)]
 pub struct PlutusScript<const VERSION: usize>(#[n(0)] pub Bytes);
 
+/// Native script — pre-Plutus combinators (signatures + timelocks).
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum NativeScript {
+    /// Require a signature from the given key hash.
     ScriptPubkey(AddrKeyhash),
+    /// Require every sub-script to be satisfied.
     ScriptAll(Vec<NativeScript>),
+    /// Require any sub-script to be satisfied.
     ScriptAny(Vec<NativeScript>),
+    /// Require at least `n` of the listed sub-scripts to be satisfied.
     ScriptNOfK(u32, Vec<NativeScript>),
+    /// Valid only at or after the given slot.
     InvalidBefore(u64),
+    /// Valid only before the given slot.
     InvalidHereafter(u64),
 }
 
+/// Script reference attached to a transaction output (CIP-33).
 pub type ScriptRef = PseudoScript<NativeScript>;

--- a/pallas-network/src/miniprotocols/localtxsubmission/server.rs
+++ b/pallas-network/src/miniprotocols/localtxsubmission/server.rs
@@ -166,8 +166,11 @@ where
     }
 }
 
+/// Decoded inbound request from the client.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Request<Tx> {
+    /// Client submitted a transaction for evaluation.
     Submit(Tx),
+    /// Client terminated the protocol.
     Done,
 }

--- a/pallas-network/src/miniprotocols/mod.rs
+++ b/pallas-network/src/miniprotocols/mod.rs
@@ -2,16 +2,27 @@
 
 mod common;
 
+/// Block-fetch mini-protocol: download block bodies for a given chain range.
 pub mod blockfetch;
+/// Chain-sync mini-protocol: follow a peer's chain and stream new blocks/headers.
 pub mod chainsync;
+/// Handshake mini-protocol: negotiate the protocol version on a fresh connection.
 pub mod handshake;
+/// Keep-alive mini-protocol: liveness pings to detect dead peers.
 pub mod keepalive;
+/// Local-message-notification mini-protocol (DMQ): receive notifications from the node.
 pub mod localmsgnotification;
+/// Local-message-submission mini-protocol (DMQ): submit messages to the node.
 pub mod localmsgsubmission;
+/// Local-state-query mini-protocol: query the node's ledger state at a given point.
 pub mod localstate;
+/// Local-tx-submission mini-protocol: submit transactions to a local node.
 pub mod localtxsubmission;
+/// Peer-sharing mini-protocol: discover other peers known to the connected node.
 pub mod peersharing;
+/// Tx-monitor mini-protocol: observe the local node's mempool.
 pub mod txmonitor;
+/// Tx-submission mini-protocol: gossip transactions between nodes.
 pub mod txsubmission;
 
 pub use common::*;

--- a/pallas-network/src/miniprotocols/peersharing/client.rs
+++ b/pallas-network/src/miniprotocols/peersharing/client.rs
@@ -5,42 +5,54 @@ use tracing::debug;
 use super::protocol::*;
 use crate::multiplexer;
 
+/// Errors produced by the peer-sharing client agent.
 #[derive(Error, Debug)]
 pub enum ClientError {
+    /// Tried to receive while we hold agency.
     #[error("attempted to receive message while agency is ours")]
     AgencyIsOurs,
 
+    /// Tried to send while the peer holds agency.
     #[error("attempted to send message while agency is theirs")]
     AgencyIsTheirs,
 
+    /// Inbound message is not valid for the current state.
     #[error("inbound message is not valid for current state")]
     InvalidInbound,
 
+    /// Outbound message is not valid for the current state.
     #[error("outbound message is not valid for current state")]
     InvalidOutbound,
 
+    /// Server returned a different number of peers than requested.
     #[error("requested amount mismatch")]
     RequestedAmountMismatch,
 
+    /// Underlying multiplexer error.
     #[error("error while sending or receiving data through the channel")]
     Plexer(multiplexer::Error),
 }
 
+/// Peer-sharing client agent.
 pub struct Client(State, multiplexer::ChannelBuffer);
 
 impl Client {
+    /// Build a client over a freshly subscribed agent channel.
     pub fn new(channel: multiplexer::AgentChannel) -> Self {
         Self(State::Idle, multiplexer::ChannelBuffer::new(channel))
     }
 
+    /// Current state-machine state.
     pub fn state(&self) -> &State {
         &self.0
     }
 
+    /// True if the protocol has terminated.
     pub fn is_done(&self) -> bool {
         self.0 == State::Done
     }
 
+    /// True if the client holds agency.
     pub fn has_agency(&self) -> bool {
         match &self.0 {
             State::Idle => true,
@@ -80,6 +92,7 @@ impl Client {
         }
     }
 
+    /// Low-level send.
     pub async fn send_message(&mut self, msg: &Message) -> Result<(), ClientError> {
         self.assert_agency_is_ours()?;
         self.assert_outbound_state(msg)?;
@@ -91,6 +104,7 @@ impl Client {
         Ok(())
     }
 
+    /// Low-level receive.
     pub async fn recv_message(&mut self) -> Result<Message, ClientError> {
         self.assert_agency_is_theirs()?;
         let msg = self.1.recv_full_msg().await.map_err(ClientError::Plexer)?;
@@ -99,6 +113,7 @@ impl Client {
         Ok(msg)
     }
 
+    /// Ask the peer to share up to `amount` known peer addresses.
     pub async fn send_share_request(&mut self, amount: Amount) -> Result<(), ClientError> {
         let msg = Message::ShareRequest(amount);
         self.send_message(&msg).await?;
@@ -108,6 +123,7 @@ impl Client {
         Ok(())
     }
 
+    /// Wait for the peer's `SharePeers` reply.
     pub async fn recv_peer_addresses(&mut self) -> Result<Vec<PeerAddress>, ClientError> {
         let msg = self.recv_message().await?;
         match msg {
@@ -124,6 +140,7 @@ impl Client {
         }
     }
 
+    /// Terminate the protocol.
     pub async fn send_done(&mut self) -> Result<(), ClientError> {
         let msg = Message::Done;
         self.send_message(&msg).await?;

--- a/pallas-network/src/miniprotocols/peersharing/protocol.rs
+++ b/pallas-network/src/miniprotocols/peersharing/protocol.rs
@@ -4,24 +4,36 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 
 use crate::miniprotocols::localstate::queries_v16::primitives::Port;
 
+/// Number of peer addresses requested or returned.
 pub type Amount = u8;
 
+/// Peer-sharing state-machine state.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum State {
+    /// Idle: client may request peers or terminate.
     Idle,
+    /// Server is gathering the requested number of peers.
     Busy(Amount),
+    /// Protocol terminated.
     Done,
 }
 
+/// An IPv4 or IPv6 peer endpoint.
 #[derive(Debug, PartialEq, Clone)]
 pub enum PeerAddress {
+    /// IPv4 address paired with a TCP port.
     V4(Ipv4Addr, Port),
+    /// IPv6 address paired with a TCP port.
     V6(Ipv6Addr, Port),
 }
 
+/// Peer-sharing protocol message.
 #[derive(Debug)]
 pub enum Message {
+    /// Client → server: ask for up to `Amount` peer addresses.
     ShareRequest(Amount),
+    /// Server → client: reply with the discovered peer addresses.
     SharePeers(Vec<PeerAddress>),
+    /// Client → server: terminate the protocol.
     Done,
 }

--- a/pallas-network/src/miniprotocols/peersharing/server.rs
+++ b/pallas-network/src/miniprotocols/peersharing/server.rs
@@ -5,35 +5,45 @@ use tracing::debug;
 use super::protocol::*;
 use crate::multiplexer;
 
+/// Errors produced by the peer-sharing server agent.
 #[derive(Error, Debug)]
 pub enum ServerError {
+    /// Tried to receive while we hold agency.
     #[error("attempted to receive message while agency is ours")]
     AgencyIsOurs,
 
+    /// Tried to send while the peer holds agency.
     #[error("attempted to send message while agency is theirs")]
     AgencyIsTheirs,
 
+    /// Inbound message is not valid for the current state.
     #[error("inbound message is not valid for current state")]
     InvalidInbound,
 
+    /// Outbound message is not valid for the current state.
     #[error("outbound message is not valid for current state")]
     InvalidOutbound,
 
+    /// Underlying multiplexer error.
     #[error("error while sending or receiving data through the channel")]
     Plexer(multiplexer::Error),
 }
 
+/// Peer-sharing server agent.
 pub struct Server(State, multiplexer::ChannelBuffer);
 
 impl Server {
+    /// Build a server over a freshly subscribed agent channel.
     pub fn new(channel: multiplexer::AgentChannel) -> Self {
         Self(State::Idle, multiplexer::ChannelBuffer::new(channel))
     }
 
+    /// Current state-machine state.
     pub fn state(&self) -> &State {
         &self.0
     }
 
+    /// True if the protocol has terminated.
     pub fn is_done(&self) -> bool {
         self.0 == State::Done
     }
@@ -77,6 +87,7 @@ impl Server {
         }
     }
 
+    /// Low-level send.
     pub async fn send_message(&mut self, msg: &Message) -> Result<(), ServerError> {
         self.assert_agency_is_ours()?;
         self.assert_outbound_state(msg)?;
@@ -88,6 +99,7 @@ impl Server {
         Ok(())
     }
 
+    /// Low-level receive.
     pub async fn recv_message(&mut self) -> Result<Message, ServerError> {
         self.assert_agency_is_theirs()?;
         let msg = self.1.recv_full_msg().await.map_err(ServerError::Plexer)?;
@@ -96,6 +108,7 @@ impl Server {
         Ok(msg)
     }
 
+    /// Wait for the next `ShareRequest` (or `Done`) and update state.
     pub async fn recv_share_request(&mut self) -> Result<Option<Amount>, ServerError> {
         let msg = self.recv_message().await?;
         match msg {
@@ -113,6 +126,7 @@ impl Server {
         }
     }
 
+    /// Reply to the pending share request with the given peer addresses.
     pub async fn send_peer_addresses(
         &mut self,
         response: Vec<PeerAddress>,

--- a/pallas-network/src/miniprotocols/txmonitor/client.rs
+++ b/pallas-network/src/miniprotocols/txmonitor/client.rs
@@ -4,35 +4,45 @@ use thiserror::*;
 use super::protocol::*;
 use crate::multiplexer;
 
+/// Errors produced by the tx-monitor client agent.
 #[derive(Error, Debug)]
 pub enum Error {
+    /// Tried to receive while we hold agency.
     #[error("attempted to receive message while agency is ours")]
     AgencyIsOurs,
 
+    /// Tried to send while the peer holds agency.
     #[error("attempted to send message while agency is theirs")]
     AgencyIsTheirs,
 
+    /// Inbound message is not valid for the current state.
     #[error("inbound message is not valid for current state")]
     InvalidInbound,
 
+    /// Outbound message is not valid for the current state.
     #[error("outbound message is not valid for current state")]
     InvalidOutbound,
 
+    /// Underlying multiplexer error.
     #[error("error while sending or receiving data through the channel")]
     Plexer(multiplexer::Error),
 }
 
+/// Tx-monitor client agent.
 pub struct Client(State, multiplexer::ChannelBuffer);
 
 impl Client {
+    /// Build a client over a freshly subscribed agent channel.
     pub fn new(channel: multiplexer::AgentChannel) -> Self {
         Self(State::Idle, multiplexer::ChannelBuffer::new(channel))
     }
 
+    /// Current state-machine state.
     pub fn state(&self) -> &State {
         &self.0
     }
 
+    /// True if the protocol has terminated.
     pub fn is_done(&self) -> bool {
         self.0 == State::Done
     }
@@ -85,6 +95,7 @@ impl Client {
         }
     }
 
+    /// Low-level send.
     pub async fn send_message(&mut self, msg: &Message) -> Result<(), Error> {
         self.assert_agency_is_ours()?;
         self.assert_outbound_state(msg)?;
@@ -93,6 +104,7 @@ impl Client {
         Ok(())
     }
 
+    /// Low-level receive.
     pub async fn recv_message(&mut self) -> Result<Message, Error> {
         self.assert_agency_is_theirs()?;
         let msg = self.1.recv_full_msg().await.map_err(Error::Plexer)?;
@@ -119,6 +131,7 @@ impl Client {
         }
     }
 
+    /// Acquire a fresh mempool snapshot and return the slot it was taken at.
     pub async fn acquire(&mut self) -> Result<Slot, Error> {
         self.send_acquire().await?;
         self.recv_while_acquiring().await
@@ -142,6 +155,7 @@ impl Client {
         }
     }
 
+    /// Ask whether a transaction with the given id is in the current snapshot.
     pub async fn query_has_tx(&mut self, id: TxId) -> Result<bool, Error> {
         self.send_request_has_tx(id).await?;
         self.recv_while_requesting_has_tx().await
@@ -165,6 +179,7 @@ impl Client {
         }
     }
 
+    /// Iterate to the next transaction in the snapshot.
     pub async fn query_next_tx(&mut self) -> Result<Option<Tx>, Error> {
         self.send_request_next_tx().await?;
         self.recv_while_requesting_next_tx().await
@@ -190,11 +205,13 @@ impl Client {
         }
     }
 
+    /// Ask for the mempool's current size and capacity.
     pub async fn query_size_and_capacity(&mut self) -> Result<MempoolSizeAndCapacity, Error> {
         self.send_request_size_and_capacity().await?;
         self.recv_while_requesting_size_and_capacity().await
     }
 
+    /// Release the current snapshot and return to the idle state.
     pub async fn release(&mut self) -> Result<(), Error> {
         let msg = Message::Release;
         self.send_message(&msg).await?;

--- a/pallas-network/src/miniprotocols/txmonitor/protocol.rs
+++ b/pallas-network/src/miniprotocols/txmonitor/protocol.rs
@@ -1,38 +1,65 @@
 use pallas_codec::utils::TagWrap;
 
+/// Absolute slot number used to tag a mempool snapshot.
 pub type Slot = u64;
+/// Transaction id rendered as a string (hex of the tx hash).
 pub type TxId = String;
+/// Era number, as carried in the multi-era transaction wrapper.
 pub type Era = u8;
+/// Raw CBOR bytes of a transaction body.
 pub type TxBody = pallas_codec::utils::Bytes;
+/// `(era, cbor-tag-24-wrapped body)` — the canonical mempool transaction shape.
 pub type Tx = (Era, TagWrap<TxBody, 24>);
 
+/// Tx-monitor state-machine state.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum State {
+    /// Idle, no snapshot acquired.
     Idle,
+    /// Awaiting acquisition of a mempool snapshot.
     Acquiring,
+    /// Snapshot acquired; ready for queries.
     Acquired,
+    /// Server is computing a response.
     Busy,
+    /// Protocol terminated.
     Done,
 }
 
+/// Mempool size accounting reported by `ResponseSizeAndCapacity`.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct MempoolSizeAndCapacity {
+    /// Maximum total transaction bytes the mempool will hold.
     pub capacity_in_bytes: u32,
+    /// Total bytes currently held in the mempool.
     pub size_in_bytes: u32,
+    /// Number of transactions currently in the mempool.
     pub number_of_txs: u32,
 }
 
+/// Tx-monitor protocol message.
 #[derive(Debug, Clone)]
 pub enum Message {
+    /// Client → server: acquire the current mempool snapshot (non-blocking).
     Acquire,
+    /// Client → server: acquire the next snapshot (blocks until it changes).
     AwaitAcquire,
+    /// Server → client: snapshot acquired at the given slot.
     Acquired(Slot),
+    /// Client → server: ask whether a specific transaction is in the snapshot.
     RequestHasTx(TxId),
+    /// Client → server: iterate to the next transaction in the snapshot.
     RequestNextTx,
+    /// Client → server: ask for mempool size and capacity.
     RequestSizeAndCapacity,
+    /// Server → client: answer to [`Message::RequestHasTx`].
     ResponseHasTx(bool),
+    /// Server → client: next transaction (or `None` if the iteration is exhausted).
     ResponseNextTx(Option<Tx>),
+    /// Server → client: answer to [`Message::RequestSizeAndCapacity`].
     ResponseSizeAndCapacity(MempoolSizeAndCapacity),
+    /// Client → server: release the current snapshot.
     Release,
+    /// Client → server: terminate the protocol.
     Done,
 }

--- a/pallas-network/src/miniprotocols/txsubmission/client.rs
+++ b/pallas-network/src/miniprotocols/txsubmission/client.rs
@@ -8,9 +8,13 @@ use super::{
     EraTxBody, EraTxId,
 };
 
+/// Decoded inbound request from the server, indicating what to reply with next.
 pub enum Request<TxId> {
+    /// Server is asking for `(ack, req)` tx ids in blocking mode.
     TxIds(u16, u16),
+    /// Server is asking for `(ack, req)` tx ids without blocking.
     TxIdsNonBlocking(u16, u16),
+    /// Server is asking for the full bodies of these tx ids.
     Txs(Vec<TxId>),
 }
 
@@ -32,6 +36,7 @@ impl<TxId, TxBody> GenericClient<TxId, TxBody>
 where
     Message<TxId, TxBody>: Fragment,
 {
+    /// Build a client over a freshly subscribed agent channel.
     pub fn new(channel: multiplexer::AgentChannel) -> Self {
         Self(
             State::Init,
@@ -41,10 +46,12 @@ where
         )
     }
 
+    /// Current state-machine state.
     pub fn state(&self) -> &State {
         &self.0
     }
 
+    /// True if the protocol has terminated.
     pub fn is_done(&self) -> bool {
         self.0 == State::Done
     }
@@ -90,6 +97,7 @@ where
         }
     }
 
+    /// Low-level send.
     pub async fn send_message(&mut self, msg: &Message<TxId, TxBody>) -> Result<(), Error> {
         self.assert_agency_is_ours()?;
         self.assert_outbound_state(msg)?;
@@ -98,6 +106,7 @@ where
         Ok(())
     }
 
+    /// Low-level receive.
     pub async fn recv_message(&mut self) -> Result<Message<TxId, TxBody>, Error> {
         self.assert_agency_is_theirs()?;
         let msg = self.1.recv_full_msg().await.map_err(Error::Plexer)?;
@@ -106,6 +115,7 @@ where
         Ok(msg)
     }
 
+    /// Send the opening `Init` message and transition to `Idle`.
     pub async fn send_init(&mut self) -> Result<(), Error> {
         let msg = Message::Init;
         self.send_message(&msg).await?;
@@ -114,6 +124,7 @@ where
         Ok(())
     }
 
+    /// Reply to a pending `RequestTxIds` with the available `(id, size)` pairs.
     pub async fn reply_tx_ids(&mut self, ids: Vec<TxIdAndSize<TxId>>) -> Result<(), Error> {
         let msg = Message::ReplyTxIds(ids);
         self.send_message(&msg).await?;
@@ -122,6 +133,7 @@ where
         Ok(())
     }
 
+    /// Reply to a pending `RequestTxs` with the full transaction bodies.
     pub async fn reply_txs(&mut self, txs: Vec<TxBody>) -> Result<(), Error> {
         let msg = Message::ReplyTxs(txs);
         self.send_message(&msg).await?;
@@ -130,6 +142,7 @@ where
         Ok(())
     }
 
+    /// Wait for the server's next `RequestTxIds` / `RequestTxs`.
     pub async fn next_request(&mut self) -> Result<Request<TxId>, Error> {
         match self.recv_message().await? {
             Message::RequestTxIds(blocking, ack, req) => match blocking {
@@ -150,6 +163,7 @@ where
         }
     }
 
+    /// Terminate the protocol.
     pub async fn send_done(&mut self) -> Result<(), Error> {
         let msg = Message::Done;
         self.send_message(&msg).await?;

--- a/pallas-network/src/miniprotocols/txsubmission/protocol.rs
+++ b/pallas-network/src/miniprotocols/txsubmission/protocol.rs
@@ -2,60 +2,85 @@ use thiserror::Error;
 
 use crate::multiplexer;
 
+/// Tx-submission state-machine state.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum State {
+    /// Initial state, awaiting the server's `Init` message.
     Init,
+    /// Idle: server may request tx ids or transactions.
     Idle,
+    /// Awaiting a non-blocking tx-id reply.
     TxIdsNonBlocking,
+    /// Awaiting a blocking tx-id reply (server waits for new txs to arrive).
     TxIdsBlocking,
+    /// Awaiting transaction bodies for previously announced ids.
     Txs,
+    /// Protocol terminated.
     Done,
 }
 
+/// Whether a tx-id request should block until new txs are available.
 pub type Blocking = bool;
 
+/// Number of transactions requested or returned.
 pub type TxCount = u16;
 
+/// Transaction size in bytes.
 pub type TxSizeInBytes = u32;
 
-// The bytes of a txId, tagged with an era number
+/// The bytes of a tx-id, tagged with the era number it was produced in.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct EraTxId(pub u16, pub Vec<u8>);
 
-// The bytes of a transaction, with an era number and some raw CBOR
+/// The bytes of a transaction body, tagged with the era number it was produced in.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct EraTxBody(pub u16, pub Vec<u8>);
 
+/// A transaction id paired with the size (in bytes) of its body.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TxIdAndSize<TxID>(pub TxID, pub TxSizeInBytes);
 
+/// Errors produced by the tx-submission protocol.
 #[derive(Error, Debug)]
 pub enum Error {
+    /// Tried to receive while we hold agency.
     #[error("attempted to receive message while agency is ours")]
     AgencyIsOurs,
 
+    /// Tried to send while the peer holds agency.
     #[error("attempted to send message while agency is theirs")]
     AgencyIsTheirs,
 
+    /// Inbound message is not valid for the current state.
     #[error("inbound message is not valid for current state")]
     InvalidInbound,
 
+    /// Outbound message is not valid for the current state.
     #[error("outbound message is not valid for current state")]
     InvalidOutbound,
 
+    /// Caller tried to re-initialize an already-running protocol.
     #[error("protocol is already initialized, no need to wait for init message")]
     AlreadyInitialized,
 
+    /// Underlying multiplexer error.
     #[error("error while sending or receiving data through the channel")]
     Plexer(multiplexer::Error),
 }
 
+/// Tx-submission protocol message.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Message<TxId, TxBody> {
+    /// Server → client: open the protocol.
     Init,
+    /// Server → client: request tx ids — `blocking`, `ack` (previously acknowledged), `req` (max new to return).
     RequestTxIds(Blocking, TxCount, TxCount),
+    /// Client → server: reply with available tx ids and their sizes.
     ReplyTxIds(Vec<TxIdAndSize<TxId>>),
+    /// Server → client: request full bodies for previously announced ids.
     RequestTxs(Vec<TxId>),
+    /// Client → server: reply with the requested transaction bodies.
     ReplyTxs(Vec<TxBody>),
+    /// Client → server: terminate the protocol.
     Done,
 }

--- a/pallas-network/src/miniprotocols/txsubmission/server.rs
+++ b/pallas-network/src/miniprotocols/txsubmission/server.rs
@@ -8,9 +8,13 @@ use super::{
 };
 use crate::multiplexer;
 
+/// Decoded inbound reply from the peer.
 pub enum Reply<TxId, TxBody> {
+    /// Peer returned available `(id, size)` pairs in response to `RequestTxIds`.
     TxIds(Vec<TxIdAndSize<TxId>>),
+    /// Peer returned full transaction bodies in response to `RequestTxs`.
     Txs(Vec<TxBody>),
+    /// Peer chose to terminate the protocol.
     Done,
 }
 
@@ -32,6 +36,7 @@ impl<TxId, TxBody> GenericServer<TxId, TxBody>
 where
     Message<TxId, TxBody>: Fragment,
 {
+    /// Build a server over a freshly subscribed agent channel.
     pub fn new(channel: multiplexer::AgentChannel) -> Self {
         Self(
             State::Init,
@@ -41,10 +46,12 @@ where
         )
     }
 
+    /// Current state-machine state.
     pub fn state(&self) -> &State {
         &self.0
     }
 
+    /// True if the protocol has terminated.
     pub fn is_done(&self) -> bool {
         self.0 == State::Done
     }
@@ -90,6 +97,7 @@ where
         }
     }
 
+    /// Low-level send.
     pub async fn send_message(&mut self, msg: &Message<TxId, TxBody>) -> Result<(), Error> {
         self.assert_agency_is_ours()?;
         self.assert_outbound_state(msg)?;
@@ -98,6 +106,7 @@ where
         Ok(())
     }
 
+    /// Low-level receive.
     pub async fn recv_message(&mut self) -> Result<Message<TxId, TxBody>, Error> {
         self.assert_agency_is_theirs()?;
         let msg = self.1.recv_full_msg().await.map_err(Error::Plexer)?;
@@ -106,6 +115,7 @@ where
         Ok(msg)
     }
 
+    /// Wait for the client's opening `Init` and transition to `Idle`.
     pub async fn wait_for_init(&mut self) -> Result<(), Error> {
         if self.0 != State::Init {
             return Err(Error::AlreadyInitialized);
@@ -118,6 +128,8 @@ where
         Ok(())
     }
 
+    /// Acknowledge `acknowledge` previously announced ids and request up to
+    /// `count` new ones; `blocking` controls whether the client may wait.
     pub async fn acknowledge_and_request_tx_ids(
         &mut self,
         blocking: Blocking,
@@ -134,6 +146,7 @@ where
         Ok(())
     }
 
+    /// Request the full bodies for a set of previously announced tx ids.
     pub async fn request_txs(&mut self, ids: Vec<TxId>) -> Result<(), Error> {
         let msg = Message::RequestTxs(ids);
         self.send_message(&msg).await?;
@@ -142,6 +155,7 @@ where
         Ok(())
     }
 
+    /// Wait for the client's next reply (ids, bodies, or done).
     pub async fn receive_next_reply(&mut self) -> Result<Reply<TxId, TxBody>, Error> {
         match self.recv_message().await? {
             Message::ReplyTxIds(ids_and_sizes) => {

--- a/pallas-network/src/multiplexer.rs
+++ b/pallas-network/src/multiplexer.rs
@@ -26,16 +26,23 @@ use tokio::io::{ReadHalf, WriteHalf};
 
 const HEADER_LEN: usize = 8;
 
+/// Wall-clock microseconds since the multiplexer started, used to stamp segments.
 pub type Timestamp = u32;
 
+/// Raw bytes of a single segment payload.
 pub type Payload = Vec<u8>;
 
+/// Mini-protocol channel identifier (16-bit).
 pub type Protocol = u16;
 
+/// 8-byte segment header that prefixes every multiplexed payload.
 #[derive(Debug)]
 pub struct Header {
+    /// Mini-protocol channel that owns the segment.
     pub protocol: Protocol,
+    /// Wall-clock microseconds since the multiplexer started.
     pub timestamp: Timestamp,
+    /// Length in bytes of the payload that follows this header.
     pub payload_len: u16,
 }
 
@@ -64,17 +71,24 @@ impl From<Header> for [u8; 8] {
     }
 }
 
+/// A single segment: header plus its raw payload bytes.
 pub struct Segment {
+    /// Segment header (protocol, timestamp, length).
     pub header: Header,
+    /// Raw payload bytes.
     pub payload: Payload,
 }
 
+/// Underlying transport carrying multiplexed segments.
 pub enum Bearer {
+    /// TCP socket (node-to-node).
     Tcp(tcp::TcpStream),
 
+    /// Unix domain socket (node-to-client on Unix).
     #[cfg(unix)]
     Unix(unix::UnixStream),
 
+    /// Windows named pipe (node-to-client on Windows).
     #[cfg(windows)]
     NamedPipe(NamedPipeClient),
 }
@@ -92,12 +106,15 @@ impl Bearer {
         Ok(())
     }
 
+    /// Connect a TCP bearer to `addr`, applying the default keep-alive and
+    /// no-delay socket settings.
     pub async fn connect_tcp(addr: impl tcp::ToSocketAddrs) -> Result<Self, tokio::io::Error> {
         let stream = tcp::TcpStream::connect(addr).await?;
         Self::configure_tcp(&stream)?;
         Ok(Self::Tcp(stream))
     }
 
+    /// Same as [`Self::connect_tcp`] but aborts with `TimedOut` after `timeout`.
     pub async fn connect_tcp_timeout(
         addr: impl tcp::ToSocketAddrs,
         timeout: std::time::Duration,
@@ -108,18 +125,21 @@ impl Bearer {
         }
     }
 
+    /// Accept the next TCP connection from `listener` as a bearer.
     pub async fn accept_tcp(listener: &tcp::TcpListener) -> IOResult<(Self, std::net::SocketAddr)> {
         let (stream, addr) = listener.accept().await?;
         Self::configure_tcp(&stream)?;
         Ok((Self::Tcp(stream), addr))
     }
 
+    /// Connect a Unix-domain bearer to `path`.
     #[cfg(unix)]
     pub async fn connect_unix(path: impl AsRef<std::path::Path>) -> IOResult<Self> {
         let stream = unix::UnixStream::connect(path).await?;
         Ok(Self::Unix(stream))
     }
 
+    /// Accept the next Unix-domain connection from `listener` as a bearer.
     #[cfg(unix)]
     pub async fn accept_unix(
         listener: &unix::UnixListener,
@@ -128,12 +148,14 @@ impl Bearer {
         Ok((Self::Unix(stream), addr))
     }
 
+    /// Connect to a Windows named pipe as a bearer.
     #[cfg(windows)]
     pub fn connect_named_pipe(pipe_name: impl AsRef<std::ffi::OsStr>) -> IOResult<Self> {
         let client = tokio::net::windows::named_pipe::ClientOptions::new().open(&pipe_name)?;
         Ok(Self::NamedPipe(client))
     }
 
+    /// Split the bearer into independent read and write halves.
     pub fn into_split(self) -> (BearerReadHalf, BearerWriteHalf) {
         match self {
             Bearer::Tcp(x) => {
@@ -159,12 +181,16 @@ impl Bearer {
     }
 }
 
+/// Read half of a split [`Bearer`].
 pub enum BearerReadHalf {
+    /// TCP read half.
     Tcp(tcp::tcp::OwnedReadHalf),
 
+    /// Unix-domain read half.
     #[cfg(unix)]
     Unix(unix::unix::OwnedReadHalf),
 
+    /// Named-pipe read half (Windows).
     #[cfg(windows)]
     NamedPipe(ReadHalf<NamedPipeClient>),
 }
@@ -183,12 +209,16 @@ impl BearerReadHalf {
     }
 }
 
+/// Write half of a split [`Bearer`].
 pub enum BearerWriteHalf {
+    /// TCP write half.
     Tcp(tcp::tcp::OwnedWriteHalf),
 
+    /// Unix-domain write half.
     #[cfg(unix)]
     Unix(unix::unix::OwnedWriteHalf),
 
+    /// Named-pipe write half (Windows).
     #[cfg(windows)]
     NamedPipe(WriteHalf<NamedPipeClient>),
 }
@@ -219,32 +249,42 @@ impl BearerWriteHalf {
     }
 }
 
+/// Errors produced by the multiplexer and its agent channels.
 #[derive(Debug, Error)]
 pub enum Error {
+    /// The bearer returned EOF before a segment could be fully read.
     #[error("no data available in bearer to complete segment")]
     EmptyBearer,
 
+    /// Underlying bearer I/O error.
     #[error("bearer I/O error")]
     BearerIo(tokio::io::Error),
 
+    /// Failed to decode a message off the wire.
     #[error("failure to encode channel message")]
     Decoding(String),
 
+    /// Failed to encode a message for the wire.
     #[error("failure to decode channel message")]
     Encoding(String),
 
+    /// Agent could not push an outbound chunk to the muxer for `Protocol`.
     #[error("agent failed to enqueue chunk for protocol {0}")]
     AgentEnqueue(Protocol, Payload),
 
+    /// Agent could not pull an inbound chunk from the demuxer.
     #[error("agent failed to dequeue chunk")]
     AgentDequeue,
 
+    /// Demuxer could not deliver an inbound chunk to the subscribed agent.
     #[error("plexer failed to dumux chunk for protocol {0}")]
     PlexerDemux(Protocol, Payload),
 
+    /// Muxer could not write a chunk to the bearer.
     #[error("plexer failed to mux chunk")]
     PlexerMux,
 
+    /// Aborting the spawned muxer / demuxer tasks failed.
     #[error("failure to abort the plexer threads")]
     AbortFailure,
 }
@@ -254,14 +294,17 @@ type Egress = HashMap<Protocol, EgressChannel>;
 
 const EGRESS_MSG_QUEUE_BUFFER: usize = 100;
 
+/// Reads segments off the bearer and dispatches them to subscribed agents.
 pub struct Demuxer(BearerReadHalf, Egress);
 
 impl Demuxer {
+    /// Build a demuxer over the read half of a bearer.
     pub fn new(bearer: BearerReadHalf) -> Self {
         let egress = HashMap::new();
         Self(bearer, egress)
     }
 
+    /// Read the next segment off the bearer and return its `(protocol, payload)`.
     pub async fn read_segment(&mut self) -> Result<(Protocol, Payload), Error> {
         trace!("waiting for segment header");
         let mut buf = vec![0u8; HEADER_LEN];
@@ -291,6 +334,8 @@ impl Demuxer {
         Ok(())
     }
 
+    /// Register an agent's interest in a protocol channel and return the
+    /// receiver it will pull inbound payloads from.
     pub fn subscribe(&mut self, protocol: Protocol) -> tokio::sync::mpsc::Receiver<Payload> {
         let (sender, recv) = tokio::sync::mpsc::channel(EGRESS_MSG_QUEUE_BUFFER);
 
@@ -301,12 +346,14 @@ impl Demuxer {
         recv
     }
 
+    /// Read one segment and dispatch it. Returns `Ok` after a single iteration.
     pub async fn tick(&mut self) -> Result<(), Error> {
         let (protocol, payload) = self.read_segment().await?;
         trace!(protocol, "demux happening");
         self.demux(protocol, payload).await
     }
 
+    /// Run the demux loop until an error occurs.
     pub async fn run(&mut self) -> Result<(), Error> {
         loop {
             if let Err(err) = self.tick().await {
@@ -325,9 +372,11 @@ type Clock = Instant;
 
 const INGRESS_MSG_QUEUE_BUFFER: usize = 100;
 
+/// Collects payloads from all agents and writes them to the bearer as segments.
 pub struct Muxer(BearerWriteHalf, Clock, Ingress);
 
 impl Muxer {
+    /// Build a muxer over the write half of a bearer.
     pub fn new(bearer: BearerWriteHalf) -> Self {
         let ingress = tokio::sync::mpsc::channel(INGRESS_MSG_QUEUE_BUFFER);
         let clock = Instant::now();
@@ -350,6 +399,7 @@ impl Muxer {
         Ok(())
     }
 
+    /// Write a single `(protocol, payload)` pair to the bearer as one segment.
     pub async fn mux(&mut self, msg: (Protocol, Payload)) -> Result<(), Error> {
         self.write_segment(msg.0, &msg.1)
             .await
@@ -366,10 +416,12 @@ impl Muxer {
         Ok(())
     }
 
+    /// Clone the ingress sender so an agent can push outbound payloads here.
     pub fn clone_sender(&self) -> tokio::sync::mpsc::Sender<(Protocol, Payload)> {
         self.2 .0.clone()
     }
 
+    /// Take one queued message and write it as a segment.
     pub async fn tick(&mut self) -> Result<(), Error> {
         let msg = self.2 .1.recv().await;
 
@@ -381,6 +433,7 @@ impl Muxer {
         Ok(())
     }
 
+    /// Run the mux loop until an error occurs.
     pub async fn run(&mut self) -> Result<(), Error> {
         loop {
             if let Err(err) = self.tick().await {
@@ -393,6 +446,8 @@ impl Muxer {
 type ToPlexerPort = tokio::sync::mpsc::Sender<(Protocol, Payload)>;
 type FromPlexerPort = tokio::sync::mpsc::Receiver<Payload>;
 
+/// Bidirectional channel exposed to a mini-protocol agent: send raw chunks out
+/// through the muxer and receive inbound chunks from the demuxer.
 pub struct AgentChannel {
     protocol: Protocol,
     to_plexer: ToPlexerPort,
@@ -424,6 +479,7 @@ impl AgentChannel {
         }
     }
 
+    /// Push an outbound chunk to the muxer for this protocol.
     pub async fn enqueue_chunk(&mut self, chunk: Payload) -> Result<(), Error> {
         self.to_plexer
             .send((self.protocol, chunk))
@@ -431,29 +487,34 @@ impl AgentChannel {
             .map_err(|SendError((protocol, payload))| Error::AgentEnqueue(protocol, payload))
     }
 
+    /// Pull the next inbound chunk for this protocol from the demuxer.
     pub async fn dequeue_chunk(&mut self) -> Result<Payload, Error> {
         self.from_plexer.recv().await.ok_or(Error::AgentDequeue)
     }
 }
 
+/// Handle to the spawned muxer and demuxer tasks of a running [`Plexer`].
 pub struct RunningPlexer {
     demuxer: JoinHandle<Result<(), Error>>,
     muxer: JoinHandle<Result<(), Error>>,
 }
 
 impl RunningPlexer {
+    /// Abort the muxer and demuxer tasks.
     pub async fn abort(self) {
         self.demuxer.abort();
         self.muxer.abort();
     }
 }
 
+/// Pairs a [`Demuxer`] and a [`Muxer`] sharing a single bearer.
 pub struct Plexer {
     demuxer: Demuxer,
     muxer: Muxer,
 }
 
 impl Plexer {
+    /// Build a plexer over the given bearer.
     pub fn new(bearer: Bearer) -> Self {
         let (r, w) = bearer.into_split();
 
@@ -463,18 +524,22 @@ impl Plexer {
         }
     }
 
+    /// Open a client-side agent channel on the given protocol id.
     pub fn subscribe_client(&mut self, protocol: Protocol) -> AgentChannel {
         let to_plexer = self.muxer.clone_sender();
         let from_plexer = self.demuxer.subscribe(protocol ^ 0x8000);
         AgentChannel::for_client(protocol, to_plexer, from_plexer)
     }
 
+    /// Open a server-side agent channel on the given protocol id.
     pub fn subscribe_server(&mut self, protocol: Protocol) -> AgentChannel {
         let to_plexer = self.muxer.clone_sender();
         let from_plexer = self.demuxer.subscribe(protocol);
         AgentChannel::for_server(protocol ^ 0x8000, to_plexer, from_plexer)
     }
 
+    /// Spawn the muxer and demuxer loops on the current Tokio runtime and
+    /// return a handle for aborting them.
     pub fn spawn(self) -> RunningPlexer {
         let mut demuxer = self.demuxer;
         let mut muxer = self.muxer;
@@ -518,6 +583,7 @@ pub struct ChannelBuffer {
 }
 
 impl ChannelBuffer {
+    /// Wrap a raw [`AgentChannel`] in a message-aware buffer.
     pub fn new(channel: AgentChannel) -> Self {
         Self {
             channel,
@@ -571,6 +637,7 @@ impl ChannelBuffer {
         }
     }
 
+    /// Discard the buffer and return the underlying raw channel.
     pub fn unwrap(self) -> AgentChannel {
         self.channel
     }

--- a/pallas-network2/src/lib.rs
+++ b/pallas-network2/src/lib.rs
@@ -1,4 +1,89 @@
-//! P2P Network stack compatible with the Ouroboros protocol
+//! A new take on the Ouroboros networking stack that prioritises P2P
+//! operation over the *client / server* shape used by `pallas-network`.
+//!
+//! The public API is split between an [`Interface`] (where IO happens) and a
+//! [`Behavior`] (the business logic), reconciled by a [`Manager`] — a layout
+//! inspired by libp2p's swarm.
+//!
+//! Once this crate is thoroughly tested and adopted by downstream clients,
+//! `network2` is intended to replace the original `pallas-network`.
+//!
+//! # Usage
+//!
+//! A typical setup pairs a transport (an [`Interface`] impl, e.g. the
+//! TCP-backed [`interface::TcpInterface`]) with a protocol (a [`Behavior`]
+//! impl, e.g. the node-to-node [`behavior::InitiatorBehavior`]) and drives
+//! both through a [`Manager`]. The manager polls the interface for IO
+//! events, hands them to the behavior, and pushes any commands the
+//! behavior emits back at the interface — leaving you to consume the
+//! behavior's external events.
+//!
+//! ```ignore
+//! use pallas_network2::{
+//!     behavior::{AnyMessage, InitiatorBehavior, InitiatorCommand, InitiatorEvent},
+//!     interface::TcpInterface,
+//!     Manager, PeerId,
+//! };
+//!
+//! let interface = TcpInterface::<AnyMessage>::new();
+//! let behavior  = InitiatorBehavior::default();
+//!
+//! let mut manager = Manager::new(interface, behavior);
+//!
+//! manager.execute(InitiatorCommand::IncludePeer(
+//!     "relays-new.cardano-mainnet.iohk.io:3001".parse::<PeerId>().unwrap(),
+//! ));
+//!
+//! while let Some(event) = manager.poll_next().await {
+//!     match event {
+//!         InitiatorEvent::PeerInitialized(pid, _) => println!("up: {pid}"),
+//!         InitiatorEvent::BlockHeaderReceived(pid, header, _) => {
+//!             println!("hdr from {pid}: {} bytes", header.cbor.len());
+//!         }
+//!         _ => {}
+//!     }
+//! }
+//! ```
+//!
+//! # Overview
+//!
+//! - [`Manager`] — drives a paired [`Interface`] + [`Behavior`].
+//!   [`Manager::poll_next`] advances IO and the behavior;
+//!   [`Manager::execute`] forwards an external command to the behavior.
+//! - [`Interface`] trait — the IO side. Receives [`InterfaceCommand`]
+//!   (`Connect` / `Send` / `Disconnect`) and yields [`InterfaceEvent`]
+//!   (`Connected` / `Disconnected` / `Sent` / `Recv` / `Error` / `Idle`).
+//! - [`Behavior`] trait — the protocol logic. Defines its own `Event`,
+//!   `Command`, `PeerState`, and `Message`, and emits [`BehaviorOutput`]s.
+//! - [`Message`] trait — describes a mini-protocol message (channel id +
+//!   payload encoding).
+//! - [`OutboundQueue`] — convenience queue of pending [`BehaviorOutput`]s
+//!   ready to be polled by the manager.
+//! - [`PeerId`], [`Channel`], [`Payload`], [`MAX_SEGMENT_PAYLOAD_LENGTH`] —
+//!   the primitive vocabulary.
+//!
+//! ## Modules
+//!
+//! - [`bearer`] — low-level transport for reading and writing multiplexed
+//!   segments.
+//! - [`interface`] — [`Interface`] implementations for TCP connections.
+//! - [`behavior`] — opinionated [`Behavior`] implementations for Cardano
+//!   stacks.
+//! - [`protocol`] — the Ouroboros mini-protocol definitions (handshake,
+//!   chainsync, blockfetch, …).
+//!
+//! # Feature flags
+//!
+//! - `emulation` — enables the `emulation` module, an in-memory test
+//!   harness for exercising behaviors without real network IO.
+//!
+//! # Usage as part of `pallas`
+//!
+//! When depending on the umbrella [`pallas`] crate (with the `network2`
+//! feature), this crate is re-exported as `pallas::network2`.
+//!
+//! [`pallas`]: https://crates.io/crates/pallas
+
 use std::{fmt::Debug, pin::Pin};
 
 use futures::{

--- a/pallas-primitives/src/lib.rs
+++ b/pallas-primitives/src/lib.rs
@@ -445,9 +445,11 @@ pub type UnitInterval = RationalNumber;
 #[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct VrfCert(
     /// VRF output bytes.
-    #[n(0)] pub Bytes,
+    #[n(0)]
+    pub Bytes,
     /// VRF proof bytes.
-    #[n(1)] pub Bytes,
+    #[n(1)]
+    pub Bytes,
 );
 
 /// Hash of a VRF verification key (Blake2b-256).

--- a/pallas-primitives/src/lib.rs
+++ b/pallas-primitives/src/lib.rs
@@ -1,11 +1,74 @@
-//! Ledger primitives and cbor codec for the Cardano eras
+//! Era-aware Cardano ledger types with their CBOR codecs.
+//!
+//! This is the data layer that the rest of the Pallas ledger crates sit on:
+//! [`pallas-traverse`] gives you a multi-era read API over these types,
+//! [`pallas-validate`] applies ledger rules to them, and [`pallas-txbuilder`]
+//! builds new ones.
+//!
+//! If you need raw, era-specific access to a `Tx`, `Block`, or `PlutusData`,
+//! you want this crate. If you'd rather work over many eras through one
+//! interface, reach for [`pallas-traverse`].
+//!
+//! [`pallas-traverse`]: https://crates.io/crates/pallas-traverse
+//! [`pallas-validate`]: https://crates.io/crates/pallas-validate
+//! [`pallas-txbuilder`]: https://crates.io/crates/pallas-txbuilder
+//!
+//! # Usage
+//!
+//! ```no_run
+//! use pallas_codec::minicbor;
+//! use pallas_primitives::conway;
+//!
+//! # let cbor_bytes: Vec<u8> = vec![];
+//! let tx: conway::Tx = minicbor::decode(&cbor_bytes)?;
+//!
+//! for input in tx.transaction_body.inputs.iter() {
+//!     println!("{:?}#{}", input.transaction_id, input.index);
+//! }
+//! # Ok::<_, Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! # Overview
+//!
+//! - [`byron`], [`alonzo`], [`babbage`], [`conway`] — one module per era,
+//!   each exposing the era's `Block`, `Tx`, `TransactionInput`,
+//!   `TransactionOutput`, `Value`, `Certificate`, `Metadata`, witness sets,
+//!   and so on.
+//! - `plutus_data` — re-exported [`PlutusData`], [`BigInt`], and helpers
+//!   shared across eras.
+//! - `framework` — common type aliases and codec primitives
+//!   ([`AddrKeyhash`], [`Coin`], [`PolicyId`], [`RationalNumber`],
+//!   [`StakeCredential`], [`TransactionInput`], [`ExUnits`],
+//!   [`PlutusScript`], …).
+//! - Re-exports from [`pallas-codec`] ([`Bytes`], [`KeepRaw`],
+//!   [`KeyValuePairs`], [`NonEmptySet`], [`Set`], [`Nullable`], …) and
+//!   [`pallas-crypto`] ([`struct@Hash`]).
+//!
+//! [`pallas-codec`]: https://crates.io/crates/pallas-codec
+//! [`pallas-crypto`]: https://crates.io/crates/pallas-crypto
+//!
+//! # Feature flags
+//!
+//! - `relaxed` — relax some validation invariants applied during decoding;
+//!   useful for round-tripping non-canonical historical artifacts.
+//!
+//! # Usage as part of `pallas`
+//!
+//! When depending on the umbrella [`pallas`] crate, this crate is re-exported
+//! as `pallas::ledger::primitives`.
+//!
+//! [`pallas`]: https://crates.io/crates/pallas
 
 mod framework;
 mod plutus_data;
 
+/// Ledger primitives for the Alonzo era (smart contracts).
 pub mod alonzo;
+/// Ledger primitives for the Babbage era (reference inputs / inline datums).
 pub mod babbage;
+/// Ledger primitives for the Byron era.
 pub mod byron;
+/// Ledger primitives for the Conway era (governance).
 pub mod conway;
 pub use plutus_data::*;
 
@@ -26,53 +89,77 @@ use std::collections::BTreeMap;
 
 // ----- Common type definitions
 
+/// Hash of a Cardano address verification key (Blake2b-224).
 pub type AddrKeyhash = Hash<28>;
 
+/// Token name within a multi-asset bundle (raw bytes, up to 32 long).
 pub type AssetName = Bytes;
 
+/// Quantity in lovelace.
 pub type Coin = u64;
 
+/// Plutus cost model: ordered list of per-primitive cost coefficients.
 pub type CostModel = Vec<i64>;
 
+/// Hash of a Plutus datum (Blake2b-256).
 pub type DatumHash = Hash<32>;
 
+/// DNS name (A or SRV record) used in relay declarations.
 pub type DnsName = String;
 
+/// Epoch number on the Cardano chain.
 pub type Epoch = u64;
 
+/// Plutus script execution budget: memory and step units.
 #[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone, Copy)]
 pub struct ExUnits {
+    /// Memory units consumed.
     #[n(0)]
     pub mem: u64,
+    /// CPU step units consumed.
     #[n(1)]
     pub steps: u64,
 }
 
+/// Per-unit prices used to convert [`ExUnits`] into fee lovelace.
 #[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct ExUnitPrices {
+    /// Price per memory unit.
     #[n(0)]
     pub mem_price: PositiveInterval,
 
+    /// Price per CPU step.
     #[n(1)]
     pub step_price: PositiveInterval,
 }
 
+/// Hash identifying a genesis configuration.
 pub type Genesishash = Bytes;
 
+/// Hash of a genesis delegate certificate.
 pub type GenesisDelegateHash = Bytes;
 
+/// IPv4 address bytes (4 bytes, big-endian).
 pub type IPv4 = Bytes;
 
+/// IPv6 address bytes (16 bytes, big-endian).
 pub type IPv6 = Bytes;
 
+/// Transaction metadata map, keyed by label.
 pub type Metadata = BTreeMap<MetadatumLabel, Metadatum>;
 
+/// Single metadata value of any supported CBOR shape.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum Metadatum {
+    /// Integer (signed or unsigned, up to 64 bits).
     Int(Int),
+    /// Raw byte string.
     Bytes(Bytes),
+    /// UTF-8 text string.
     Text(String),
+    /// Ordered list of metadata values.
     Array(Vec<Metadatum>),
+    /// Map of metadata values keyed by metadata values.
     Map(KeyValuePairs<Metadatum, Metadatum>),
 }
 
@@ -86,15 +173,19 @@ codec_by_datatype! {
     ()
 }
 
+/// Top-level metadata label (CIP-10 / CIP-25 / etc.).
 pub type MetadatumLabel = u64;
 
+/// The network this artifact targets (encoded as a small CBOR enum).
 #[derive(
     Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy,
 )]
 #[cbor(index_only)]
 pub enum NetworkId {
+    /// The Cardano testnet.
     #[n(0)]
     Testnet,
+    /// The Cardano mainnet.
     #[n(1)]
     Mainnet,
 }
@@ -120,25 +211,32 @@ impl TryFrom<u8> for NetworkId {
     }
 }
 
+/// Praos nonce used as input to the leader-selection schedule.
 #[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct Nonce {
+    /// Discriminator selecting how the nonce was produced.
     #[n(0)]
     pub variant: NonceVariant,
 
+    /// Hash payload, present when `variant` is [`NonceVariant::Nonce`].
     #[n(1)]
     pub hash: Option<Hash<32>>,
 }
 
+/// Discriminator for [`Nonce`]: neutral (genesis) or hashed.
 #[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
 #[cbor(index_only)]
 pub enum NonceVariant {
+    /// Initial neutral nonce, with no hash payload.
     #[n(0)]
     NeutralNonce,
 
+    /// A hashed nonce; the payload lives in [`Nonce::hash`].
     #[n(1)]
     Nonce,
 }
 
+/// Raw bytes of a Plutus script of language version `VERSION` (1, 2, or 3).
 #[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
 #[cbor(transparent)]
 pub struct PlutusScript<const VERSION: usize>(pub Bytes);
@@ -149,30 +247,42 @@ impl<const VERSION: usize> AsRef<[u8]> for PlutusScript<VERSION> {
     }
 }
 
+/// Hash of a minting policy (Blake2b-224).
 pub type PolicyId = Hash<28>;
 
+/// Hash of a stake pool's cold key (Blake2b-224).
 pub type PoolKeyhash = Hash<28>;
 
+/// Stake pool metadata reference: URL plus the hash of the pointed-to JSON.
 #[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct PoolMetadata {
+    /// URL serving the pool metadata JSON.
     #[n(0)]
     pub url: String,
 
+    /// Hash of the JSON document served at `url`.
     #[n(1)]
     pub hash: PoolMetadataHash,
 }
 
+/// Hash of stake pool metadata (Blake2b-256).
 pub type PoolMetadataHash = Bytes;
 
+/// TCP/UDP port number.
 pub type Port = u32;
 
+/// Rational number guaranteed to be strictly positive.
 pub type PositiveInterval = RationalNumber;
 
+/// Protocol version: `(major, minor)`.
 pub type ProtocolVersion = (u64, u64);
 
+/// On-chain rational number, encoded as a CBOR tag-30 array of `[num, den]`.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct RationalNumber {
+    /// Numerator of the rational.
     pub numerator: u64,
+    /// Denominator of the rational.
     pub denominator: u64,
 }
 
@@ -202,10 +312,14 @@ impl<C> minicbor::encode::Encode<C> for RationalNumber {
     }
 }
 
+/// Network endpoint declared by a stake pool's relay.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum Relay {
+    /// IP-based relay with optional port and either or both IPv4/IPv6.
     SingleHostAddr(Option<Port>, Option<IPv4>, Option<IPv6>),
+    /// DNS A-record relay with optional port and a hostname.
     SingleHostName(Option<Port>, DnsName),
+    /// DNS SRV-record relay (port and host both come from the SRV record).
     MultiHostName(DnsName),
 }
 
@@ -267,8 +381,10 @@ impl<C> minicbor::encode::Encode<C> for Relay {
     }
 }
 
+/// Reward-account bytes (network header byte plus stake-credential hash).
 pub type RewardAccount = Bytes;
 
+/// Hash of a script (Blake2b-224).
 pub type ScriptHash = Hash<28>;
 
 #[derive(
@@ -285,15 +401,20 @@ pub type ScriptHash = Hash<28>;
 // StakeCredential will be ordered. So, it is crucial to preserve this quirks to
 // avoid hard to troubleshoot issues down the line.
 #[cbor(flat)]
+/// On-chain credential controlling a stake address: a script or a key hash.
 pub enum StakeCredential {
+    /// Stake credential backed by a script hash.
     #[n(1)]
     ScriptHash(#[n(0)] ScriptHash),
+    /// Stake credential backed by a verification-key hash.
     #[n(0)]
     AddrKeyhash(#[n(0)] AddrKeyhash),
 }
 
+/// Index of a transaction within its containing block.
 pub type TransactionIndex = u32;
 
+/// Reference to a transaction output: `(tx_hash, output_index)`.
 #[derive(
     Serialize,
     Deserialize,
@@ -308,16 +429,26 @@ pub type TransactionIndex = u32;
     std::hash::Hash,
 )]
 pub struct TransactionInput {
+    /// Hash of the transaction that produced the output.
     #[n(0)]
     pub transaction_id: Hash<32>,
 
+    /// Index of the output within that transaction.
     #[n(1)]
     pub index: u64,
 }
 
+/// Rational number constrained to the closed interval [0, 1].
 pub type UnitInterval = RationalNumber;
 
+/// VRF certificate: the output bytes followed by the proof bytes.
 #[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
-pub struct VrfCert(#[n(0)] pub Bytes, #[n(1)] pub Bytes);
+pub struct VrfCert(
+    /// VRF output bytes.
+    #[n(0)] pub Bytes,
+    /// VRF proof bytes.
+    #[n(1)] pub Bytes,
+);
 
+/// Hash of a VRF verification key (Blake2b-256).
 pub type VrfKeyhash = Hash<32>;

--- a/pallas-traverse/src/lib.rs
+++ b/pallas-traverse/src/lib.rs
@@ -1,4 +1,66 @@
-//! Utilities to traverse over multi-era block data
+//! A read-only, era-agnostic view over Cardano blocks and transactions.
+//!
+//! Where [`pallas-primitives`] exposes the raw typed CBOR per era, this crate
+//! hides the era split behind `MultiEra*` enums so a single piece of
+//! indexing or analysis code can run against everything from Byron to
+//! Conway.
+//!
+//! This is the read side of the ledger. For transaction construction see
+//! [`pallas-txbuilder`]; for ledger-rule validation see [`pallas-validate`].
+//!
+//! [`pallas-primitives`]: https://crates.io/crates/pallas-primitives
+//! [`pallas-txbuilder`]: https://crates.io/crates/pallas-txbuilder
+//! [`pallas-validate`]: https://crates.io/crates/pallas-validate
+//!
+//! # Usage
+//!
+//! ```no_run
+//! use pallas_traverse::MultiEraBlock;
+//!
+//! # let cbor_bytes: Vec<u8> = vec![];
+//! let block = MultiEraBlock::decode(&cbor_bytes)?;
+//!
+//! println!("era={:?} slot={} hash={}", block.era(), block.slot(), block.hash());
+//!
+//! for tx in block.txs() {
+//!     for output in tx.outputs() {
+//!         println!("  → {} lovelace", output.lovelace_amount());
+//!     }
+//! }
+//! # Ok::<_, Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! # Overview
+//!
+//! - [`MultiEraBlock`], [`MultiEraTx`], [`MultiEraHeader`] — top-level entry
+//!   points with `decode` / `decode_for_era` constructors.
+//! - [`MultiEraInput`], [`MultiEraOutput`], [`MultiEraValue`],
+//!   [`MultiEraAsset`], [`MultiEraPolicyAssets`] — per-piece views.
+//! - [`MultiEraCert`], [`MultiEraRedeemer`], [`MultiEraWithdrawals`],
+//!   [`MultiEraSigners`], [`MultiEraMeta`], [`MultiEraUpdate`],
+//!   [`MultiEraProposal`], [`MultiEraGovAction`] — the rest of the tx
+//!   surface, normalised across eras.
+//! - [`Era`] and [`Feature`] — discriminators for "which era is this" and
+//!   "does this era support X" (multi-assets, smart contracts, CIP-1694, …).
+//! - Trait-driven hashing: [`ComputeHash`] and [`OriginalHash`] give a
+//!   uniform way to take Blake2b digests of typed structures.
+//! - Per-aspect submodules for deeper helpers: [`block`], [`tx`], [`input`],
+//!   [`output`], [`assets`], [`value`], [`cert`], [`redeemers`],
+//!   [`witnesses`], [`signers`], [`hashes`], [`fees`], [`governance`],
+//!   [`time`], [`header`], [`meta`], [`auxiliary`], [`probe`], [`size`],
+//!   [`withdrawals`], [`wellknown`].
+//!
+//! # Feature flags
+//!
+//! - `unstable` — exposes APIs that are not yet considered stable and may
+//!   change between minor releases.
+//!
+//! # Usage as part of `pallas`
+//!
+//! When depending on the umbrella [`pallas`] crate, this crate is re-exported
+//! as `pallas::ledger::traverse`.
+//!
+//! [`pallas`]: https://crates.io/crates/pallas
 
 use pallas_codec::utils::NonZeroInt;
 use pallas_codec::utils::PositiveCoin;
@@ -13,237 +75,358 @@ use pallas_primitives::{alonzo, babbage, byron, conway};
 
 mod support;
 
+/// Helpers for inspecting native and Plutus assets inside outputs and mints.
 pub mod assets;
+/// Helpers for transaction auxiliary data (metadata, native scripts, plutus scripts).
 pub mod auxiliary;
+/// Block-level traversal: era detection, header access, transaction iteration.
 pub mod block;
+/// Helpers for inspecting on-chain certificates across eras.
 pub mod cert;
+/// Helpers for Cardano ledger eras and feature gating.
 pub mod era;
+/// Fee inspection and computation helpers.
 pub mod fees;
+/// Helpers for Conway governance actions, votes, and proposals.
 pub mod governance;
+/// Stable hash computation for ledger entities (`ComputeHash`, `OriginalHash`).
 pub mod hashes;
+/// Block-header traversal across era-specific header shapes.
 pub mod header;
+/// Helpers for transaction inputs across eras.
 pub mod input;
+/// Helpers for transaction metadata.
 pub mod meta;
+/// Helpers for transaction outputs across eras.
 pub mod output;
+/// Era detection by probing CBOR shape.
 pub mod probe;
+/// Helpers for Plutus redeemers.
 pub mod redeemers;
+/// Helpers for required-signer hashes.
 pub mod signers;
+/// Size accounting helpers for transactions and blocks.
 pub mod size;
+/// Slot / epoch / wall-clock conversion helpers.
 pub mod time;
+/// Transaction-level traversal: inputs, outputs, witnesses, etc.
 pub mod tx;
+/// Helpers for protocol-parameter update proposals.
 pub mod update;
+/// Helpers for ada plus multi-asset values across eras.
 pub mod value;
+/// Helpers for reward-account withdrawals.
 pub mod withdrawals;
+/// Helpers for Plutus and native witnesses.
 pub mod witnesses;
 
 // TODO: move to genesis crate
+/// Well-known genesis hashes and parameter snapshots (will move to a genesis crate).
 pub mod wellknown;
 
+/// The Cardano ledger eras in chronological order.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum Era {
+    /// The original era (no staking, no multi-assets).
     Byron,
+    /// Introduces staking, delegation, and reward accounting.
     Shelley,
-    Allegra, // time-locks
-    Mary,    // multi-assets
-    Alonzo,  // smart-contracts
-    Babbage, // CIP-31/32/33
-    Conway,  // governance CIP-1694
+    /// Adds time-locked native scripts.
+    Allegra,
+    /// Adds native multi-asset tokens.
+    Mary,
+    /// Adds Plutus V1 smart contracts.
+    Alonzo,
+    /// Adds CIP-31 reference inputs, CIP-32 inline datums, CIP-33 reference scripts.
+    Babbage,
+    /// Adds CIP-1694 on-chain governance.
+    Conway,
 }
 
+/// Feature flags individual eras can be queried for.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum Feature {
+    /// Time-locked native scripts (Allegra+).
     TimeLocks,
+    /// Native multi-asset tokens (Mary+).
     MultiAssets,
+    /// Staking and reward accounting (Shelley+).
     Staking,
+    /// Plutus smart contracts (Alonzo+).
     SmartContracts,
+    /// Reference inputs (Babbage+).
     CIP31,
+    /// Inline datums (Babbage+).
     CIP32,
+    /// Reference scripts (Babbage+).
     CIP33,
+    /// On-chain governance (Conway+).
     CIP1694,
 }
 
+/// A block header normalized across eras, keeping access to its raw CBOR.
 #[derive(Debug)]
 pub enum MultiEraHeader<'b> {
+    /// Byron epoch-boundary block header.
     EpochBoundary(Cow<'b, KeepRaw<'b, byron::EbbHead>>),
+    /// Shelley / Allegra / Mary / Alonzo header (all share one shape).
     ShelleyCompatible(Cow<'b, KeepRaw<'b, alonzo::Header>>),
+    /// Babbage / Conway header.
     BabbageCompatible(Cow<'b, KeepRaw<'b, babbage::Header>>),
+    /// Byron main block header.
     Byron(Cow<'b, KeepRaw<'b, byron::BlockHead>>),
 }
 
+/// A block normalized across eras.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum MultiEraBlock<'b> {
+    /// Byron epoch-boundary block.
     EpochBoundary(Box<byron::EbBlock<'b>>),
+    /// Block of any Alonzo-compatible era (Shelley/Allegra/Mary/Alonzo).
     AlonzoCompatible(Box<alonzo::Block<'b>>, Era),
+    /// Babbage block.
     Babbage(Box<babbage::Block<'b>>),
+    /// Byron main block.
     Byron(Box<byron::Block<'b>>),
+    /// Conway block.
     Conway(Box<conway::Block<'b>>),
 }
 
+/// A transaction normalized across eras.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum MultiEraTx<'b> {
+    /// Transaction of any Alonzo-compatible era (Shelley/Allegra/Mary/Alonzo).
     AlonzoCompatible(Box<Cow<'b, alonzo::Tx<'b>>>, Era),
+    /// Babbage transaction.
     Babbage(Box<Cow<'b, babbage::Tx<'b>>>),
+    /// Byron transaction payload.
     Byron(Box<Cow<'b, byron::TxPayload<'b>>>),
+    /// Conway transaction.
     Conway(Box<Cow<'b, conway::Tx<'b>>>),
 }
 
+/// Ada-plus-multi-asset value normalized across eras.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum MultiEraValue<'b> {
+    /// Byron value (lovelace only).
     Byron(u64),
+    /// Value from any Alonzo-compatible era (lovelace + optional Mary assets).
     AlonzoCompatible(Cow<'b, alonzo::Value>),
+    /// Conway value (uses [`PositiveCoin`] for token quantities).
     Conway(Cow<'b, conway::Value>),
 }
 
+/// Transaction output normalized across eras.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum MultiEraOutput<'b> {
+    /// Output of any Alonzo-compatible era.
     AlonzoCompatible(Box<Cow<'b, alonzo::TransactionOutput>>, Era),
+    /// Babbage output (supports inline datums and reference scripts).
     Babbage(Box<Cow<'b, babbage::TransactionOutput<'b>>>),
+    /// Conway output.
     Conway(Box<Cow<'b, conway::TransactionOutput<'b>>>),
+    /// Byron output.
     Byron(Box<Cow<'b, byron::TxOut>>),
 }
 
+/// Transaction input normalized across eras.
 #[derive(Debug, Clone, PartialEq, Eq, StdHash)]
 #[non_exhaustive]
 pub enum MultiEraInput<'b> {
+    /// Byron transaction input.
     Byron(Box<Cow<'b, byron::TxIn>>),
+    /// Input of any Alonzo-compatible or later era.
     AlonzoCompatible(Box<Cow<'b, alonzo::TransactionInput>>),
 }
 
+/// On-chain certificate normalized across eras.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum MultiEraCert<'b> {
+    /// Era does not carry certificates (Byron).
     NotApplicable,
+    /// Certificate of any Alonzo-compatible or Babbage era.
     AlonzoCompatible(Box<Cow<'b, alonzo::Certificate>>),
+    /// Conway-era certificate (adds governance-related variants).
     Conway(Box<Cow<'b, conway::Certificate>>),
 }
 
+/// Plutus redeemer normalized across eras.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum MultiEraRedeemer<'b> {
+    /// Redeemer of any Alonzo-compatible or Babbage era.
     AlonzoCompatible(Box<Cow<'b, alonzo::Redeemer>>),
+    /// Conway redeemer, split into key (tag + pointer) and value (data + ex-units).
     Conway(
         Box<Cow<'b, conway::RedeemersKey>>,
         Box<Cow<'b, conway::RedeemersValue>>,
     ),
 }
 
+/// Transaction metadata normalized across eras.
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 pub enum MultiEraMeta<'b> {
+    /// Metadata field present but empty.
     #[default]
     Empty,
+    /// Era does not carry metadata (Byron).
     NotApplicable,
+    /// Metadata from any Shelley-or-later era.
     AlonzoCompatible(&'b alonzo::Metadata),
 }
 
+/// Multi-asset bundle for a single policy, normalized across eras.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum MultiEraPolicyAssets<'b> {
+    /// Mint/burn bundle from an Alonzo-compatible or Babbage era (signed quantities).
     AlonzoCompatibleMint(&'b alonzo::PolicyId, &'b BTreeMap<alonzo::AssetName, i64>),
+    /// Output bundle from an Alonzo-compatible or Babbage era (unsigned quantities).
     AlonzoCompatibleOutput(&'b alonzo::PolicyId, &'b BTreeMap<alonzo::AssetName, u64>),
+    /// Mint/burn bundle from the Conway era (non-zero signed quantities).
     ConwayMint(
         &'b alonzo::PolicyId,
         &'b BTreeMap<alonzo::AssetName, NonZeroInt>,
     ),
+    /// Output bundle from the Conway era (strictly positive quantities).
     ConwayOutput(
         &'b alonzo::PolicyId,
         &'b BTreeMap<alonzo::AssetName, PositiveCoin>,
     ),
 }
 
+/// A single native or Plutus asset, normalized across eras.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum MultiEraAsset<'b> {
+    /// Asset appearing in an Alonzo-compatible or Babbage output.
     AlonzoCompatibleOutput(&'b alonzo::PolicyId, &'b alonzo::AssetName, u64),
+    /// Asset appearing in an Alonzo-compatible or Babbage mint field.
     AlonzoCompatibleMint(&'b alonzo::PolicyId, &'b alonzo::AssetName, i64),
+    /// Asset appearing in a Conway output.
     ConwayOutput(&'b alonzo::PolicyId, &'b alonzo::AssetName, PositiveCoin),
+    /// Asset appearing in a Conway mint field.
     ConwayMint(&'b alonzo::PolicyId, &'b alonzo::AssetName, NonZeroInt),
 }
 
+/// Reward-account withdrawals normalized across eras.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum MultiEraWithdrawals<'b> {
+    /// Era does not carry withdrawals (Byron).
     NotApplicable,
+    /// Withdrawals field present but empty.
     Empty,
+    /// Withdrawals from any Alonzo-compatible or Babbage transaction.
     AlonzoCompatible(&'b alonzo::Withdrawals),
+    /// Withdrawals from a Conway transaction.
     Conway(&'b conway::Withdrawals),
 }
 
+/// Protocol-parameter update proposal normalized across eras.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum MultiEraUpdate<'b> {
+    /// Byron update proposal, tagged with the proposing epoch.
     Byron(u64, Box<Cow<'b, byron::UpProp>>),
+    /// Update from any Alonzo-compatible era.
     AlonzoCompatible(Box<Cow<'b, alonzo::Update>>),
+    /// Babbage update.
     Babbage(Box<Cow<'b, babbage::Update>>),
+    /// Conway update.
     Conway(Box<Cow<'b, conway::Update>>),
 }
 
+/// Conway-era governance proposal procedure.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum MultiEraProposal<'b> {
+    /// Conway proposal procedure.
     Conway(Box<Cow<'b, conway::ProposalProcedure>>),
 }
 
+/// Conway-era governance action carried by a [`MultiEraProposal`].
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum MultiEraGovAction<'b> {
+    /// Conway governance action.
     Conway(Box<Cow<'b, conway::GovAction>>),
 }
 
+/// Required-signer hashes normalized across eras.
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 pub enum MultiEraSigners<'b> {
+    /// Era does not carry a required-signers field (Byron / Shelley / Allegra / Mary).
     NotApplicable,
+    /// Required-signers field present but empty.
     #[default]
     Empty,
+    /// Required signers from any Alonzo-compatible or later transaction.
     AlonzoCompatible(&'b alonzo::RequiredSigners),
 }
 
+/// Reference to a transaction output by transaction hash and output index.
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct OutputRef(Hash<32>, u64);
 
+/// Errors produced while traversing or decoding multi-era data.
 #[derive(Debug, Error)]
 pub enum Error {
+    /// CBOR did not parse into the expected era-specific shape.
     #[error("Invalid CBOR structure: {0}")]
     InvalidCbor(String),
 
+    /// CBOR did not match any known era shape.
     #[error("Unknown CBOR structure: {0}")]
     UnknownCbor(String),
 
+    /// Era tag is not one this crate knows how to handle.
     #[error("Unknown era tag: {0}")]
     UnknownEra(u16),
 
+    /// Operation requested in an era that does not support it.
     #[error("Invalid era for request: {0}")]
     InvalidEra(Era),
 
+    /// String could not be parsed as a UTxO reference (`<tx_hash>#<index>`).
     #[error("Invalid UTxO ref: {0}")]
     InvalidUtxoRef(String),
 }
 
 impl Error {
+    /// Construct an [`Error::InvalidCbor`] from any displayable error.
     pub fn invalid_cbor(error: impl Display) -> Self {
         Error::InvalidCbor(format!("{error}"))
     }
 
+    /// Construct an [`Error::UnknownCbor`] from the offending bytes.
     pub fn unknown_cbor(bytes: &[u8]) -> Self {
         Error::UnknownCbor(hex::encode(bytes))
     }
 
+    /// Construct an [`Error::InvalidUtxoRef`] from the offending string.
     pub fn invalid_utxo_ref(str: &str) -> Self {
         Error::InvalidUtxoRef(str.to_owned())
     }
 }
 
+/// Recompute the hash of a value from its current in-memory shape.
 pub trait ComputeHash<const BYTES: usize> {
+    /// Compute the hash from the current value (may differ from the on-wire hash if the value was modified).
     fn compute_hash(&self) -> pallas_crypto::hash::Hash<BYTES>;
 }
 
+/// Recover the hash that the value had on the wire, preserving any encoding quirks.
 pub trait OriginalHash<const BYTES: usize> {
+    /// Return the hash as computed over the value's original CBOR bytes.
     fn original_hash(&self) -> pallas_crypto::hash::Hash<BYTES>;
 }

--- a/pallas-txbuilder/src/conway.rs
+++ b/pallas-txbuilder/src/conway.rs
@@ -24,7 +24,14 @@ use pallas_primitives::{
 };
 use pallas_traverse::ComputeHash;
 
+/// Conway-era build step: converts a [`StagingTransaction`] into a
+/// [`BuiltTransaction`] with no automatic fee/ex-units calculation.
 pub trait BuildConway {
+    /// Build the transaction using exactly the fields the caller has populated.
+    ///
+    /// "Raw" means no balancing: fees, collateral, and execution units must
+    /// already be set on the staging transaction. Returns
+    /// [`TxBuilderError`] if any field is malformed.
     fn build_conway_raw(self) -> Result<BuiltTransaction, TxBuilderError>;
 
     // fn build_babbage(staging_tx: StagingTransaction, resolver: (), params: ()) ->
@@ -305,6 +312,7 @@ impl BuildConway for StagingTransaction {
 }
 
 impl Output {
+    /// Convert this staging output into its Babbage / post-Alonzo on-wire form.
     pub fn build_babbage_raw(&self) -> Result<TransactionOutput<'_>, TxBuilderError> {
         let assets = self
             .assets

--- a/pallas-txbuilder/src/lib.rs
+++ b/pallas-txbuilder/src/lib.rs
@@ -1,3 +1,48 @@
+//! Ergonomic builder for constructing and signing Cardano transactions.
+//!
+//! The crate is organised around [`StagingTransaction`], a fluent builder
+//! that collects inputs, outputs, mint, scripts, datums, and redeemers, and
+//! finalises into a [`BuiltTransaction`] ready to be signed and submitted.
+//!
+//! Currently the only era supported for building is **Conway** (via the
+//! [`BuildConway`] trait). Earlier-era builders are intentionally not
+//! maintained.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use pallas_txbuilder::{BuildConway, Input, Output, StagingTransaction};
+//!
+//! let tx = StagingTransaction::new()
+//!     .input(Input::new(prev_tx_hash, 0))
+//!     .output(Output::new(recipient_address, 2_000_000))
+//!     .fee(170_000)
+//!     .build_conway_raw()?;
+//!
+//! let signed = tx.sign(&signing_key)?;
+//! let cbor = signed.tx_bytes;
+//! ```
+//!
+//! # Overview
+//!
+//! - [`StagingTransaction`] — the in-progress, mutable transaction; the
+//!   entry point for everything (`new`, `input`, `output`, `mint`, `fee`,
+//!   `network_id`, `valid_after`, …).
+//! - [`BuiltTransaction`] — the finalised, encoded body produced by
+//!   [`BuildConway`]; exposes `sign(&signer)` and the raw CBOR bytes.
+//! - [`Input`], [`Output`], [`ExUnits`], [`ScriptKind`], [`Bytes`],
+//!   [`Bytes32`] — the value types that go into the builder.
+//! - [`BuildConway`] trait — implemented for [`StagingTransaction`]; turns
+//!   staging state into a Conway-encoded transaction.
+//! - [`TxBuilderError`] — the unified error returned from build / sign.
+//!
+//! # Usage as part of `pallas`
+//!
+//! When depending on the umbrella [`pallas`] crate, this crate is re-exported
+//! as `pallas::txbuilder`.
+//!
+//! [`pallas`]: https://crates.io/crates/pallas
+
 mod conway;
 mod transaction;
 
@@ -7,6 +52,7 @@ pub use transaction::{
     Bytes, Bytes32,
 };
 
+/// Errors produced while staging, building, or signing a transaction.
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum TxBuilderError {
     /// Provided bytes could not be decoded into a script

--- a/pallas-txbuilder/src/transaction/mod.rs
+++ b/pallas-txbuilder/src/transaction/mod.rs
@@ -11,6 +11,7 @@ pub enum TransactionStatus {
     Built,
 }
 
+/// Fixed-length 32-byte buffer (transaction hashes, datum hashes, public keys).
 #[derive(PartialEq, Eq, Hash, Debug, Clone)]
 pub struct Bytes32(pub [u8; 32]);
 
@@ -23,6 +24,7 @@ type Signature = Bytes64;
 #[derive(Clone, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
 pub struct Hash28(pub [u8; 28]);
 
+/// Owned variable-length byte buffer used for asset names, datum payloads, etc.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct Bytes(pub Vec<u8>);
 

--- a/pallas-txbuilder/src/transaction/model.rs
+++ b/pallas-txbuilder/src/transaction/model.rs
@@ -20,28 +20,50 @@ use super::{
 };
 use pallas_codec::minicbor;
 // TODO: Don't make wrapper types public
+/// In-progress transaction that converts to a [`BuiltTransaction`] via an era-specific build trait.
 #[derive(Default, Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct StagingTransaction {
+    /// Schema version of this staging document (for serialization compat).
     pub version: String,
+    /// Lifecycle state of this transaction.
     pub status: TransactionStatus,
+    /// Inputs consumed by this transaction.
     pub inputs: Option<Vec<Input>>,
+    /// Reference inputs read but not consumed (CIP-31).
     pub reference_inputs: Option<Vec<Input>>,
+    /// Outputs produced by this transaction.
     pub outputs: Option<Vec<Output>>,
+    /// Fee in lovelace (must already include script execution costs).
     pub fee: Option<u64>,
+    /// Tokens minted or burned by this transaction.
     pub mint: Option<MintAssets>,
+    /// Earliest slot at which this transaction is valid.
     pub valid_from_slot: Option<u64>,
+    /// Slot at which this transaction becomes invalid (TTL).
     pub invalid_from_slot: Option<u64>,
+    /// Network id this transaction targets (0 testnet, 1 mainnet).
     pub network_id: Option<u8>,
+    /// Inputs offered as collateral for phase-2 script evaluation.
     pub collateral_inputs: Option<Vec<Input>>,
+    /// Output receiving leftover collateral when scripts succeed.
     pub collateral_output: Option<Output>,
+    /// Required-signer key hashes hinted to script evaluation.
     pub disclosed_signers: Option<Vec<PubKeyHash>>,
+    /// Native and Plutus scripts attached to the transaction, keyed by hash.
     pub scripts: Option<HashMap<ScriptHash, Script>>,
+    /// Plutus datums attached to the transaction, keyed by datum hash.
     pub datums: Option<HashMap<DatumHash, DatumBytes>>,
+    /// Plutus redeemers paired with their target script purpose.
     pub redeemers: Option<Redeemers>,
+    /// Cached script-data hash; recomputed at build time when scripts are present.
     pub script_data_hash: Option<Bytes32>,
+    /// Override for the assumed number of signatures (fee estimation).
     pub signature_amount_override: Option<u8>,
+    /// Address receiving change when the builder balances the transaction.
     pub change_address: Option<Address>,
+    /// Plutus language-view CBOR encodings used in the script-data hash.
     pub language_views: Option<pallas_primitives::conway::LanguageViews>,
+    /// Auxiliary data (metadata, native scripts) attached to the transaction.
     pub auxiliary_data: Option<AuxiliaryData>,
     // pub certificates: TODO
     // pub withdrawals: TODO
@@ -50,6 +72,7 @@ pub struct StagingTransaction {
 }
 
 impl StagingTransaction {
+    /// Create an empty staging transaction in the `Staging` status.
     pub fn new() -> Self {
         Self {
             version: String::from("v1"),
@@ -58,6 +81,7 @@ impl StagingTransaction {
         }
     }
 
+    /// Append a consumed input.
     pub fn input(mut self, input: Input) -> Self {
         let mut txins = self.inputs.unwrap_or_default();
         txins.push(input);
@@ -65,6 +89,7 @@ impl StagingTransaction {
         self
     }
 
+    /// Remove a previously added consumed input.
     pub fn remove_input(mut self, input: Input) -> Self {
         let mut txins = self.inputs.unwrap_or_default();
         txins.retain(|x| *x != input);
@@ -72,6 +97,7 @@ impl StagingTransaction {
         self
     }
 
+    /// Append a reference input (CIP-31; read-only, not spent).
     pub fn reference_input(mut self, input: Input) -> Self {
         let mut ref_txins = self.reference_inputs.unwrap_or_default();
         ref_txins.push(input);
@@ -79,6 +105,7 @@ impl StagingTransaction {
         self
     }
 
+    /// Remove a previously added reference input.
     pub fn remove_reference_input(mut self, input: Input) -> Self {
         let mut ref_txins = self.reference_inputs.unwrap_or_default();
         ref_txins.retain(|x| *x != input);
@@ -86,6 +113,7 @@ impl StagingTransaction {
         self
     }
 
+    /// Append a produced output.
     pub fn output(mut self, output: Output) -> Self {
         let mut txouts = self.outputs.unwrap_or_default();
         txouts.push(output);
@@ -93,6 +121,7 @@ impl StagingTransaction {
         self
     }
 
+    /// Remove the output at the given index.
     pub fn remove_output(mut self, index: usize) -> Self {
         let mut txouts = self.outputs.unwrap_or_default();
         txouts.remove(index);
@@ -100,16 +129,20 @@ impl StagingTransaction {
         self
     }
 
+    /// Set the fee (lovelace).
     pub fn fee(mut self, fee: u64) -> Self {
         self.fee = Some(fee);
         self
     }
 
+    /// Clear any previously set fee.
     pub fn clear_fee(mut self) -> Self {
         self.fee = None;
         self
     }
 
+    /// Add (or accumulate) a mint/burn quantity for `(policy, name)`. Positive
+    /// values mint; negative values burn. Fails if the asset name exceeds 32 bytes.
     pub fn mint_asset(
         mut self,
         policy: Hash<28>,
@@ -142,6 +175,7 @@ impl StagingTransaction {
         Ok(self)
     }
 
+    /// Remove the mint/burn entry for `(policy, name)`.
     pub fn remove_mint_asset(mut self, policy: Hash<28>, name: Vec<u8>) -> Self {
         let mut mint = if let Some(mint) = self.mint {
             mint.0
@@ -161,36 +195,43 @@ impl StagingTransaction {
         self
     }
 
+    /// Set the earliest slot at which the transaction becomes valid.
     pub fn valid_from_slot(mut self, slot: u64) -> Self {
         self.valid_from_slot = Some(slot);
         self
     }
 
+    /// Clear the lower validity bound.
     pub fn clear_valid_from_slot(mut self) -> Self {
         self.valid_from_slot = None;
         self
     }
 
+    /// Set the slot at which the transaction becomes invalid (TTL).
     pub fn invalid_from_slot(mut self, slot: u64) -> Self {
         self.invalid_from_slot = Some(slot);
         self
     }
 
+    /// Clear the TTL.
     pub fn clear_invalid_from_slot(mut self) -> Self {
         self.invalid_from_slot = None;
         self
     }
 
+    /// Set the network id (0 = testnet, 1 = mainnet).
     pub fn network_id(mut self, id: u8) -> Self {
         self.network_id = Some(id);
         self
     }
 
+    /// Clear the network id.
     pub fn clear_network_id(mut self) -> Self {
         self.network_id = None;
         self
     }
 
+    /// Append a collateral input.
     pub fn collateral_input(mut self, input: Input) -> Self {
         let mut coll_ins = self.collateral_inputs.unwrap_or_default();
         coll_ins.push(input);
@@ -198,6 +239,7 @@ impl StagingTransaction {
         self
     }
 
+    /// Remove a previously added collateral input.
     pub fn remove_collateral_input(mut self, input: Input) -> Self {
         let mut coll_ins = self.collateral_inputs.unwrap_or_default();
         coll_ins.retain(|x| *x != input);
@@ -205,16 +247,19 @@ impl StagingTransaction {
         self
     }
 
+    /// Set the collateral-return output.
     pub fn collateral_output(mut self, output: Output) -> Self {
         self.collateral_output = Some(output);
         self
     }
 
+    /// Clear the collateral-return output.
     pub fn clear_collateral_output(mut self) -> Self {
         self.collateral_output = None;
         self
     }
 
+    /// Add a required-signer key hash.
     pub fn disclosed_signer(mut self, pub_key_hash: Hash<28>) -> Self {
         let mut disclosed_signers = self.disclosed_signers.unwrap_or_default();
         disclosed_signers.push(Hash28(*pub_key_hash));
@@ -222,6 +267,7 @@ impl StagingTransaction {
         self
     }
 
+    /// Remove a previously added required-signer key hash.
     pub fn remove_disclosed_signer(mut self, pub_key_hash: Hash<28>) -> Self {
         let mut disclosed_signers = self.disclosed_signers.unwrap_or_default();
         disclosed_signers.retain(|x| *x != Hash28(*pub_key_hash));
@@ -229,6 +275,8 @@ impl StagingTransaction {
         self
     }
 
+    /// Attach a native or Plutus script. The script is keyed by its
+    /// language-tagged Blake2b-224 hash.
     pub fn script(mut self, language: ScriptKind, bytes: Vec<u8>) -> Self {
         let mut scripts = self.scripts.unwrap_or_default();
 
@@ -251,6 +299,7 @@ impl StagingTransaction {
         self
     }
 
+    /// Remove the script with the given hash.
     pub fn remove_script_by_hash(mut self, script_hash: Hash<28>) -> Self {
         let mut scripts = self.scripts.unwrap_or_default();
 
@@ -260,6 +309,7 @@ impl StagingTransaction {
         self
     }
 
+    /// Attach a Plutus datum keyed by its Blake2b-256 hash.
     pub fn datum(mut self, datum: Vec<u8>) -> Self {
         let mut datums = self.datums.unwrap_or_default();
 
@@ -270,6 +320,7 @@ impl StagingTransaction {
         self
     }
 
+    /// Remove a previously attached datum identified by its raw bytes.
     pub fn remove_datum(mut self, datum: Vec<u8>) -> Self {
         let mut datums = self.datums.unwrap_or_default();
 
@@ -280,6 +331,7 @@ impl StagingTransaction {
         self
     }
 
+    /// Remove a previously attached datum identified by its hash.
     pub fn remove_datum_by_hash(mut self, datum_hash: Hash<32>) -> Self {
         let mut datums = self.datums.unwrap_or_default();
 
@@ -288,11 +340,14 @@ impl StagingTransaction {
         self
     }
 
+    /// Replace the Plutus language-views map used to compute the script-data hash.
     pub fn language_views(mut self, views: pallas_primitives::conway::LanguageViews) -> Self {
         self.language_views = Some(views);
         self
     }
 
+    /// Add or replace the cost model for a single Plutus language version.
+    /// Native scripts are a no-op.
     pub fn add_language(mut self, plutus_version: ScriptKind, cost_model: Vec<i64>) -> Self {
         let version = match plutus_version {
             ScriptKind::PlutusV1 => 0,
@@ -310,6 +365,8 @@ impl StagingTransaction {
         self
     }
 
+    /// Attach a spend redeemer targeting `input`. Pass `ex_units = None` to
+    /// have the builder compute them later.
     pub fn add_spend_redeemer(
         mut self,
         input: Input,
@@ -328,6 +385,7 @@ impl StagingTransaction {
         self
     }
 
+    /// Remove the spend redeemer targeting `input`.
     pub fn remove_spend_redeemer(mut self, input: Input) -> Self {
         let mut rdmrs = self.redeemers.map(|x| x.0).unwrap_or_default();
 
@@ -338,6 +396,8 @@ impl StagingTransaction {
         self
     }
 
+    /// Attach a mint redeemer targeting `policy`. Pass `ex_units = None` to
+    /// have the builder compute them later.
     pub fn add_mint_redeemer(
         mut self,
         policy: Hash<28>,
@@ -356,6 +416,7 @@ impl StagingTransaction {
         self
     }
 
+    /// Remove the mint redeemer targeting `policy`.
     pub fn remove_mint_redeemer(mut self, policy: Hash<28>) -> Self {
         let mut rdmrs = self.redeemers.map(|x| x.0).unwrap_or_default();
 
@@ -366,26 +427,31 @@ impl StagingTransaction {
         self
     }
 
+    /// Override the assumed signature count used in fee estimation.
     pub fn signature_amount_override(mut self, amount: u8) -> Self {
         self.signature_amount_override = Some(amount);
         self
     }
 
+    /// Clear the signature-count override.
     pub fn clear_signature_amount_override(mut self) -> Self {
         self.signature_amount_override = None;
         self
     }
 
+    /// Set the address receiving change when the builder balances the transaction.
     pub fn change_address(mut self, address: PallasAddress) -> Self {
         self.change_address = Some(Address(address));
         self
     }
 
+    /// Clear the change address.
     pub fn clear_change_address(mut self) -> Self {
         self.change_address = None;
         self
     }
 
+    /// Attach auxiliary data parsed from raw CBOR. Invalid CBOR is silently ignored.
     pub fn add_auxiliary_data(mut self, data: Vec<u8>) -> Self {
         if let Ok(aux) = minicbor::decode::<AuxiliaryData>(data.as_ref()) {
             self.auxiliary_data = Some(aux);
@@ -393,6 +459,7 @@ impl StagingTransaction {
         self
     }
 
+    /// Clear any attached auxiliary data.
     pub fn clear_auxiliary_data(mut self) -> Self {
         self.auxiliary_data = None;
         self
@@ -400,13 +467,17 @@ impl StagingTransaction {
 }
 
 // TODO: Don't want our wrapper types in fields public
+/// Reference to a single transaction output (consumed or referenced).
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Hash, Clone)]
 pub struct Input {
+    /// Hash of the transaction that produced the output.
     pub tx_hash: TxHash,
+    /// Index of the output within that transaction.
     pub txo_index: u64,
 }
 
 impl Input {
+    /// Build an input from a transaction hash and output index.
     pub fn new(tx_hash: Hash<32>, txo_index: u64) -> Self {
         Self {
             tx_hash: Bytes32(*tx_hash),
@@ -416,16 +487,23 @@ impl Input {
 }
 
 // TODO: Don't want our wrapper types in fields public
+/// Transaction output being produced.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct Output {
+    /// Destination address.
     pub address: Address,
+    /// Lovelace amount.
     pub lovelace: u64,
+    /// Optional native-token bundle paired with the lovelace.
     pub assets: Option<OutputAssets>,
+    /// Optional datum (inline data or hash) attached to the output.
     pub datum: Option<Datum>,
+    /// Optional script reference attached to the output (CIP-33).
     pub script: Option<Script>,
 }
 
 impl Output {
+    /// Build an output paying `lovelace` to `address`.
     pub fn new(address: PallasAddress, lovelace: u64) -> Self {
         Self {
             address: Address(address),
@@ -436,6 +514,8 @@ impl Output {
         }
     }
 
+    /// Add (or accumulate) a quantity of `(policy, name)` to this output.
+    /// Fails if the asset name exceeds 32 bytes.
     pub fn add_asset(
         mut self,
         policy: Hash<28>,
@@ -469,6 +549,7 @@ impl Output {
         Ok(self)
     }
 
+    /// Attach an inline datum (CIP-32) to this output.
     pub fn set_inline_datum(mut self, plutus_data: Vec<u8>) -> Self {
         self.datum = Some(Datum {
             kind: DatumKind::Inline,
@@ -478,6 +559,7 @@ impl Output {
         self
     }
 
+    /// Attach a datum hash to this output (datum body provided separately).
     pub fn set_datum_hash(mut self, datum_hash: Hash<32>) -> Self {
         self.datum = Some(Datum {
             kind: DatumKind::Hash,
@@ -487,6 +569,7 @@ impl Output {
         self
     }
 
+    /// Attach an inline script reference (CIP-33) to this output.
     pub fn set_inline_script(mut self, language: ScriptKind, bytes: Vec<u8>) -> Self {
         self.script = Some(Script {
             kind: language,
@@ -497,6 +580,7 @@ impl Output {
     }
 }
 
+/// Native-token bundle attached to a transaction output.
 #[derive(PartialEq, Eq, Debug, Clone, Default)]
 pub struct OutputAssets(HashMap<PolicyId, HashMap<AssetName, u64>>);
 
@@ -509,11 +593,13 @@ impl Deref for OutputAssets {
 }
 
 impl OutputAssets {
+    /// Build an [`OutputAssets`] from a pre-constructed policy → asset map.
     pub fn from_map(map: HashMap<PolicyId, HashMap<Bytes, u64>>) -> Self {
         Self(map)
     }
 }
 
+/// Mint/burn bundle attached to a transaction (signed quantities).
 #[derive(PartialEq, Eq, Debug, Clone, Default)]
 pub struct MintAssets(HashMap<PolicyId, HashMap<AssetName, i64>>);
 
@@ -526,31 +612,42 @@ impl Deref for MintAssets {
 }
 
 impl MintAssets {
+    /// Create an empty mint bundle.
     pub fn new() -> Self {
         MintAssets(HashMap::new())
     }
 
+    /// Build a [`MintAssets`] from a pre-constructed policy → asset map.
     pub fn from_map(map: HashMap<PolicyId, HashMap<Bytes, i64>>) -> Self {
         Self(map)
     }
 }
 
+/// Discriminator selecting a script language.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum ScriptKind {
+    /// Cardano native script (timelock and signature combinators).
     Native,
+    /// Plutus V1 script.
     PlutusV1,
+    /// Plutus V2 script.
     PlutusV2,
+    /// Plutus V3 script.
     PlutusV3,
 }
 
+/// A native or Plutus script and its language.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct Script {
+    /// Script language.
     pub kind: ScriptKind,
+    /// Serialized script bytes.
     pub bytes: ScriptBytes,
 }
 
 impl Script {
+    /// Build a script from its language tag and bytes.
     pub fn new(kind: ScriptKind, bytes: Vec<u8>) -> Self {
         Self {
             kind,
@@ -559,33 +656,46 @@ impl Script {
     }
 }
 
+/// Discriminator for how a datum is referenced from an output.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum DatumKind {
+    /// `bytes` is the 32-byte Blake2b-256 hash of the datum.
     Hash,
+    /// `bytes` is the inline datum body (CIP-32).
     Inline,
 }
 
+/// Datum attached to an output, either by hash or inline.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct Datum {
+    /// Whether `bytes` holds a hash or the inline body.
     pub kind: DatumKind,
+    /// Hash or inline payload, per [`DatumKind`].
     pub bytes: DatumBytes,
 }
 
+/// Target a Plutus redeemer applies to.
 #[derive(PartialEq, Eq, Hash, Debug, Clone)]
 pub enum RedeemerPurpose {
+    /// Spend redeemer targeting a specific input.
     Spend(Input),
+    /// Mint redeemer targeting a specific minting policy.
     Mint(PolicyId),
     // Reward TODO
     // Cert TODO
 }
 
+/// Plutus script execution budget.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct ExUnits {
+    /// Memory units consumed.
     pub mem: u64,
+    /// CPU step units consumed.
     pub steps: u64,
 }
 
+/// Plutus redeemers keyed by their purpose.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Default, Clone)]
 pub struct Redeemers(HashMap<RedeemerPurpose, (Bytes, Option<ExUnits>)>);
 
@@ -598,11 +708,13 @@ impl Deref for Redeemers {
 }
 
 impl Redeemers {
+    /// Build a [`Redeemers`] from a pre-constructed purpose → `(datum, ex_units)` map.
     pub fn from_map(map: HashMap<RedeemerPurpose, (Bytes, Option<ExUnits>)>) -> Self {
         Self(map)
     }
 }
 
+/// Newtype wrapper around [`pallas_addresses::Address`] usable in serde contexts.
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Address(pub PallasAddress);
 
@@ -620,15 +732,21 @@ impl From<PallasAddress> for Address {
     }
 }
 
+/// Era the builder targeted when producing a [`BuiltTransaction`].
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum BuilderEra {
+    /// Babbage-era output shape.
     Babbage,
+    /// Conway-era output shape.
     Conway,
 }
 
+/// Anything that can produce Ed25519 signatures used by [`BuiltTransaction::sign`].
 pub trait Ed25519Signer {
+    /// Return the public key paired with this signer.
     fn public_key(&self) -> ed25519::PublicKey;
+    /// Sign `msg` with this signer.
     fn sign<T: AsRef<[u8]>>(&self, msg: T) -> ed25519::Signature;
 }
 
@@ -652,17 +770,26 @@ impl Ed25519Signer for ed25519::SecretKeyExtended {
     }
 }
 
+/// A fully built (and possibly signed) transaction ready to submit.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct BuiltTransaction {
+    /// Schema version of this built document (matches the source [`StagingTransaction`]).
     pub version: String,
+    /// Era the transaction was built for.
     pub era: BuilderEra,
+    /// Lifecycle state — typically `TransactionStatus::Built`.
     pub status: TransactionStatus,
+    /// Hash of the transaction body (the message signers attest to).
     pub tx_hash: TxHash,
+    /// CBOR-encoded transaction bytes.
     pub tx_bytes: Bytes,
+    /// Map of public-key → signature for each attached witness.
     pub signatures: Option<HashMap<PublicKey, Signature>>,
 }
 
 impl BuiltTransaction {
+    /// Sign this transaction with `private_key` and embed the witness in
+    /// `tx_bytes`. Calling multiple times accumulates witnesses.
     pub fn sign<K: Ed25519Signer>(mut self, private_key: &K) -> Result<Self, TxBuilderError> {
         let pubkey: [u8; 32] = private_key
             .public_key()
@@ -711,6 +838,7 @@ impl BuiltTransaction {
         Ok(self)
     }
 
+    /// Embed a signature produced out-of-band. Useful for HSM / hardware-wallet flows.
     pub fn add_signature(
         mut self,
         pub_key: ed25519::PublicKey,
@@ -759,6 +887,7 @@ impl BuiltTransaction {
         Ok(self)
     }
 
+    /// Remove the witness attached for `pub_key`, if any.
     pub fn remove_signature(mut self, pub_key: ed25519::PublicKey) -> Result<Self, TxBuilderError> {
         match self.era {
             BuilderEra::Conway => {

--- a/pallas-utxorpc/src/lib.rs
+++ b/pallas-utxorpc/src/lib.rs
@@ -1,3 +1,66 @@
+//! Map Pallas ledger types onto the [UTxORPC] Cardano protobuf schema.
+//!
+//! Both spec versions are always compiled in side by side, so a caller can
+//! choose `v1alpha` or `v1beta` per call site without juggling features.
+//!
+//! [UTxORPC]: https://utxorpc.org
+//!
+//! # Usage
+//!
+//! ```
+//! use pallas_utxorpc::Mapper;          // default features: alias for v1alpha::Mapper
+//! use pallas_utxorpc::v1alpha::Mapper as V1Alpha;
+//! use pallas_utxorpc::v1beta::Mapper as V1Beta;
+//! ```
+//!
+//! For back-compat with pre-v1beta releases, the default
+//! `u5c-v1alpha-compat` feature re-exports `v1alpha` at the crate root, so
+//! `pallas_utxorpc::Mapper` and `pallas_utxorpc::spec` keep resolving to
+//! v1alpha. Disable the compat shim to force callers onto explicit version
+//! paths:
+//!
+//! ```toml
+//! pallas-utxorpc = { version = "...", default-features = false }
+//! ```
+//!
+//! # Overview
+//!
+//! - [`v1alpha`] — `Mapper` returning
+//!   `utxorpc_spec::utxorpc::v1alpha::cardano::*`.
+//! - [`v1beta`] — `Mapper` returning
+//!   `utxorpc_spec::utxorpc::v1beta::cardano::*`, including the v1beta-only
+//!   types (`BootstrapWitness`, `VoterVotes`, `VotingProcedure`, `Vote`).
+//! - Crate-root infrastructure ([`LedgerContext`], [`TxHash`], [`TxoIndex`],
+//!   [`TxoRef`], [`Cbor`], [`EraCbor`], [`UtxoMap`], [`DatumMap`]) is
+//!   shared across versions and unaffected by the feature flag.
+//!
+//! # Feature flags
+//!
+//! - `u5c-v1alpha-compat` *(default)* — re-export [`v1alpha::Mapper`] and
+//!   [`v1alpha::spec`] at the crate root for back-compat with pre-v1beta
+//!   callers.
+//!
+//! # Testing
+//!
+//! Each version has a snapshot test that decodes a fixed Babbage block and
+//! compares the mapper output against a JSON file under `test_data/`
+//! (`u5c_v1alpha.json`, `u5c_v1beta.json`). To overwrite both snapshots with
+//! the current mapper output:
+//!
+//! ```sh
+//! REGENERATE_SNAPSHOTS=1 cargo test -p pallas-utxorpc
+//! ```
+//!
+//! When the variable is unset (the normal case), the tests assert against
+//! the checked-in JSON files.
+//!
+//! # Usage as part of `pallas`
+//!
+//! When depending on the umbrella [`pallas`] crate, this crate is re-exported
+//! as `pallas::interop::utxorpc`.
+//!
+//! [`pallas`]: https://crates.io/crates/pallas
+
 use std::collections::HashMap;
 
 use pallas_crypto::hash::Hash;
@@ -7,22 +70,36 @@ use pallas_traverse as trv;
 #[macro_use]
 mod shared;
 
+/// Mappers and types for the `v1alpha` UTxO RPC schema.
 pub mod v1alpha;
+/// Mappers and types for the `v1beta` UTxO RPC schema.
 pub mod v1beta;
 
 #[cfg(feature = "u5c-v1alpha-compat")]
 pub use v1alpha::{spec, Mapper};
 
+/// 32-byte transaction hash.
 pub type TxHash = Hash<32>;
+/// Index of an output within a transaction.
 pub type TxoIndex = u32;
+/// Reference to a single transaction output: `(tx_hash, output_index)`.
 pub type TxoRef = (TxHash, TxoIndex);
+/// Raw CBOR bytes for an on-chain artifact.
 pub type Cbor = Vec<u8>;
+/// CBOR bytes tagged with the era they were produced in.
 pub type EraCbor = (trv::Era, Cbor);
+/// Resolved UTxO set keyed by output reference.
 pub type UtxoMap = HashMap<TxoRef, EraCbor>;
+/// Plutus datums keyed by their 32-byte hash.
 pub type DatumMap = HashMap<Hash<32>, alonzo::PlutusData>;
 
+/// Side-channel a UTxO RPC mapper uses to resolve information that is not
+/// inlined in the transaction or block being mapped (referenced UTxOs, slot
+/// timestamps, etc.).
 pub trait LedgerContext: Clone {
+    /// Resolve a set of output references to their on-chain CBOR.
     fn get_utxos(&self, refs: &[TxoRef]) -> Option<UtxoMap>;
+    /// Resolve a slot number to its wall-clock timestamp (UNIX seconds).
     fn get_slot_timestamp(&self, slot: u64) -> Option<u64>;
 }
 

--- a/pallas-validate/src/lib.rs
+++ b/pallas-validate/src/lib.rs
@@ -1,5 +1,65 @@
+//! Phase-1 (and optionally phase-2) Cardano transaction validation against
+//! the live ledger rules.
+//!
+//! Useful for clients that want to reject ill-formed or unenforceable
+//! transactions locally before submitting them, or to replay historical
+//! chains and confirm conformance with the protocol specification.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use pallas_validate::phase1::validate_tx;
+//!
+//! validate_tx(&tx, tx_index, &env, &utxos, &mut cert_state)?;
+//! ```
+//!
+//! [`phase1::validate_tx`] dispatches on the era encoded in the
+//! `Environment.prot_params` and routes to the matching era-specific
+//! validator ([`phase1::byron::validate_byron_tx`],
+//! [`phase1::shelley_ma::validate_shelley_ma_tx`],
+//! [`phase1::alonzo::validate_alonzo_tx`],
+//! [`phase1::babbage::validate_babbage_tx`],
+//! [`phase1::conway::validate_conway_tx`]).
+//!
+//! # Overview
+//!
+//! - [`phase1`] — phase-1 (structural / rule-based) validation, with one
+//!   module per era: [`phase1::byron`], [`phase1::shelley_ma`],
+//!   [`phase1::alonzo`], [`phase1::babbage`], [`phase1::conway`]. Top-level
+//!   entry points are [`phase1::validate_tx`] (single tx) and
+//!   [`phase1::validate_txs`] (LEDGERS sequence rule).
+//! - `phase2` — phase-2 (Plutus script execution) validation. Behind the
+//!   `phase2` cargo feature.
+//! - [`utils`] — the shared input types every validator takes:
+//!   [`utils::Environment`], [`utils::UTxOs`], [`utils::CertState`],
+//!   [`utils::MultiEraProtocolParameters`], and the unified
+//!   [`utils::ValidationError`] / [`utils::ValidationResult`] types.
+//!
+//! # Feature flags
+//!
+//! - `phase2` — pulls in Plutus script execution and exposes the `phase2`
+//!   module.
+//!
+//! # Further reading
+//!
+//! - `docs/byron.md`, `docs/shelleyMA.md`, `docs/alonzo.md`,
+//!   `docs/babbage.md` — mathematical specifications, one per era.
+//! - `tests/README.md` — test-suite layout and how to reproduce the per-era
+//!   fixtures.
+//!
+//! # Usage as part of `pallas`
+//!
+//! When depending on the umbrella [`pallas`] crate, this crate is re-exported
+//! as `pallas::ledger::validate`.
+//!
+//! [`pallas`]: https://crates.io/crates/pallas
+
+/// Phase-1 (structural / rule-based) validation, with one module per era.
 pub mod phase1;
+/// Shared input types: [`utils::Environment`], [`utils::UTxOs`],
+/// [`utils::CertState`], [`utils::ValidationError`], and friends.
 pub mod utils;
 
+/// Phase-2 (Plutus script execution) validation (feature `phase2`).
 #[cfg(feature = "phase2")]
 pub mod phase2;

--- a/pallas/src/lib.rs
+++ b/pallas/src/lib.rs
@@ -47,7 +47,6 @@
 //! | [`p2p-responder`]     | Accept incoming P2P connections using `pallas-network2`              |
 //! | [`p2p-discovery`]     | Peer discovery using `pallas-network2`                               |
 //! | [`wallet`]            | Wallet key generation, BIP-39 mnemonics, address derivation          |
-//! | [`otel`]              | OpenTelemetry collector configuration for tracing the examples above |
 //!
 //! [`block-decode`]: https://github.com/txpipe/pallas/tree/main/examples/block-decode
 //! [`block-download`]: https://github.com/txpipe/pallas/tree/main/examples/block-download
@@ -58,7 +57,6 @@
 //! [`p2p-responder`]: https://github.com/txpipe/pallas/tree/main/examples/p2p-responder
 //! [`p2p-discovery`]: https://github.com/txpipe/pallas/tree/main/examples/p2p-discovery
 //! [`wallet`]: https://github.com/txpipe/pallas/tree/main/examples/wallet
-//! [`otel`]: https://github.com/txpipe/pallas/tree/main/examples/otel
 //!
 //! # Feature flags
 //!

--- a/pallas/src/lib.rs
+++ b/pallas/src/lib.rs
@@ -1,90 +1,277 @@
-//! Rust-native building blocks for the Cardano blockchain ecosystem
+//! Rust-native building blocks for the Cardano blockchain ecosystem.
 //!
-//! Pallas is an expanding collection of modules that re-implements common
-//! Cardano logic in native Rust. This crate doesn't provide any particular
-//! application, it is meant to be used as a base layer to facilitate the
-//! development of higher-level use-cases, such as explorers, wallets, etc (who
-//! knows, maybe even a full node in the far away future).
+//! Pallas is a collection of modules that re-implements core Ouroboros /
+//! Cardano logic in native Rust. It does not provide any single application;
+//! it is a base layer for higher-level use-cases — explorers, indexers,
+//! wallets, transaction builders, validators, and (eventually) full nodes.
+//!
+//! # Crate layout
+//!
+//! The umbrella `pallas` crate re-exports every building block under a single
+//! module tree, organised by domain:
+//!
+//! ```text
+//! pallas
+//! ├── network         — Ouroboros networking stack
+//! ├── network2        — P2P-first networking stack (feature `network2`)
+//! ├── ledger
+//! │   ├── primitives  — multi-era CBOR primitives
+//! │   ├── traverse    — multi-era traversal helpers
+//! │   ├── addresses   — Cardano address codec
+//! │   └── validate    — phase-1 / phase-2 transaction validation
+//! ├── crypto          — cryptographic primitives
+//! ├── codec           — CBOR codec (minicbor)
+//! ├── interop
+//! │   ├── utxorpc     — UTxO RPC interop
+//! │   └── hardano     — Haskell-node interop (feature `hardano`)
+//! └── txbuilder       — ergonomic transaction builder
+//! ```
+//!
+//! Each module is a thin re-export of a standalone `pallas-*` crate published
+//! on crates.io ([`pallas-network`], [`pallas-primitives`], …). If you only
+//! need a subset, depend on the individual crates directly.
+//!
+//! # Examples
+//!
+//! Runnable demonstrations of common integration patterns live in the
+//! [`examples/`] directory of the repository:
+//!
+//! | Example               | Description                                                          |
+//! | --------------------- | -------------------------------------------------------------------- |
+//! | [`block-decode`]      | Decode a Byron-era block from CBOR                                   |
+//! | [`block-download`]    | Download a single block from a remote node by chain point            |
+//! | [`crawler`]           | Consume the chain-sync mini-protocol with pluggable block/tx filters |
+//! | [`n2n-miniprotocols`] | Node-to-node mini-protocols over TCP                                 |
+//! | [`n2c-miniprotocols`] | Node-to-client mini-protocols over a local Unix socket               |
+//! | [`p2p-initiator`]     | Initiate a P2P connection using `pallas-network2`                    |
+//! | [`p2p-responder`]     | Accept incoming P2P connections using `pallas-network2`              |
+//! | [`p2p-discovery`]     | Peer discovery using `pallas-network2`                               |
+//! | [`wallet`]            | Wallet key generation, BIP-39 mnemonics, address derivation          |
+//! | [`otel`]              | OpenTelemetry collector configuration for tracing the examples above |
+//!
+//! [`block-decode`]: https://github.com/txpipe/pallas/tree/main/examples/block-decode
+//! [`block-download`]: https://github.com/txpipe/pallas/tree/main/examples/block-download
+//! [`crawler`]: https://github.com/txpipe/pallas/tree/main/examples/crawler
+//! [`n2n-miniprotocols`]: https://github.com/txpipe/pallas/tree/main/examples/n2n-miniprotocols
+//! [`n2c-miniprotocols`]: https://github.com/txpipe/pallas/tree/main/examples/n2c-miniprotocols
+//! [`p2p-initiator`]: https://github.com/txpipe/pallas/tree/main/examples/p2p-initiator
+//! [`p2p-responder`]: https://github.com/txpipe/pallas/tree/main/examples/p2p-responder
+//! [`p2p-discovery`]: https://github.com/txpipe/pallas/tree/main/examples/p2p-discovery
+//! [`wallet`]: https://github.com/txpipe/pallas/tree/main/examples/wallet
+//! [`otel`]: https://github.com/txpipe/pallas/tree/main/examples/otel
+//!
+//! # Feature flags
+//!
+//! | Feature    | Enables                                                       |
+//! | ---------- | ------------------------------------------------------------- |
+//! | `hardano`  | Haskell-node interop (`pallas::interop::hardano`)             |
+//! | `phase2`   | Plutus script validation in [`ledger::validate`]              |
+//! | `network2` | The P2P-first networking stack (`pallas::network2`)           |
+//! | `relaxed`  | Relaxed validation modes across primitives and crypto         |
+//! | `unstable` | Aggregates feature gates that are not yet stable              |
+//!
+//! Features are additive: enabling one never removes APIs exposed by another.
+//! [docs.rs](https://docs.rs/pallas) builds with `all-features`.
+//!
+//! # Minimum Supported Rust Version
+//!
+//! Pallas's MSRV is **Rust 1.88**. Bumping it is treated as a breaking change
+//! and is called out in the changelog.
+//!
+//! # License
+//!
+//! Distributed under the terms of the [Apache License 2.0][license]. To report
+//! a security issue, follow the disclosure process in [SECURITY.md][security]
+//! rather than opening a public issue.
+//!
+//! [`pallas-network`]: https://crates.io/crates/pallas-network
+//! [`pallas-primitives`]: https://crates.io/crates/pallas-primitives
+//! [`examples/`]: https://github.com/txpipe/pallas/tree/main/examples
+//! [license]: https://github.com/txpipe/pallas/blob/main/LICENSE
+//! [security]: https://github.com/txpipe/pallas/blob/main/SECURITY.md
 
 #![warn(missing_docs)]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/txpipe/pallas/main/assets/logo-light.svg"
+)]
 
-#[doc(inline)]
-pub use pallas_network as network;
-
-#[cfg(feature = "network2")]
-#[doc(inline)]
-pub use pallas_network2 as network2;
-
-pub mod ledger {
-    //! Ledger primitives and cbor codecs for different Cardano eras
-
-    #[doc(inline)]
-    pub use pallas_primitives as primitives;
-
-    #[doc(inline)]
-    pub use pallas_traverse as traverse;
-
-    #[doc(inline)]
-    pub use pallas_addresses as addresses;
-
-    #[doc(inline)]
-    pub use pallas_validate as validate;
-
-    #[doc(inline)]
-    // WARNING: this is deprecated, use `pallas::interop::hardano::configs` instead.
-    // Since deprecation notices don't work for re-exports we don't have a way to notify users.
-    pub use pallas_configs as configs;
+pub mod network {
+    //! Wire-level Ouroboros networking stack.
+    //!
+    //! Implements the multiplexer and the node-to-node / node-to-client
+    //! mini-protocols (chain-sync, block-fetch, tx-submission, local-state
+    //! query, handshake, keep-alive, …) used to communicate with other
+    //! Cardano nodes.
+    //!
+    //! Re-export of the [`pallas-network`] crate.
+    //!
+    //! [`pallas-network`]: https://crates.io/crates/pallas-network
+    pub use pallas_network::*;
 }
 
-#[doc(inline)]
-pub use pallas_crypto as crypto;
+#[cfg(feature = "network2")]
+pub mod network2 {
+    //! P2P-first rewrite of the Ouroboros networking stack.
+    //!
+    //! Adds peer discovery and inbound connection handling on top of the
+    //! mini-protocols, suitable for participating in the public relay mesh
+    //! rather than only connecting out to a known node.
+    //!
+    //! Requires the `network2` feature. Re-export of the [`pallas-network2`]
+    //! crate.
+    //!
+    //! [`pallas-network2`]: https://crates.io/crates/pallas-network2
+    pub use pallas_network2::*;
+}
 
-#[doc(inline)]
-pub use pallas_codec as codec;
+pub mod ledger {
+    //! Cardano's on-chain data model.
+    //!
+    //! How blocks, transactions, addresses, and ledger state are represented,
+    //! traversed, and validated across every era from Byron to Conway.
+
+    pub mod primitives {
+        //! Ledger primitives and CBOR codec for every Cardano era.
+        //!
+        //! One module per era (`byron`, `alonzo`, `babbage`, `conway`, …)
+        //! exposing the canonical types and their `minicbor`
+        //! encode/decode implementations.
+        //!
+        //! Re-export of the [`pallas-primitives`] crate.
+        //!
+        //! [`pallas-primitives`]: https://crates.io/crates/pallas-primitives
+        pub use pallas_primitives::*;
+    }
+
+    pub mod traverse {
+        //! Multi-era traversal of block and transaction data.
+        //!
+        //! A unified API for walking over blocks, headers, transactions,
+        //! inputs, outputs, assets, certificates, and metadata without
+        //! branching on era at every call site.
+        //!
+        //! Re-export of the [`pallas-traverse`] crate.
+        //!
+        //! [`pallas-traverse`]: https://crates.io/crates/pallas-traverse
+        pub use pallas_traverse::*;
+    }
+
+    pub mod addresses {
+        //! Encode and decode Cardano addresses of any type.
+        //!
+        //! Covers Byron, Shelley payment, and stake addresses, with bech32,
+        //! hex, and raw-byte representations.
+        //!
+        //! Re-export of the [`pallas-addresses`] crate.
+        //!
+        //! [`pallas-addresses`]: https://crates.io/crates/pallas-addresses
+        pub use pallas_addresses::*;
+    }
+
+    pub mod validate {
+        //! Apply Cardano ledger rules to transactions and blocks.
+        //!
+        //! Phase-1 covers structural and policy checks (fees, witnesses,
+        //! validity intervals, …). Phase-2 evaluates Plutus scripts and
+        //! reports execution units; it is gated on the `phase2` feature.
+        //!
+        //! Re-export of the [`pallas-validate`] crate.
+        //!
+        //! [`pallas-validate`]: https://crates.io/crates/pallas-validate
+        pub use pallas_validate::*;
+    }
+}
+
+pub mod crypto {
+    //! Cryptographic primitives used across Cardano.
+    //!
+    //! Blake2b hashes, Ed25519 keys and signatures, KES (Key Evolving
+    //! Signatures), VRF, and the nonce derivation used by Ouroboros leader
+    //! selection. Algorithms target the choices made by the Cardano
+    //! protocol.
+    //!
+    //! Re-export of the [`pallas-crypto`] crate.
+    //!
+    //! [`pallas-crypto`]: https://crates.io/crates/pallas-crypto
+    pub use pallas_crypto::*;
+}
+
+pub mod codec {
+    //! Shared CBOR codec for Cardano data structures.
+    //!
+    //! Built on [`minicbor`]; also re-exports the Plutus Core flat codec and
+    //! the round-trip helper types (`Bytes`, `Nullable`, `Set`, …) that the
+    //! rest of Pallas depends on.
+    //!
+    //! Re-export of the [`pallas-codec`] crate.
+    //!
+    //! [`pallas-codec`]: https://crates.io/crates/pallas-codec
+    pub use pallas_codec::codec_by_datatype;
+    pub use pallas_codec::*;
+}
 
 // TODO: re-incorporate math here once we commit to a final set of upstream
 // dependencies
 
-// #[doc(inline)]
-// #[cfg(feature = "pallas-math")]
-// pub use pallas_math as math;
+// pub mod math {
+//     //! Cardano-specific math (rational arithmetic, fixed-point decimals).
+//     #[cfg(feature = "pallas-math")]
+//     pub use pallas_math::*;
+// }
 
 pub mod interop {
-    //! Interoperability with other protocols, formats & systems
+    //! Adapters for systems built outside Pallas.
+    //!
+    //! Bridges to external file formats, RPC schemas, and node artifacts so
+    //! Pallas types can be consumed from — and produced for — the wider
+    //! Cardano tooling ecosystem.
 
-    #[doc(inline)]
-    pub use pallas_utxorpc as utxorpc;
+    pub mod utxorpc {
+        //! Convert between Pallas types and the [UTxO RPC] wire format.
+        //!
+        //! Re-export of the [`pallas-utxorpc`] crate.
+        //!
+        //! [UTxO RPC]: https://utxorpc.org
+        //! [`pallas-utxorpc`]: https://crates.io/crates/pallas-utxorpc
+        pub use pallas_utxorpc::*;
+    }
 
-    #[cfg(feature = "pallas-hardano")]
+    #[cfg(feature = "hardano")]
     pub mod hardano {
-        //! Interoperability with the Haskell Cardano node
+        //! Interop with implementation-specific artifacts of the Haskell
+        //! Cardano node.
+        //!
+        //! Read on-disk chain data written by the upstream node. Gated on
+        //! the `hardano` feature.
+        //!
+        //! Re-export of the [`pallas-hardano`] crate.
+        //!
+        //! [`pallas-hardano`]: https://crates.io/crates/pallas-hardano
+        pub use pallas_hardano::*;
 
-        #[doc(inline)]
-        pub use pallas_hardano::storage;
-
-        #[doc(inline)]
-        pub use pallas_configs as configs;
+        pub mod configs {
+            //! Genesis configs matching the Haskell Cardano node.
+            //!
+            //! Strongly-typed structs for the Byron, Shelley, Alonzo, and Conway
+            //! genesis files.
+            //!
+            //! Re-export of the [`pallas-configs`] crate.
+            //!
+            //! [`pallas-configs`]: https://crates.io/crates/pallas-configs
+            pub use pallas_configs::*;
+        }
     }
 }
 
-pub mod storage {
-    //! Storage engines for chain-related persistence
-
-    #[cfg(feature = "pallas-hardano")]
-    #[doc(inline)]
-    // WARNING: this is deprecated, use `pallas::interop::hardano::storage` instead.
-    // Since deprecation notices don't work for re-exports we don't have a way to notify users.
-    pub use pallas_hardano::storage as hardano;
+pub mod txbuilder {
+    //! Ergonomic builder for Cardano transactions.
+    //!
+    //! Stage inputs, outputs, mints, certificates, and witnesses through a
+    //! fluent API, then call into an era-specific builder (e.g. Conway) to
+    //! produce a fully-encoded, signable transaction.
+    //!
+    //! Re-export of the [`pallas-txbuilder`] crate.
+    //!
+    //! [`pallas-txbuilder`]: https://crates.io/crates/pallas-txbuilder
+    pub use pallas_txbuilder::*;
 }
-
-pub mod wallet {
-    //! Utilities for wallet implementations
-
-    #[doc(inline)]
-    pub use pallas_txbuilder as txbuilder;
-}
-
-#[doc(inline)]
-// WARNING: this is deprecated, use `pallas::wallet::txbuilder` instead.
-// Since deprecation notices don't work for re-exports we don't have a way to notify users.
-pub use pallas_txbuilder as txbuilder;


### PR DESCRIPTION
Adds comprehensive crate- and module-level documentation across the workspace, fixes rustdoc warnings, and moves `pallas::interop::configs` inside `hardano`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded public API surface across networking protocols with new message variants for protocol termination and batch operations.
  * Added `Network::Other(u8)` support for custom networks in address handling.
  * Exposed additional public modules: `nonce` in crypto, `math_dashu` in math, `multiplexer` in network, and `conway` in primitives.

* **Documentation**
  * Substantially enhanced Rustdoc comments across all crates with comprehensive usage examples and architectural overviews.

* **Chores**
  * Reorganized crate root module structure to use explicit public modules instead of alias re-exports.
  * Updated project hierarchy and configuration entries.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/txpipe/pallas/pull/769)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->