### PR TITLE
fix: correct inverted native script timelock comparisons

### DIFF
--- a/pallas-validate/src/phase1/shelley_ma.rs
+++ b/pallas-validate/src/phase1/shelley_ma.rs
@@ -784,7 +784,10 @@ mod tests {
             NativeScript::InvalidBefore(100),
             NativeScript::InvalidHereafter(200),
         ]);
-        assert!(eval(&all, Some(120), Some(180)), "interval within the window");
+        assert!(
+            eval(&all, Some(120), Some(180)),
+            "interval within the window"
+        );
         assert!(!eval(&all, Some(80), Some(180)), "starts too early");
         assert!(!eval(&all, Some(120), Some(220)), "ends too late");
 
@@ -792,7 +795,10 @@ mod tests {
             NativeScript::InvalidBefore(100),
             NativeScript::InvalidHereafter(200),
         ]);
-        assert!(eval(&any, Some(80), Some(180)), "satisfies the hereafter arm");
+        assert!(
+            eval(&any, Some(80), Some(180)),
+            "satisfies the hereafter arm"
+        );
         assert!(!eval(&any, Some(80), Some(220)), "satisfies neither arm");
     }
 }

--- a/pallas-validate/src/phase1/shelley_ma.rs
+++ b/pallas-validate/src/phase1/shelley_ma.rs
@@ -727,15 +727,72 @@ fn eval_native_script(
         }
         NativeScript::InvalidBefore(val) => {
             match low_bnd {
-                Some(time) => val >= time,
+                // The script is satisfied when the transaction cannot be applied
+                // before `val`, i.e. its validity interval starts at or after it.
+                Some(time) => val <= time,
                 None => false, // as per mary-ledger.pdf, p.20
             }
         }
         NativeScript::InvalidHereafter(val) => {
             match upp_bnd {
-                Some(time) => val <= time,
+                // The script is satisfied when the transaction cannot be applied
+                // at or after `val`, i.e. its validity interval ends at or before it.
+                Some(time) => val >= time,
                 None => false, // as per mary-ledger.pdf, p.20
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::eval_native_script;
+    use pallas_primitives::alonzo::NativeScript;
+
+    // Evaluates `native_script` with no vkey witnesses and the given validity
+    // interval bounds (`low_bnd` is `validity_interval_start`, `upp_bnd` is `ttl`).
+    fn eval(native_script: &NativeScript, low_bnd: Option<u64>, upp_bnd: Option<u64>) -> bool {
+        eval_native_script(&Vec::new(), native_script, &low_bnd, &upp_bnd)
+    }
+
+    #[test]
+    // `InvalidBefore(n)` holds only when the transaction's validity interval
+    // starts at or after slot `n` (mary-ledger.pdf, p.20).
+    fn invalid_before() {
+        let script = NativeScript::InvalidBefore(100);
+        assert!(eval(&script, Some(150), None), "starts after the lock");
+        assert!(eval(&script, Some(100), None), "starts exactly at the lock");
+        assert!(!eval(&script, Some(50), None), "starts before the lock");
+        assert!(!eval(&script, None, None), "no lower bound");
+    }
+
+    #[test]
+    // `InvalidHereafter(n)` holds only when the transaction's validity interval
+    // ends at or before slot `n` (mary-ledger.pdf, p.20).
+    fn invalid_hereafter() {
+        let script = NativeScript::InvalidHereafter(200);
+        assert!(eval(&script, None, Some(150)), "ends before the lock");
+        assert!(eval(&script, None, Some(200)), "ends exactly at the lock");
+        assert!(!eval(&script, None, Some(250)), "ends after the lock");
+        assert!(!eval(&script, None, None), "no upper bound");
+    }
+
+    #[test]
+    // Recursion combinators must thread the bounds down to nested timelocks.
+    fn nested_timelocks() {
+        let all = NativeScript::ScriptAll(vec![
+            NativeScript::InvalidBefore(100),
+            NativeScript::InvalidHereafter(200),
+        ]);
+        assert!(eval(&all, Some(120), Some(180)), "interval within the window");
+        assert!(!eval(&all, Some(80), Some(180)), "starts too early");
+        assert!(!eval(&all, Some(120), Some(220)), "ends too late");
+
+        let any = NativeScript::ScriptAny(vec![
+            NativeScript::InvalidBefore(100),
+            NativeScript::InvalidHereafter(200),
+        ]);
+        assert!(eval(&any, Some(80), Some(180)), "satisfies the hereafter arm");
+        assert!(!eval(&any, Some(80), Some(220)), "satisfies neither arm");
     }
 }


### PR DESCRIPTION
## Summary

`eval_native_script` in `pallas-validate/src/phase1/shelley_ma.rs` evaluated both native-script timelock opcodes with **inverted comparisons**:

- `InvalidBefore(n)` was satisfied when the transaction's validity interval started *before* slot `n` — it should be satisfied when it starts *at or after* `n`.
- `InvalidHereafter(n)` was satisfied when the validity interval ended *after* slot `n` — it should be satisfied when it ends *at or before* `n`.

This matches `evalTimelock` in the Mary/Allegra ledger spec (mary-ledger.pdf p.20). The result was consensus-relevant validation that both accepts invalid transactions and rejects valid ones.

The issue reporter spotted `InvalidBefore`; `InvalidHereafter` was inverted the same way and is fixed here too. The `None` (unbounded) arms were already correct and are unchanged.

## Changes

- Flip the two comparison operators in `eval_native_script`.
- Add a `#[cfg(test)] mod tests` exercising the previously untested timelock branches: `invalid_before`, `invalid_hereafter` (after / exactly-at / before the lock, plus the missing-bound case), and `nested_timelocks` (`ScriptAll` / `ScriptAny` recursion).

## Verification

- New unit tests: 3 passed
- Existing `shelley_ma` integration tests: 25 passed — no regression

Fixes #718

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected timelock validation semantics: validity-interval bounds for before/after checks now evaluate in the intended direction, affecting when native scripts are considered satisfied.

* **Tests**
  * Added unit tests covering before/after bound checks and recursive propagation through combined timelock scripts to validate the updated behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/txpipe/pallas/pull/778?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->