### PR TITLE
fix: make serde a non-optional dependency of pallas-primitives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,20 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace --all-targets ${{ matrix.flags }}
 
+  isolated-features:
+    name: Isolated no-default-features
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # A workspace-wide --no-default-features build unifies features across
+      # members, so it always pulls pallas-primitives in with `json` enabled.
+      # Check the crate in isolation to catch missing serde feature gating.
+      - run: cargo check -p pallas-primitives --no-default-features
+
   msrv:
     name: MSRV (1.88)
     runs-on: ubuntu-latest

--- a/pallas-primitives/Cargo.toml
+++ b/pallas-primitives/Cargo.toml
@@ -15,7 +15,7 @@ authors.workspace = true
 hex.workspace = true
 pallas-crypto.workspace = true
 pallas-codec.workspace = true
-serde = { workspace = true, optional = true }
+serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -23,6 +23,6 @@ proptest = { workspace = true, features = ["alloc"] }
 test-case = "3.3.1"
 
 [features]
-json = ["serde", "serde_json"]
+json = ["serde_json"]
 default = ["json"]
 relaxed = ["pallas-crypto/relaxed"]


### PR DESCRIPTION
## Summary

`pallas-primitives` declared `serde` as an optional dependency gated behind the `json` feature, but the era models (`lib.rs`, `plutus_data.rs`, `alonzo/model.rs`, `babbage/model.rs`, `conway/model.rs`, `conway/script_data.rs`) use `serde::{Serialize, Deserialize}` and `#[serde(...)]` attributes **unconditionally**. Building the crate with `default-features = false` therefore failed with `E0432: unresolved import \`serde\``.

Rather than `#[cfg(feature = "json")]`-gating ~90 derive/attribute sites, this makes `serde` a plain (non-optional) dependency:

- `pallas-codec` and `pallas-crypto` already depend on `serde` unconditionally, so any consumer of `pallas-primitives` — even with `default-features = false` — already compiles serde transitively. The "optional" gating provided no real benefit; it only broke the build.
- The `json` feature now gates only `serde_json` (the `to_json` API in `framework.rs` / `alonzo/json.rs`), which was already correctly `#[cfg]`-gated.

## Why CI didn't catch this

The existing `features` job runs `cargo check --workspace --no-default-features`, but a workspace-wide build unifies features across members — other crates depend on `pallas-primitives` with default features, so `json` (and serde) was always pulled back in. This PR adds an `isolated-features` job running `cargo check -p pallas-primitives --no-default-features`, which builds the crate on its own and would have caught the regression.

## Verification

- `cargo build -p pallas-primitives` (default) — ok
- `cargo build -p pallas-primitives --no-default-features` — ok (previously failed)
- `cargo build --workspace` — ok
- `cargo test -p pallas-primitives` — ok

Fixes #740

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CI workflow job for isolated feature validation
  * Updated dependency configuration to ensure proper feature gating

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/txpipe/pallas/pull/779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->