### PR TITLE
Fix flaky `full_protocol_flow` test by removing redundant `Housekeeping`

### DIFF
--- a/pallas-network2/tests/initiator_responder.rs
+++ b/pallas-network2/tests/initiator_responder.rs
@@ -124,7 +124,6 @@ async fn full_protocol_flow() {
     // Phase 3: blockfetch
     let range = (Point::Origin, Point::new(100, vec![0xAA; 32]));
     initiator.execute(InitiatorCommand::RequestBlocks(range));
-    initiator.execute(InitiatorCommand::Housekeeping);
 
     let events = initiator.wait_for_block().await;
     assert!(


### PR DESCRIPTION
Removes the explicit `Housekeeping` command immediately after `RequestBlocks` in `full_protocol_flow`.

Test `full_protocol_flow` sometime fails:
```
thread 'full_protocol_flow' panicked at pallas-network2/tests/harness/node.rs:170:13:
test timed out after 10s. Events collected: []
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test full_protocol_flow ... FAILED
```
I reproduced that with running it in loop:
```sh
for i in $(seq 1 30); do
  echo "RUN $i"
  cargo +1.88 test -p pallas-network2 --test initiator_responder full_protocol_flow -- --nocapture || break
done
```
Removing `Housekeeping` after `RequestBlocks` solved this for me. `run_until` already calls it so maybe it is redundant:

https://github.com/txpipe/pallas/blob/705dc70c8dc348fee141089134d8e7f13ba4a5c0/pallas-network2/tests/harness/node.rs#L161-L162
