### PR TITLE
ci: fix silent no-op crates.io publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,10 @@ jobs:
       - name: Publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo release publish --workspace --execute --no-confirm --allow-branch HEAD
+        # --isolated ignores [workspace.metadata.release], whose `publish = false`
+        # (kept so local `cargo release <version>` only tags) would otherwise make
+        # this a silent no-op.
+        run: cargo release publish --workspace --execute --no-confirm --allow-branch HEAD --isolated
 
   github_release:
     name: Create GitHub Release


### PR DESCRIPTION
## Problem

The `v1.1.0` release CI job ran green but published **nothing** to crates.io. The publish step (`cargo release publish --workspace --execute ...`) printed only its plan line (`Publishing pallas-codec, …`) and exited `0` without uploading a single crate.

Root cause: the workspace `Cargo.toml` carries

```toml
[workspace.metadata.release]
push = false
publish = false
```

`publish = false` is intentional — it lets a local `cargo release <version>` do bump + commit + tag only. But cargo-release reads that same config in CI, so `cargo release publish` treated every crate as do-not-publish and no-op'd while still exiting `0`. The green check hid it.

## Fix

- Add `--isolated` to the CI publish command so cargo-release ignores `[workspace.metadata.release]` and `publish` defaults back to `true` — **CI only**, the local tag-only flow is unchanged. Verified against the `v1.1.0` tree: without it → silent no-op; with it → `Uploading pallas-codec v1.1.0 …`.
- Add a post-publish guard that polls the sparse index for the umbrella `pallas` crate at the tag's version and **fails the job** if it never appears, so a no-op publish can never report success again. Since all crates publish together pinned to `=version`, `pallas` being live implies the rest are.

## Note

`v1.1.0` has already been published manually to crates.io to unblock consumers; this PR prevents a recurrence on the next release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow reliability by adding verification that published versions are properly indexed on crates.io before workflow completion, reducing the risk of failed or incomplete releases going undetected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->