### PR TITLE
Add strict varuint and pointer parsing

### DIFF
--- a/pallas-addresses/src/lib.rs
+++ b/pallas-addresses/src/lib.rs
@@ -133,6 +133,18 @@ pub type CertIdx = u64;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Pointer(Slot, TxIdx, CertIdx);
 
+/// Errors produced by strict pointer parsing.
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum PointerStrictError {
+    /// A variable-length uint inside a pointer address failed strict decoding.
+    #[error("variable-length uint error: {0}")]
+    VarUintError(varuint::StrictError),
+
+    /// The three pointer components were valid, but extra bytes remained.
+    #[error("pointer payload has trailing bytes")]
+    TrailingBytes,
+}
+
 fn slice_to_hash(slice: &[u8]) -> Result<Hash<28>, Error> {
     if slice.len() == 28 {
         let mut sized = [0u8; 28];
@@ -155,6 +167,21 @@ impl Pointer {
         let a = varuint::read(&mut cursor).map_err(Error::VarUintError)?;
         let b = varuint::read(&mut cursor).map_err(Error::VarUintError)?;
         let c = varuint::read(&mut cursor).map_err(Error::VarUintError)?;
+
+        Ok(Pointer(a, b, c))
+    }
+
+    /// Parse a pointer from its variable-length byte encoding, requiring
+    /// canonical varuints and full input consumption.
+    pub fn parse_strict(bytes: &[u8]) -> Result<Self, PointerStrictError> {
+        let mut cursor = Cursor::new(bytes);
+        let a = varuint::read_strict(&mut cursor).map_err(PointerStrictError::VarUintError)?;
+        let b = varuint::read_strict(&mut cursor).map_err(PointerStrictError::VarUintError)?;
+        let c = varuint::read_strict(&mut cursor).map_err(PointerStrictError::VarUintError)?;
+
+        if cursor.position() != bytes.len() as u64 {
+            return Err(PointerStrictError::TrailingBytes);
+        }
 
         Ok(Pointer(a, b, c))
     }
@@ -1071,5 +1098,48 @@ mod tests {
             "015bad085057ac10ecc7060f7ac41edd6f63068d8963ef7d86ca58669e5ecf2d283418a60be5a848a2380eb721000da1e0bbf39733134beca4cb57afb0b35fc89c63061c9914e055001a518c7516",
         );
         assert!(matches!(addr, Ok(Address::Shelley(_))));
+    }
+
+    #[test]
+    fn pointer_parse_accepts_noncanonical_varuint_encoding() {
+        let noncanonical = [0x80, 0x00, 0x80, 0x00, 0x80, 0x00];
+
+        let parsed = Pointer::parse(&noncanonical).unwrap();
+
+        assert_eq!(parsed, Pointer::new(0, 0, 0));
+        assert_eq!(parsed.to_vec(), vec![0x00, 0x00, 0x00]);
+        assert_ne!(parsed.to_vec(), noncanonical);
+    }
+
+    #[test]
+    fn pointer_parse_strict_rejects_noncanonical_varuint_encoding() {
+        let noncanonical = [0x80, 0x00, 0x80, 0x00, 0x80, 0x00];
+
+        let parsed = Pointer::parse_strict(&noncanonical);
+
+        assert_eq!(
+            parsed,
+            Err(PointerStrictError::VarUintError(
+                varuint::StrictError::NonCanonical
+            ))
+        );
+    }
+
+    #[test]
+    fn pointer_parse_strict_accepts_canonical_encoding() {
+        let canonical = [0x00, 0x00, 0x00];
+
+        let parsed = Pointer::parse_strict(&canonical).unwrap();
+
+        assert_eq!(parsed, Pointer::new(0, 0, 0));
+    }
+
+    #[test]
+    fn pointer_parse_strict_rejects_trailing_bytes() {
+        let bytes = [0x00, 0x00, 0x00, 0x00];
+
+        let parsed = Pointer::parse_strict(&bytes);
+
+        assert_eq!(parsed, Err(PointerStrictError::TrailingBytes));
     }
 }

--- a/pallas-addresses/src/varuint.rs
+++ b/pallas-addresses/src/varuint.rs
@@ -4,7 +4,7 @@ use std::io::{Cursor, Read, Write};
 
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum Error {
     #[error("variable-length uint overflow")]
     VarUintOverflow,
@@ -13,20 +13,65 @@ pub enum Error {
     UnexpectedEof,
 }
 
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum StrictError {
+    #[error("variable-length uint overflow")]
+    VarUintOverflow,
+
+    #[error("unexpected end-of-buffer")]
+    UnexpectedEof,
+
+    #[error("non-canonical variable-length uint encoding")]
+    NonCanonical,
+}
+
 pub fn read(cursor: &mut Cursor<&[u8]>) -> Result<u64, Error> {
+    read_inner(cursor, false).map_err(|e| match e {
+        ReadModeError::Legacy(err) => err,
+        ReadModeError::Strict(StrictError::VarUintOverflow) => Error::VarUintOverflow,
+        ReadModeError::Strict(StrictError::UnexpectedEof) => Error::UnexpectedEof,
+        ReadModeError::Strict(StrictError::NonCanonical) => unreachable!(),
+    })
+}
+
+pub fn read_strict(cursor: &mut Cursor<&[u8]>) -> Result<u64, StrictError> {
+    read_inner(cursor, true).map_err(|e| match e {
+        ReadModeError::Legacy(err) => match err {
+            Error::VarUintOverflow => StrictError::VarUintOverflow,
+            Error::UnexpectedEof => StrictError::UnexpectedEof,
+        },
+        ReadModeError::Strict(err) => err,
+    })
+}
+
+enum ReadModeError {
+    Legacy(Error),
+    Strict(StrictError),
+}
+
+fn read_inner(cursor: &mut Cursor<&[u8]>, strict: bool) -> Result<u64, ReadModeError> {
     let mut output = 0u128;
     let mut buf = [0u8; 1];
+    let start = cursor.position() as usize;
 
     loop {
-        cursor
-            .read_exact(&mut buf)
-            .map_err(|_| Error::UnexpectedEof)?;
+        cursor.read_exact(&mut buf).map_err(|_| {
+            if strict {
+                ReadModeError::Strict(StrictError::UnexpectedEof)
+            } else {
+                ReadModeError::Legacy(Error::UnexpectedEof)
+            }
+        })?;
 
         let byte = buf[0];
 
         output = (output << 7) | (byte & 0x7F) as u128;
 
         if output > u64::MAX.into() {
+            if strict {
+                return Err(ReadModeError::Strict(StrictError::VarUintOverflow));
+            }
+
             // Strictly speaking, if we find a value above max u64, an overflow error should
             // be returned. The problem is that testnet has some invalid address values
             // somehow minted in valid blocks. The node and many explorers, instead of
@@ -38,7 +83,19 @@ pub fn read(cursor: &mut Cursor<&[u8]>) -> Result<u64, Error> {
         }
 
         if (byte & 0x80) == 0 {
-            return Ok(output as u64);
+            let output = output as u64;
+
+            if strict {
+                let end = cursor.position() as usize;
+                let consumed = &cursor.get_ref()[start..end];
+                let canonical = encode_to_vec(output);
+
+                if consumed != canonical.as_slice() {
+                    return Err(ReadModeError::Strict(StrictError::NonCanonical));
+                }
+            }
+
+            return Ok(output);
         }
     }
 }
@@ -53,4 +110,59 @@ pub fn write(cursor: &mut Cursor<Vec<u8>>, mut num: u64) {
     output.reverse();
 
     cursor.write_all(&output).unwrap();
+}
+
+fn encode_to_vec(num: u64) -> Vec<u8> {
+    let mut cursor = Cursor::new(vec![]);
+    write(&mut cursor, num);
+    cursor.into_inner()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_accepts_noncanonical_zero_for_compatibility() {
+        let bytes = [0x80, 0x00];
+        let mut cursor = Cursor::new(bytes.as_slice());
+
+        let value = read(&mut cursor).unwrap();
+
+        assert_eq!(value, 0);
+        assert_eq!(cursor.position(), 2);
+    }
+
+    #[test]
+    fn read_strict_rejects_noncanonical_zero() {
+        let bytes = [0x80, 0x00];
+        let mut cursor = Cursor::new(bytes.as_slice());
+
+        let value = read_strict(&mut cursor);
+
+        assert_eq!(value, Err(StrictError::NonCanonical));
+    }
+
+    #[test]
+    fn read_strict_accepts_canonical_zero() {
+        let bytes = [0x00];
+        let mut cursor = Cursor::new(bytes.as_slice());
+
+        let value = read_strict(&mut cursor).unwrap();
+
+        assert_eq!(value, 0);
+        assert_eq!(cursor.position(), 1);
+    }
+
+    #[test]
+    fn read_strict_rejects_overflow() {
+        let bytes = [
+            0x82, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x00,
+        ];
+        let mut cursor = Cursor::new(bytes.as_slice());
+
+        let value = read_strict(&mut cursor);
+
+        assert_eq!(value, Err(StrictError::VarUintOverflow));
+    }
 }


### PR DESCRIPTION
## Summary

Adds strict opt-in parsing APIs for pointer varuints in `pallas-addresses`
without changing the legacy parsing behavior.

Closes #786.

## What changed

- added `varuint::StrictError`
- added `varuint::read_strict`
- added `PointerStrictError`
- added `Pointer::parse_strict`
- added regression tests for the legacy behavior
- added strict-mode tests for:
  - non-canonical varuint rejection
  - overflow rejection
  - trailing-byte rejection
  - canonical pointer acceptance

## Validation

- `cargo fmt -p pallas-addresses`
- `cargo check -p pallas-addresses`
- `cargo clippy -p pallas-addresses --all-targets -- -D warnings`
- `cargo test -p pallas-addresses --lib`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict validation mode for parsing address data that enforces canonical encoding standards
  * Detects and rejects non-canonical representations, malformed encodings, and trailing bytes
  * Provides detailed error types for specific validation failures

* **Improvements**
  * Enhanced robustness of data parsing with stricter integrity checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->