### PR TITLE
fix(utxorpc): convert block timestamp from seconds to ms in u5c mapping

### DIFF
--- a/pallas-utxorpc/src/shared.rs
+++ b/pallas-utxorpc/src/shared.rs
@@ -461,10 +461,13 @@ macro_rules! impl_cardano_mapper_shared {
                         tx: block.txs().iter().map(|x| self.map_tx(x)).collect(),
                     }
                     .into(),
+                    // The spec declares `Block.timestamp` as milliseconds;
+                    // `get_slot_timestamp` returns UNIX seconds.
                     timestamp: self
                         .ledger
                         .as_ref()
                         .and_then(|ledger| ledger.get_slot_timestamp(block.slot()))
+                        .map(|seconds| seconds * 1000)
                         .unwrap_or(0),
                 }
             }


### PR DESCRIPTION
A sixth site of the seconds-vs-milliseconds timestamp mismatch fixed in txpipe/dolos#1003: the u5c `Mapper` writes `LedgerContext::get_slot_timestamp`'s seconds-typed value straight into `Block.timestamp`, which the utxorpc spec declares as milliseconds.

## What the proto says

`utxorpc/spec` declares `cardano.Block.timestamp` as milliseconds (`// Block ms timestamp`), same as the four `ChainPoint`/`BlockRef` sites dolos#1003 covered.

## What the mapper actually writes

`pallas-utxorpc/src/shared.rs` (`map_block`, shared by the v1alpha and v1beta mappers):

```rust
timestamp: self
    .ledger
    .as_ref()
    .and_then(|ledger| ledger.get_slot_timestamp(block.slot()))
    .unwrap_or(0),
```

`LedgerContext::get_slot_timestamp` is documented as UNIX **seconds** (`pallas-utxorpc/src/lib.rs`), and implementations follow that contract — so every parsed block flowing through the mapper (Dolos `SyncService.FollowTip` / `DumpHistory` among others) carries a seconds value in a ms field.

Observed downstream against Dolos `sha-c469c7f` on preprod: a block at slot ~125.54M arrived with `timestamp ≈ 1_781_253_xxx`. Read as seconds that decodes to 2026-06-12, which matches the slot arithmetic (preprod system start 2022-06-01, 20-day Byron era at 20s slots, 1s slots after) to the day; read as ms per spec it decodes to 1970-01-21, which is how our chain-follower's e2e caught it.

## The fix

Same principle as dolos#1003: convert at the proto write boundary, keep the trait untouched — its seconds contract is documented and correctly implemented. One functional line:

```rust
.map(|seconds| seconds * 1000)
```

A missing timestamp stays `0` (proto3 default), unchanged.

## Verification

`cargo test -p pallas-utxorpc` green. With the multiplication in place the observed preprod values decode to the same wall-clock dates as the slot math — the conversion promotes units, it does not reinterpret anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected block timestamps to use millisecond precision.
  * Preserved a fallback timestamp when ledger timing data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->