### PR TITLE
fix(ci): restore green CI under current stable clippy and cddl 0.10.7

### DIFF
--- a/pallas-hardano/src/display/haskell_display.rs
+++ b/pallas-hardano/src/display/haskell_display.rs
@@ -681,8 +681,8 @@ impl HaskellDisplay for ValidityInterval {
     fn to_haskell_str(&self) -> String {
         format!(
             "(ValidityInterval {{invalidBefore = {}, invalidHereafter = {}}})",
-            &self.invalid_before.as_slot_no(),
-            &self.invalid_hereafter.as_slot_no()
+            self.invalid_before.as_slot_no(),
+            self.invalid_hereafter.as_slot_no()
         )
     }
 }

--- a/pallas-hardano/src/display/haskell_display.rs
+++ b/pallas-hardano/src/display/haskell_display.rs
@@ -2549,7 +2549,9 @@ impl AsIPv6 for Nullable<Bytes> {
             Nullable::Some(b) => {
                 let data: [u8; 16] = b
                     .deref()
-                    .chunks_exact(4)
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
                     .flat_map(|x| {
                         let mut y = x.to_vec();
                         y.reverse();

--- a/pallas-math/src/math.rs
+++ b/pallas-math/src/math.rs
@@ -441,8 +441,8 @@ mod tests {
                 (&one - &threshold_b).to_string(),
                 expected_threshold_b,
                 "(1 - f) *** b failed to match! - (1 - f)={}, b={}",
-                &c,
-                &b
+                c,
+                b
             );
 
             // do Taylor approximation for
@@ -467,14 +467,14 @@ mod tests {
             if a < threshold && res.estimation != ExpOrdering::LT {
                 panic!(
                     "wrong result should be leader {} should be more like {}",
-                    &temp, threshold
+                    temp, threshold
                 );
             }
 
             if a >= threshold && res.estimation != ExpOrdering::GT {
                 panic!(
                     "wrong result should not be leader {} should be more like {}",
-                    &temp, threshold
+                    temp, threshold
                 );
             }
 

--- a/pallas-network2/Cargo.toml
+++ b/pallas-network2/Cargo.toml
@@ -24,7 +24,11 @@ byteorder.workspace = true
 socket2.workspace = true
 thiserror.workspace = true
 hex.workspace = true
-cddl = { version = "0.10", optional = true }
+# Pinned: cddl 0.10.7 regressed map entries whose key is a type-rule reference
+# (`bitmaps = { * word16 => word64 }` with `word16 = uint`), rejecting every key
+# as unexpected. Inline key types still validate, named ones do not. Still broken
+# on cddl master as of 2026-08-25. Relax once a release carries the fix.
+cddl = { version = "=0.10.6", optional = true }
 
 [features]
 emulation = ["tokio", "rand"]

--- a/pallas-validate/src/phase1/alonzo.rs
+++ b/pallas-validate/src/phase1/alonzo.rs
@@ -909,7 +909,7 @@ fn check_minting(tx_body: &TransactionBody, mtx: &Tx) -> ValidationResult {
                     None => Vec::new(),
                     Some(plutus_v1_script_wits) => plutus_v1_script_wits.clone(),
                 };
-            for (policy, _) in minted_value.iter() {
+            for policy in minted_value.keys() {
                 if native_script_wits
                     .iter()
                     .all(|native_script| compute_native_script_hash(native_script) != *policy)

--- a/pallas-validate/src/phase1/babbage.rs
+++ b/pallas-validate/src/phase1/babbage.rs
@@ -471,7 +471,7 @@ fn check_minting(tx_body: &TransactionBody, mtx: &Tx, utxos: &UTxOs) -> Validati
 
             dbg!(&all_scripts_wits);
 
-            for (policy, _) in minted_value.iter() {
+            for policy in minted_value.keys() {
                 if !all_scripts_wits.contains(policy) {
                     return Err(PostAlonzo(MintingLacksPolicy(*policy)));
                 }

--- a/pallas-validate/src/phase1/conway.rs
+++ b/pallas-validate/src/phase1/conway.rs
@@ -603,7 +603,7 @@ fn check_minting(tx_body: &TransactionBody, mtx: &Tx, utxos: &UTxOs) -> Validati
                 .chain(ref_scripts)
                 .collect();
 
-            for (policy, _) in minted_value.iter() {
+            for policy in minted_value.keys() {
                 if !all_scripts_wits.contains(policy) {
                     return Err(PostAlonzo(MintingLacksPolicy(*policy)));
                 }

--- a/pallas-validate/src/phase1/shelley_ma.rs
+++ b/pallas-validate/src/phase1/shelley_ma.rs
@@ -386,7 +386,7 @@ fn check_minting(tx_body: &TransactionBody, mtx: &Tx) -> ValidationResult {
                         .map(|x| x.clone().unwrap())
                         .collect(),
                 };
-            for (policy, _) in minted_value.iter() {
+            for policy in minted_value.keys() {
                 if native_script_wits
                     .iter()
                     .all(|script| compute_script_hash(script) != *policy)


### PR DESCRIPTION
CI on `main` is red, and has been since the last green run on 2026-07-01 (`cdee91d`). The workspace does not commit `Cargo.lock` and CI resolves `dtolnay/rust-toolchain@stable`, so both failures are external drift rather than anything in a PR. Reproduced on a clean checkout of `origin/main` with no local changes.

Surfaced while triaging #793, which only touches `pallas-utxorpc/src/shared.rs` and is unaffected by either failure.

## 1. Clippy — new lints on current stable (1.98.0)

`cargo clippy --workspace --all-targets -- -D warnings` fails on four `for_kv_map` hits in `pallas-validate`:

```
error: you seem to want to iterate on a map's keys
   --> pallas-validate/src/phase1/alonzo.rs:912:32
912 |             for (policy, _) in minted_value.iter() {
```

…plus the same in `babbage.rs`, `conway.rs` and `shelley_ma.rs`. The CI log stops there because the build bails, but more failures hide behind it — each one only becomes visible once the crate ahead of it compiles:

- `useless_borrows_in_formatting` on `&`-prefixed `format!`/`assert_eq!`/`panic!` arguments in `pallas-math` tests and `pallas-hardano`'s `ValidityInterval` display.
- `chunks_exact_to_as_chunks` (new in clippy 1.98) on the constant-size `chunks_exact(4)` in `pallas-hardano`'s `AsIPv6`. `slice::as_chunks` is stable since 1.88.0, which is exactly the workspace MSRV, and `.0` drops the same (always empty here) remainder.

All mechanical; `.keys()` is already the idiom elsewhere in the same files. No behaviour change.

## 2. `cddl` 0.10.7 regressed map keys that reference a type rule

`cargo test -p pallas-network -p pallas-network2 --features blueprint` fails on all three OSes:

```
`msgLeiosBlockTxs` does not conform to CDDL:
error validating at cbor location /2: unexpected key Integer(Integer(0))
```

`cddl` 0.10.7 was published 2026-08-10, after the last green run; 0.10.6 (2026-06-29) is what that run resolved. The leios-fetch blueprint schema declares

```cddl
bitmaps = { * base.word16 => base.word64 }
```

and 0.10.7 rejects every key of a map whose key is a *named type rule* rather than an inline type. Reduced repro:

| schema | CBOR | 0.10.6 | 0.10.7 |
|---|---|---|---|
| `{ * uint => uint }` | `{0: 1}` | ok | ok |
| `{ * k => uint }`, `k = uint` | `{0: 1}` | ok | `unexpected key Integer(0)` |
| `{ * k => uint }`, `k = tstr` | `{"a": 10}` | ok | `unexpected key Text("a")` |
| `{ * uint => v }`, `v = uint` | `{0: 1}` | ok | ok |

Only the key position is affected; a named *value* rule still resolves. Definite- and indefinite-length maps behave identically, so this is not about our encoder. Still reproduces against `cddl` master as of 2026-08-25, so this is pinned to `=0.10.6` rather than waiting on a patch release.

`cddl` is optional and reached only through the test-only `blueprint` feature, so the pin does not affect default builds or downstream consumers who leave the feature off. The comment in `Cargo.toml` records when to relax it.

## Verification

Every CI job run locally on rustc/clippy 1.98.0 — the same stable CI resolves — against a freshly resolved lockfile (`rm Cargo.lock`):

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo test --workspace` — no failures
- `cargo test -p pallas-network -p pallas-network2 --features blueprint` — all suites green
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` — clean
- `cargo check --workspace --all-targets` with `--all-features` and `--no-default-features` — clean
- `cargo check -p pallas-primitives --no-default-features` — clean

## Follow-ups (not in this PR)

- The `cddl` map-key regression is unreported upstream; worth an issue on `anweiss/cddl`.
- Both failures reached `main` because nothing runs CI between merges and `Cargo.lock` is uncommitted. A scheduled run would catch drift closer to when it lands, instead of surprising the next contributor to open a PR.
- `connection_sustained_over_time` (pallas-network2) is flaky on the macOS runner: it timed out at `wait_for_intersection` with `Events collected: []`, then passed on re-run of the same commit, having also passed on macOS one commit earlier. The 10s `DEFAULT_TIMEOUT` over a real loopback connection looks tight for a contended runner. Same family as `0353bf4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pinned the optional CDDL parser to a stable version, preventing failures when processing maps with named key types.

* **Refactor**
  * Simplified internal validation, display, and mathematical formatting logic while preserving existing behavior and generated output.
  * Improved consistency and maintainability across transaction validation and data presentation without introducing user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
