### PR TITLE
fix(network2): send a leios-fetch request when it is issued

### DIFF
--- a/pallas-network2/src/behavior/initiator/leiosfetch.rs
+++ b/pallas-network2/src/behavior/initiator/leiosfetch.rs
@@ -33,6 +33,24 @@ impl LeiosFetchBehavior {
         tracing::info!(total = self.requests.len(), "new leios-fetch request");
     }
 
+    /// Sends the first queued request targeting `pid`, when that peer is ready
+    /// to take one. Does nothing if the peer is busy or has nothing queued.
+    pub(super) fn serve_next(
+        &mut self,
+        pid: &PeerId,
+        state: &mut InitiatorState,
+        outbound: &mut OutboundQueue<InitiatorBehavior>,
+    ) {
+        if !peer_is_available(state) {
+            return;
+        }
+
+        if let Some(idx) = self.requests.iter().position(|(p, _)| p == pid) {
+            let (_, request) = self.requests.remove(idx).expect("index just found");
+            self.send_request(pid, &request, outbound);
+        }
+    }
+
     /// Drops any queued requests targeting `pid`. Called when the peer goes away
     /// so requests don't leak or get re-sent to a later reconnection of the same
     /// `PeerId` (which may no longer hold the offered EB).
@@ -99,15 +117,7 @@ impl PeerVisitor for LeiosFetchBehavior {
         state: &mut InitiatorState,
         outbound: &mut OutboundQueue<InitiatorBehavior>,
     ) {
-        if !peer_is_available(state) {
-            return;
-        }
-
-        // Serve the first queued request targeting this peer.
-        if let Some(idx) = self.requests.iter().position(|(p, _)| p == pid) {
-            let (_, request) = self.requests.remove(idx).expect("index just found");
-            self.send_request(pid, &request, outbound);
-        }
+        self.serve_next(pid, state, outbound);
     }
 
     fn visit_disconnected(

--- a/pallas-network2/src/behavior/initiator/mod.rs
+++ b/pallas-network2/src/behavior/initiator/mod.rs
@@ -529,6 +529,21 @@ impl InitiatorBehavior {
 
         self.move_discovered_into_promotion();
     }
+
+    /// Puts a queued leios-fetch request on the wire for `pid` straight away,
+    /// rather than waiting for the next housekeeping tick.
+    fn serve_leios_fetch(&mut self, pid: &PeerId) {
+        let Self {
+            leiosfetch,
+            peers,
+            outbound,
+            ..
+        } = self;
+
+        if let Some(state) = peers.get_mut(pid) {
+            leiosfetch.serve_next(pid, state, outbound);
+        }
+    }
 }
 
 impl Stream for InitiatorBehavior {
@@ -621,12 +636,16 @@ impl Behavior for InitiatorBehavior {
             InitiatorCommand::FetchEb(pid, point) => {
                 tracing::debug!("fetch eb command");
                 self.leiosfetch
-                    .enqueue(pid, leiosfetch::FetchRequest::Block(point));
+                    .enqueue(pid.clone(), leiosfetch::FetchRequest::Block(point));
+                self.serve_leios_fetch(&pid);
             }
             InitiatorCommand::FetchEbTxs(pid, point, bitmaps) => {
                 tracing::debug!("fetch eb txs command");
-                self.leiosfetch
-                    .enqueue(pid, leiosfetch::FetchRequest::BlockTxs(point, bitmaps));
+                self.leiosfetch.enqueue(
+                    pid.clone(),
+                    leiosfetch::FetchRequest::BlockTxs(point, bitmaps),
+                );
+                self.serve_leios_fetch(&pid);
             }
         }
     }
@@ -1061,6 +1080,47 @@ mod tests {
         assert!(
             outputs.has_event(|e| matches!(e, InitiatorEvent::EbFetched(..))),
             "should surface the fetched EB body as an event"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_command_sends_request_without_housekeeping() {
+        // Composition: a fetch command enqueues and serves in one step, so the
+        // request is sent without running the rest of housekeeping.
+        tokio::time::pause();
+
+        let mut behavior = InitiatorBehavior::default();
+        let pid = PeerId::test(21);
+        let eb = Point::new(7, vec![0xCD; 32]);
+
+        behavior.execute(InitiatorCommand::IncludePeer(pid.clone()));
+        behavior.execute(InitiatorCommand::Housekeeping);
+        drain_outputs(&mut behavior);
+
+        behavior.handle_io(InterfaceEvent::Connected(pid.clone()));
+        drain_outputs(&mut behavior);
+        complete_handshake_leios(&mut behavior, &pid);
+        drain_outputs(&mut behavior);
+
+        // Housekeeping drives the notify pull loop, so RequestNext marks a turn.
+        behavior.execute(InitiatorCommand::Housekeeping);
+        let ticked = drain_outputs(&mut behavior);
+        assert!(
+            ticked.has_send(|m| matches!(m, AnyMessage::LeiosNotify(ln::Message::RequestNext))),
+            "should send RequestNext on a housekeeping tick"
+        );
+
+        // Issuing a fetch, with no tick of any kind.
+        behavior.execute(InitiatorCommand::FetchEb(pid.clone(), eb.clone()));
+        let issued = drain_outputs(&mut behavior);
+
+        assert!(
+            issued.has_send(|m| matches!(m, AnyMessage::LeiosFetch(lf::Message::BlockRequest(_)))),
+            "should send the leios-fetch request when it is issued"
+        );
+        assert!(
+            !issued.has_send(|m| matches!(m, AnyMessage::LeiosNotify(ln::Message::RequestNext))),
+            "should NOT drive the notify pull loop"
         );
     }
 }


### PR DESCRIPTION

## What?

This PR changes `InitiatorBehavior` so that it serves a queued leios-fetch request right after the request is enqueued, rather than waiting for it to be polled on the next housekeeping tick.

## Why?

Before this change, a request in the queue had to wait for a housekeeping tick to occur, so every fetch would cost a whole tick. With this commit, 20 sequential fetches against the public Leios relay took 38 ms in total instead of 20 seconds, at a one second tick.

## Testing done

Added `fetch_command_sends_request_without_housekeeping`. `cargo test --workspace` is green.

These numbers come from a small timing example built twice: once at this commit's parent and once at this commit (with no other changes). The binary fetches 20 endorser blocks (hardcoded by hash) from a relay address (also hardcoded) and waits for each response before issuing the next. Below is one test, before and after, at a one second tick.

```
STATS n=20 median_ms=1002.487 p95_ms=1060.858 min_ms=839.960 max_ms=1153.859 total_ms=19995.903
STATS n=20 median_ms=1.558 p95_ms=4.033 min_ms=1.026 max_ms=4.370 total_ms=37.966
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Leios-fetch requests are now dispatched immediately after being queued when the peer is available.
  * Requests no longer need to wait for the next housekeeping cycle, improving fetch responsiveness.
  * Queued requests continue to be sent only to available peers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->